### PR TITLE
Mark known issues as "skipped" instead of "failed"

### DIFF
--- a/CsharpBetaTests/CsharpBetaTests.csproj
+++ b/CsharpBetaTests/CsharpBetaTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CsharpBetaTests/SnippetCompileBetaTests.cs
+++ b/CsharpBetaTests/SnippetCompileBetaTests.cs
@@ -24,9 +24,9 @@ namespace CsharpBetaTests
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
         [TestCaseSource(typeof(SnippetCompileBetaTests), nameof(TestDataBeta))]
-        public void Test(string fileName, string docsLink, Versions version)
+        public void Test(CsharpTestData testData)
         {
-            CSharpTestRunner.Run(fileName, docsLink, version);
+            CSharpTestRunner.Run(testData);
         }
     }
 }

--- a/CsharpV1Tests/CsharpV1Tests.csproj
+++ b/CsharpV1Tests/CsharpV1Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CsharpV1Tests/SnippetCompileV1Tests.cs
+++ b/CsharpV1Tests/SnippetCompileV1Tests.cs
@@ -24,9 +24,9 @@ namespace CsharpV1Tests
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
         [TestCaseSource(typeof(SnippetCompileV1Tests), nameof(TestDataV1))]
-        public void Test(string fileName, string docsLink, Versions version)
+        public void Test(CsharpTestData testData)
         {
-            CSharpTestRunner.Run(fileName, docsLink, version);
+            CSharpTestRunner.Run(testData);
         }
     }
 }

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -20,6 +20,7 @@ namespace TestsCommon
         private const string SDKShellTemplate = @"using System;
 using Microsoft.Graph;
 using MsGraphSDKSnippetsCompiler;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;

--- a/TestsCommon/CompilationOutputMessage.cs
+++ b/TestsCommon/CompilationOutputMessage.cs
@@ -27,16 +27,34 @@ namespace TestsCommon
         private readonly string DocsLink;
 
         /// <summary>
+        /// Message for known issue
+        /// </summary>
+        private readonly string KnownIssueMessage;
+
+        /// <summary>
+        /// Whether the issue is known or not
+        /// </summary>
+        private readonly bool IsKnownIssue;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="model">Compilation result</param>
         /// <param name="code">Code that was attempted to be compiled</param>
         /// <param name="docsLink">documentation page where the snippet is shown</param>
-        public CompilationOutputMessage(CompilationResultsModel model, string code, string docsLink)
+        /// <param name="knownIssueMessage">message for known issue</param>
+        public CompilationOutputMessage(
+            CompilationResultsModel model,
+            string code,
+            string docsLink,
+            string knownIssueMessage,
+            bool isKnownIssue)
         {
             Model = model;
             Code = code;
             DocsLink = docsLink;
+            KnownIssueMessage = knownIssueMessage;
+            IsKnownIssue = isKnownIssue;
         }
 
         /// <summary>
@@ -45,16 +63,19 @@ namespace TestsCommon
         /// <returns>
         /// Code with line numbers and compiler errors
         /// </returns>
-        public override string ToString() => GetDocsLink() + GetCodeWithLineNumbers() + CompilerErrors();
+        public override string ToString() => GetKnownIssueMessage() + GetDocsLink() + GetCodeWithLineNumbers() + CompilerErrors();
+
+        /// <summary>
+        /// Get string representation of known issue message
+        /// </summary>
+        /// <returns>Known issue message if the issue is known, empty string if not</returns>
+        private string GetKnownIssueMessage() => IsKnownIssue ? $"Known Issue: {KnownIssueMessage}\r\n" : string.Empty;
 
         /// <summary>
         /// Gets documentation link for the snippet
         /// </summary>
         /// <returns>Documentation link for the snippet</returns>
-        private string GetDocsLink()
-        {
-            return $"{DocsLink}\r\n";
-        }
+        private string GetDocsLink() => $"{DocsLink}\r\n";
 
         /// <summary>
         /// For each compiler error, generates an error string with code location references

