### PR TITLE
Unreferenced C# snippets shouldn't be compiled

### DIFF
--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -80,12 +80,11 @@ public class GraphSDKTest
         public static void Run(string fileName, string docsLink, Versions version)
         {
             var fullPath = Path.Join(GraphDocsDirectory.GetCsharpSnippetsDirectory(version), fileName);
+            Assert.IsTrue(File.Exists(fullPath), "Snippet file referenced in documentation is not found!");
+
             var fileContent = File.ReadAllText(fullPath);
-
             var match = RegExp.Match(fileContent);
-
-            // match groups return the full text in Groups[0] and matched portion in Groups[1]
-            Assert.AreEqual(2, match.Groups.Count, "There should be only one match!");
+            Assert.IsTrue(match.Success, "Csharp snippet file is not in expected format!");
 
             var codeSnippetFormatted = match.Groups[1].Value
                 .Replace("\r\n", "\r\n        ")            // add indentation to match with the template

--- a/TestsCommon/CompilationOutputMessage.cs
+++ b/TestsCommon/CompilationOutputMessage.cs
@@ -50,10 +50,10 @@ namespace TestsCommon
         /// <summary>
         /// Gets documentation link for the snippet
         /// </summary>
-        /// <returns>Error message if the link is not found, link itself if found</returns>
+        /// <returns>Documentation link for the snippet</returns>
         private string GetDocsLink()
         {
-            return DocsLink == null ? "No link has been found in the documentation for this snippet. \r\n" : $"{DocsLink}\r\n";
+            return $"{DocsLink}\r\n";
         }
 
         /// <summary>

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -63,12 +63,11 @@ namespace TestsCommon
         public static IEnumerable<TestCaseData> GetTestCaseData(Versions version)
         {
             var documentationLinks = GetDocumentationLinks(version);
-            var directory = GraphDocsDirectory.GetCsharpSnippetsDirectory(version);
-            return from file in Directory.GetFiles(directory, "*.md")
-                   let fileName = Path.GetFileName(file)                            // e.g. application-addpassword-csharp-snippets.md
+            var snippetFileNames = documentationLinks.Keys.ToList();
+            return from fileName in snippetFileNames                                // e.g. application-addpassword-csharp-snippets.md
                    let testNamePostfix = version.ToString() + "-compiles"           // e.g. Beta-compiles
                    let testName = fileName.Replace("snippets.md", testNamePostfix)  // e.g. application-addpassword-csharp-Beta-compiles
-                   let docsLink = documentationLinks.ContainsKey(fileName) ? documentationLinks[fileName] : null
+                   let docsLink = documentationLinks[fileName]
                    select new TestCaseData(fileName, docsLink, version).SetName(testName);
         }
     }


### PR DESCRIPTION
- Refer to documentation for valid snippet files instead of snippets folder
- Add a check on whether the referenced file exists
- Remove checks on documentation link as that is now the source of test cases
- Make regex success check more readable

Pass rate changes as we are now attempting to compile only a subset of previous snippets (the ones that are referenced in the docs).

### Test Results
|             | Total | Passed | Failed | Success Rate |
|-------------|-------|--------|--------|--------------|
| V1 Before   | 821   | 689    | 132    | 83.9%        |
| V1 After    | 725   | 599    | 126    | 82.6%        |
| Beta Before | 1464  | 1237   | 227    | 84.4%        |
| Beta After  | 1292  | 1077   | 215    | 83.3%        |
