### PR TITLE
Refer to self for msgraph-sdk-raptor repo in Azure pipeline

### DIFF
--- a/azure-pipelines/csharp-beta-compile-tests.yml
+++ b/azure-pipelines/csharp-beta-compile-tests.yml
@@ -9,11 +9,6 @@ resources:
      endpoint: microsoftgraph
      name: microsoftgraph/microsoft-graph-docs
      ref: master
-   - repository: msgraph-sdk-raptor
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/msgraph-sdk-raptor
-     ref: master
 
 pool:
   vmImage: 'windows-2019'
@@ -27,7 +22,7 @@ steps:
   fetchDepth: 1
   persistCredentials: true
 
-- checkout: msgraph-sdk-raptor
+- checkout: self
   clean: true
   fetchDepth: 1
 

--- a/azure-pipelines/csharp-v1-compile-tests.yml
+++ b/azure-pipelines/csharp-v1-compile-tests.yml
@@ -9,11 +9,6 @@ resources:
      endpoint: microsoftgraph
      name: microsoftgraph/microsoft-graph-docs
      ref: master
-   - repository: msgraph-sdk-raptor
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/msgraph-sdk-raptor
-     ref: master
 
 pool:
   vmImage: 'windows-2019'
@@ -27,7 +22,7 @@ steps:
   fetchDepth: 1
   persistCredentials: true
 
-- checkout: msgraph-sdk-raptor
+- checkout: self
   clean: true
   fetchDepth: 1
 


### PR DESCRIPTION
Changing repository reference in Azure pipeline from `master` to `self` for `msgraph-sdk-raptor`.

`self` in this context refers to which branch the pipeline is running from.