--- a/TestsCommon/CsharpTestData.cs
+++ b/TestsCommon/CsharpTestData.cs
@@ -1,0 +1,32 @@
+﻿using MsGraphSDKSnippetsCompiler.Models;
+
+namespace TestsCommon
+{
+    public class CsharpTestData
+    {
+        /// <summary>
+        /// Docs version e.g. V1 or Beta
+        /// </summary>
+        public Versions Version { get; set; }
+
+        /// <summary>
+        /// Whether the test case is failing due to a known issue
+        /// </summary>
+        public bool IsKnownIssue { get; set; }
+
+        /// <summary>
+        /// Message to represent known issue
+        /// </summary>
+        public string KnownIssueMessage { get; set; }
+
+        /// <summary>
+        /// Documentation link where snippet is shown
+        /// </summary>
+        public string DocsLink { get; set; }
+
+        /// <summary>
+        /// Snippet file name
+        /// </summary>
+        public string FileName { get; set; }
+    }
+}

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -2,7 +2,6 @@
 
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,6 +9,26 @@ using System.Text.RegularExpressions;
 
 namespace TestsCommon
 {
+    public static class KnownIssues
+    {
+        /// <summary>
+        /// Known issue message for cases where there is a feature missing in SDK
+        /// </summary>
+        private const string NotSupported = "Feature not supported by SDK";
+
+        /// <summary>
+        /// Gets known issues
+        /// </summary>
+        /// <returns>A mapping of test names into known issues</returns>
+        public static Dictionary<string, string> GetIssues()
+        {
+            return new Dictionary<string, string>()
+            {
+                { "get-rangeformat-csharp-V1-compiles", NotSupported }
+            };
+        }
+    }
+
     /// <summary>
     /// Generates TestCaseData for NUnit
     /// </summary>
@@ -63,12 +82,23 @@ namespace TestsCommon
         public static IEnumerable<TestCaseData> GetTestCaseData(Versions version)
         {
             var documentationLinks = GetDocumentationLinks(version);
+            var knownIssues = KnownIssues.GetIssues();
             var snippetFileNames = documentationLinks.Keys.ToList();
             return from fileName in snippetFileNames                                // e.g. application-addpassword-csharp-snippets.md
                    let testNamePostfix = version.ToString() + "-compiles"           // e.g. Beta-compiles
                    let testName = fileName.Replace("snippets.md", testNamePostfix)  // e.g. application-addpassword-csharp-Beta-compiles
                    let docsLink = documentationLinks[fileName]
-                   select new TestCaseData(fileName, docsLink, version).SetName(testName);
+                   let isKnownIssue = knownIssues.ContainsKey(testName)
+                   let knownIssueMessage = isKnownIssue ? knownIssues[testName] : string.Empty
+                   let testCaseData = new CsharpTestData
+                   {
+                       Version = version,
+                       IsKnownIssue = isKnownIssue,
+                       KnownIssueMessage = knownIssueMessage,
+                       DocsLink = docsLink,
+                       FileName = fileName
+                   }
+                   select new TestCaseData(testCaseData).SetName(testName);
         }
     }
 }

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -3,6 +3,7 @@
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -12,9 +13,26 @@ namespace TestsCommon
     public static class KnownIssues
     {
         /// <summary>
-        /// Known issue message for cases where there is a feature missing in SDK
+        /// Known issue message for cases where composable functions feature is missing in SDK
         /// </summary>
-        private const string NotSupported = "Feature not supported by SDK";
+        private const string FeatureNotSupported = "Range composable functions are not supported by SDK\r\n"
+            + "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/490";
+
+        /// <summary>
+        /// Known issue message for cases where HTTP snippet input should be fixed
+        /// </summary>
+        private const string HttpSnippetWrong = "Http snippet should be fixed";
+
+        /// <summary>
+        /// Constructs property not found message
+        /// </summary>
+        /// <param name="type">Type that need to define the property</param>
+        /// <param name="property">Property that needs to be defined but missing in metadata</param>
+        /// <returns>String representation of property not found message</returns>
+        private static string GetPropertyNotFoundMessage(string type, string property)
+        {
+            return HttpSnippetWrong + string.Format(CultureInfo.InvariantCulture, ": {0} does not contain definition of {1} in metadata", type, property);
+        }
 
         /// <summary>
         /// Gets known issues
@@ -24,7 +42,108 @@ namespace TestsCommon
         {
             return new Dictionary<string, string>()
             {
-                { "get-rangeformat-csharp-V1-compiles", NotSupported }
+                { "call-transfer-csharp-V1-compiles", GetPropertyNotFoundMessage("InvitationParticipantInfo", "EndpointType") },
+                { "create-educationschool-from-educationroot-csharp-V1-compiles", GetPropertyNotFoundMessage("EducationSchool", "Status") },
+                { "create-item-attachment-from-eventmessage-csharp-V1-compiles", HttpSnippetWrong + ": Item needs to be an OutlookItem object, not a string" },
+                { "create-rangeborder-from-rangeformat-csharp-V1-compiles", FeatureNotSupported },
+                { "create-reference-attachment-with-post-csharp-V1-compiles", GetPropertyNotFoundMessage("ReferenceAttachment", "SourceUrl, ProviderType, Permission and IsFolder") },
+                { "create-tablecolumn-from-table-csharp-V1-compiles", HttpSnippetWrong + "Id should be string not int" },
+                { "get-borders-csharp-V1-compiles", FeatureNotSupported },
+                { "get-formatprotection-csharp-V1-compiles", FeatureNotSupported },
+                { "get-rangeborder-csharp-V1-compiles", FeatureNotSupported },
+                { "get-rangebordercollection-csharp-V1-compiles", FeatureNotSupported },
+                { "get-rangefill-csharp-V1-compiles", FeatureNotSupported },
+                { "get-rangefont-csharp-V1-compiles", FeatureNotSupported },
+                { "get-rangeformat-csharp-V1-compiles", FeatureNotSupported },
+                { "post-reply-csharp-V1-compiles", HttpSnippetWrong + ": Odata.Type for concreate Attachment type should be added" },
+                { "rangefill-clear-csharp-V1-compiles", FeatureNotSupported },
+                { "rangeformat-autofitcolumns-csharp-V1-compiles", FeatureNotSupported },
+                { "rangeformat-autofitrows-csharp-V1-compiles", FeatureNotSupported },
+                { "update-activitybasedtimeoutpolicy-csharp-V1-compiles", GetPropertyNotFoundMessage("ActivityBasedTimeoutPolicy", "Type")},
+                { "update-formatprotection-csharp-V1-compiles", FeatureNotSupported },
+                { "update-homerealmdiscoverypolicy-csharp-V1-compiles", GetPropertyNotFoundMessage("HomeRealmDiscoveryPolicy", "Type") },
+                { "update-rangeborder-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangefill-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangefont-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-fill-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-fill-three-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-fill-two-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-font-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-font-two-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-three-csharp-V1-compiles", FeatureNotSupported },
+                { "update-rangeformat-two-csharp-V1-compiles", FeatureNotSupported },
+                { "update-tokenissuancepolicy-csharp-V1-compiles", GetPropertyNotFoundMessage("TokenIssuancePolicy", "Type")},
+                { "update-tokenlifetimepolicy-csharp-V1-compiles", GetPropertyNotFoundMessage("TokenLifetimePolicy", "Type") },
+                {" range-cell-csharp-V1-compiles", FeatureNotSupported },
+                {" range-clear-csharp-V1-compiles", FeatureNotSupported },
+                {" range-column-csharp-V1-compiles", FeatureNotSupported },
+                {" range-delete-csharp-Beta-compiles", FeatureNotSupported },
+                {" range-delete-csharp-V1-compiles", FeatureNotSupported },
+                {" range-usedrange-valuesonly-csharp-V1-compiles", FeatureNotSupported },
+                {" update-rangeformat-font-three-csharp-V1-compiles", FeatureNotSupported },
+                {" workbookrange-columnsafter-csharp-Beta-compiles", FeatureNotSupported },
+                {" workbookrange-columnsafter-csharp-V1-compiles", FeatureNotSupported },
+                {" workbookrange-columnsbefore-csharp-Beta-compiles", FeatureNotSupported },
+                {" workbookrange-columnsbefore-csharp-V1-compiles", FeatureNotSupported },
+                {"create-rangeborder-from-rangeformat-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-borders-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-formatprotection-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-rangeborder-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-rangebordercollection-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-rangefill-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-rangefont-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-rangeformat-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-rows-csharp-Beta-compiles", FeatureNotSupported },
+                {"get-rows-csharp-V1-compiles", FeatureNotSupported },
+                {"range-clear-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-entirecolumn-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-entirecolumn-csharp-V1-compiles", FeatureNotSupported },
+                {"range-entirerow-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-entirerow-csharp-V1-compiles", FeatureNotSupported },
+                {"range-insert-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-insert-csharp-V1-compiles", FeatureNotSupported },
+                {"range-lastcell-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-lastcell-csharp-V1-compiles", FeatureNotSupported },
+                {"range-lastcolumn-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-lastcolumn-csharp-V1-compiles", FeatureNotSupported },
+                {"range-lastrow-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-lastrow-csharp-V1-compiles", FeatureNotSupported },
+                {"range-merge-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-merge-csharp-V1-compiles", FeatureNotSupported },
+                {"range-unmerge-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-unmerge-csharp-V1-compiles", FeatureNotSupported },
+                {"range-usedrange-csharp-Beta-compiles", FeatureNotSupported },
+                {"range-usedrange-csharp-V1-compiles", FeatureNotSupported },
+                {"range-usedrange-valuesonly-csharp-V1-compiles", FeatureNotSupported },
+                {"rangefill-clear-csharp-Beta-compiles", FeatureNotSupported },
+                {"rangeformat-autofitcolumns-csharp-Beta-compiles", FeatureNotSupported },
+                {"rangeformat-autofitrows-csharp-Beta-compiles", FeatureNotSupported },
+                {"rangesort-apply-csharp-Beta-compiles", FeatureNotSupported },
+                {"rangesort-apply-csharp-V1-compiles", FeatureNotSupported },
+                {"update-formatprotection-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeborder-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangefill-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangefont-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-fill-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-fill-three-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-fill-two-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-font-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-font-three-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-font-two-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-three-csharp-Beta-compiles", FeatureNotSupported },
+                {"update-rangeformat-two-csharp-Beta-compiles", FeatureNotSupported },
+                {"workbookrange-rowsabove-csharp-Beta-compiles", FeatureNotSupported },
+                {"workbookrange-rowsabove-csharp-V1-compiles", FeatureNotSupported },
+                {"workbookrange-rowsabove-nocount-csharp-V1-compiles", FeatureNotSupported },
+                {"workbookrange-rowsbelow-csharp-Beta-compiles", FeatureNotSupported },
+                {"workbookrange-rowsbelow-csharp-V1-compiles", FeatureNotSupported },
+                {"workbookrange-rowsbelow-nocount-csharp-V1-compiles", FeatureNotSupported },
+                {"workbookrange-visibleview-csharp-Beta-compiles", FeatureNotSupported },
+                {"workbookrange-visibleview-csharp-V1-compiles", FeatureNotSupported },
+                {"workbookrangeview-range-csharp-Beta-compiles", FeatureNotSupported },
+                {"workbookrangeview-range-csharp-V1-compiles", FeatureNotSupported },
             };
         }
     }

--- a/TestsCommon/TestsCommon.csproj
+++ b/TestsCommon/TestsCommon.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -10,10 +10,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Graph" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.0" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.16.0-preview" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.4" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="0.17.0-preview" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.CodeDom" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
- Added support for identifying known issues and reporting them as `skipped`
  - Added [an issue](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/490) regarding composable functions on Range() and their associated test cases
  - Added several test cases from v1.0 where HTTP snippets need to be fixed
- Upgraded nuget packages for Graph
- Added `Newtonsoft.Json.Linq` to compilation template to resolve `JObject` type
- Refactored test case data into a class of its own to avoid passing multiple parameters to test cases

#AB4682