### PR TITLE
Add System.Text for encoding Edm.Binary objects

### DIFF
--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -18,9 +18,10 @@ namespace TestsCommon
         /// </summary>
         private const string SDKShellTemplate = @"using System;
 using Microsoft.Graph;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 using MsGraphSDKSnippetsCompiler;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
 
 // Disambiguate colliding namespaces
 using DayOfWeek = Microsoft.Graph.DayOfWeek;


### PR DESCRIPTION
Code snippet generation PR [here](https://github.com/microsoftgraph/microsoft-graph-explorer-api/pull/236) adds support for converting `string` into `byte[]` using `Encoding.ASCII.GetBytes`. That requires `System.Text` namespace as part of the compilation template.

#AB4666