### PR TITLE
Add optional custom test run title

### DIFF
--- a/azure-pipelines/csharp-beta-compile-tests.yml
+++ b/azure-pipelines/csharp-beta-compile-tests.yml
@@ -47,5 +47,5 @@ steps:
     testResultsFormat: 'VSTest'
     searchFolder: '$(Agent.TempDirectory)'
     testResultsFiles: '**/*.trx'
-    testRunTitle: 'Beta C# Snippet Compilation Tests'
+    testRunTitle: 'Beta C# Snippet Compilation Tests $(testRunTitle)'
   displayName: 'Publish Test Results'

--- a/azure-pipelines/csharp-v1-compile-tests.yml
+++ b/azure-pipelines/csharp-v1-compile-tests.yml
@@ -47,5 +47,5 @@ steps:
     testResultsFormat: 'VSTest'
     searchFolder: '$(Agent.TempDirectory)'
     testResultsFiles: '**/*.trx'
-    testRunTitle: 'V1 C# Snippet Compilation Tests'
+    testRunTitle: 'V1 C# Snippet Compilation Tests $(testRunTitle)'
   displayName: 'Publish Test Results'


### PR DESCRIPTION
Adding an optional custom test run title to distinguish different test runs. Currently test runs are named:

1. `Beta C# Snippet Compilation Tests` 
2. `V1 C# Snippet Compilation Tests`

If the custom test run title is set, they will be:

1. `Beta C# Snippet Compilation Tests <custom test run title>` 
2. `V1 C# Snippet Compilation Tests <custom test run title>`

#AB4681