### PR TITLE
Split test runs for known issues

### DIFF
--- a/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj
+++ b/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
+++ b/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+using MsGraphSDKSnippetsCompiler.Models;
+using NUnit.Framework;
+using System.Collections.Generic;
+using TestsCommon;
+
+namespace CsharpBetaKnownFailureTests
+{
+    [TestFixture]
+    public class KnownFailuresBeta
+    {
+        /// <summary>
+        /// Gets TestCaseData for Beta known failures
+        /// TestCaseData contains snippet file name, version and test case name
+        /// </summary>
+        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(Versions.Beta, knownFailuresRequested: true);
+
+        /// <summary>
+        /// Represents test runs generated from test case data
+        /// </summary>
+        /// <param name="fileName">snippet file name in docs repo</param>
+        /// <param name="docsLink">documentation page where the snippet is shown</param>
+        /// <param name="version">Docs version (e.g. V1, Beta)</param>
+        [Test]
+        [TestCaseSource(typeof(KnownFailuresBeta), nameof(TestDataBeta))]
+        public void Test(CsharpTestData testData)
+        {
+            CSharpTestRunner.Run(testData);
+        }
+    }
+}

--- a/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj
+++ b/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CsharpV1KnownFailureTests/KnownFailuresV1.cs
+++ b/CsharpV1KnownFailureTests/KnownFailuresV1.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+using MsGraphSDKSnippetsCompiler.Models;
+using NUnit.Framework;
+using System.Collections.Generic;
+using TestsCommon;
+
+namespace CsharpV1KnownFailureTests
+{
+    [TestFixture]
+    public class KnownFailuresV1
+    {
+        /// <summary>
+        /// Gets TestCaseData for V1 known failures
+        /// TestCaseData contains snippet file name, version and test case name
+        /// </summary>
+        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(Versions.V1, knownFailuresRequested: true);
+
+        /// <summary>
+        /// Represents test runs generated from test case data
+        /// </summary>
+        /// <param name="fileName">snippet file name in docs repo</param>
+        /// <param name="docsLink">documentation page where the snippet is shown</param>
+        /// <param name="version">Docs version (e.g. V1, Beta)</param>
+        [Test]
+        [TestCaseSource(typeof(KnownFailuresV1), nameof(TestDataV1))]
+        public void Test(CsharpTestData testData)
+        {
+            CSharpTestRunner.Run(testData);
+        }
+    }
+}

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -106,25 +106,11 @@ public class GraphSDKTest
 
             if (compilationResultsModel.IsSuccess)
             {
-                if (testData.IsKnownIssue)
-                {
-                    Assert.Fail("This snippet started compiling, it should be removed from known issues!");
-                }
-                else
-                {
-                    Assert.Pass();
-                }
+                Assert.Pass();
             }
 
             var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsKnownIssue);
-            if (testData.IsKnownIssue)
-            {
-                Assert.Ignore($"{compilationOutputMessage}");
-            }
-            else
-            {
-                Assert.Fail($"{compilationOutputMessage}");
-            }
+            Assert.Fail($"{compilationOutputMessage}");
         }
     }
 }

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -195,10 +195,11 @@ namespace TestsCommon
         /// Test case name is also set to to unique name based on file name
         /// </summary>
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
+        /// <param name="knownFailuresRequested">return whether known failures as test cases or not</param>
         /// <returns>
         /// TestCaseData to be consumed by C# compilation tests
         /// </returns>
-        public static IEnumerable<TestCaseData> GetTestCaseData(Versions version)
+        public static IEnumerable<TestCaseData> GetTestCaseData(Versions version, bool knownFailuresRequested = false)
         {
             var documentationLinks = GetDocumentationLinks(version);
             var knownIssues = KnownIssues.GetIssues();
@@ -217,6 +218,7 @@ namespace TestsCommon
                        DocsLink = docsLink,
                        FileName = fileName
                    }
+                   where !(isKnownIssue ^ knownFailuresRequested) // select known issues if requested
                    select new TestCaseData(testCaseData).SetName(testName);
         }
     }

--- a/azure-pipelines/csharp-beta-compile-tests-known-issues.yml
+++ b/azure-pipelines/csharp-beta-compile-tests-known-issues.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+
+resources:
+ repositories:
+   - repository: microsoft-graph-docs
+     type: github
+     endpoint: microsoftgraph
+     name: microsoftgraph/microsoft-graph-docs
+     ref: master
+
+pool:
+  vmImage: 'windows-2019'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- checkout: microsoft-graph-docs
+  clean: true
+  fetchDepth: 1
+  persistCredentials: true
+
+- checkout: self
+  clean: true
+  fetchDepth: 1
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'build'
+    projects: msgraph-sdk-raptor/**/*.csproj
+    arguments: '--configuration $(buildConfiguration)'
+  displayName: 'Build Projects'
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'test'
+    projects: '**/CsharpBetaKnownFailureTests.csproj'
+    arguments: '--configuration $(buildConfiguration) --logger trx --results-directory $(Agent.TempDirectory)'
+    publishTestResults: false
+  displayName: 'Csharp Beta Compilation Tests - Known Issues'
+  continueOnError: true
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: 'VSTest'
+    searchFolder: '$(Agent.TempDirectory)'
+    testResultsFiles: '**/*.trx'
+    testRunTitle: 'Beta C# Snippet Compilation Tests - Known Issues $(testRunTitle)'
+  displayName: 'Publish Test Results'

--- a/azure-pipelines/csharp-beta-compile-tests-known-issues.yml
+++ b/azure-pipelines/csharp-beta-compile-tests-known-issues.yml
@@ -11,7 +11,7 @@ resources:
      ref: master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-latest'
 
 variables:
   buildConfiguration: 'Release'

--- a/azure-pipelines/csharp-beta-compile-tests.yml
+++ b/azure-pipelines/csharp-beta-compile-tests.yml
@@ -11,7 +11,7 @@ resources:
      ref: master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-latest'
 
 variables:
   buildConfiguration: 'Release'

--- a/azure-pipelines/csharp-v1-compile-tests-known-issues.yml
+++ b/azure-pipelines/csharp-v1-compile-tests-known-issues.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+
+resources:
+ repositories:
+   - repository: microsoft-graph-docs
+     type: github
+     endpoint: microsoftgraph
+     name: microsoftgraph/microsoft-graph-docs
+     ref: master
+
+pool:
+  vmImage: 'windows-2019'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- checkout: microsoft-graph-docs
+  clean: true
+  fetchDepth: 1
+  persistCredentials: true
+
+- checkout: self
+  clean: true
+  fetchDepth: 1
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'build'
+    projects: msgraph-sdk-raptor/**/*.csproj
+    arguments: '--configuration $(buildConfiguration)'
+  displayName: 'Build Projects'
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'test'
+    projects: '**/CsharpV1KnownFailureTests.csproj'
+    arguments: '--configuration $(buildConfiguration) --logger trx --results-directory $(Agent.TempDirectory)'
+    publishTestResults: false
+  displayName: 'Csharp V1 Compilation Tests - Known Issues'
+  continueOnError: true
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: 'VSTest'
+    searchFolder: '$(Agent.TempDirectory)'
+    testResultsFiles: '**/*.trx'
+    testRunTitle: 'V1 C# Snippet Compilation Tests - Known Issues $(testRunTitle)'
+  displayName: 'Publish Test Results'

--- a/azure-pipelines/csharp-v1-compile-tests-known-issues.yml
+++ b/azure-pipelines/csharp-v1-compile-tests-known-issues.yml
@@ -11,7 +11,7 @@ resources:
      ref: master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-latest'
 
 variables:
   buildConfiguration: 'Release'

--- a/azure-pipelines/csharp-v1-compile-tests.yml
+++ b/azure-pipelines/csharp-v1-compile-tests.yml
@@ -11,7 +11,7 @@ resources:
      ref: master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-latest'
 
 variables:
   buildConfiguration: 'Release'

--- a/msgraph-sdk-raptor.sln
+++ b/msgraph-sdk-raptor.sln
@@ -11,6 +11,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestsCommon", "TestsCommon\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsharpBetaTests", "CsharpBetaTests\CsharpBetaTests.csproj", "{409BE1A6-4978-405C-9F0B-478DDF344AA4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpBetaKnownFailureTests", "CsharpBetaKnownFailureTests\CsharpBetaKnownFailureTests.csproj", "{6A08DD1F-4865-4366-AFFF-A1A5A4B6C24A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpV1KnownFailureTests", "CsharpV1KnownFailureTests\CsharpV1KnownFailureTests.csproj", "{418B1372-FC4F-4C90-9526-45C7A62F8BBB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +37,14 @@ Global
 		{409BE1A6-4978-405C-9F0B-478DDF344AA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{409BE1A6-4978-405C-9F0B-478DDF344AA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{409BE1A6-4978-405C-9F0B-478DDF344AA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A08DD1F-4865-4366-AFFF-A1A5A4B6C24A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A08DD1F-4865-4366-AFFF-A1A5A4B6C24A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A08DD1F-4865-4366-AFFF-A1A5A4B6C24A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A08DD1F-4865-4366-AFFF-A1A5A4B6C24A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{418B1372-FC4F-4C90-9526-45C7A62F8BBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{418B1372-FC4F-4C90-9526-45C7A62F8BBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{418B1372-FC4F-4C90-9526-45C7A62F8BBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{418B1372-FC4F-4C90-9526-45C7A62F8BBB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The purpose of this change is to provide feature owners a web link with all the actionable feedback regarding failures.

Azure DevOps has a few limitations around working with known issues.
1. I have investigated the option of marking known issues as "ignored" or "inconclusive". In these cases Azure DevOps doesn't show the error message, which contains the documentation link and other details about the failure. So we can't provide a web link to interested parties, such as owners that need to fix HTTP snippets.
2. Azure DevOps also has a UI to add analysis for individual failures, but these analyses are per each pipeline run. In other words, they do not stick to the test cases even though the system is able track the history of a test properly for failed/passed states.

With this change, I am splitting test projects into two as known issues and others. I also generated two new pipelines for known issues.

The results now look like the following:
| Title | Failed | Pass Rate |
|--|--|--|
| Beta C# Snippet Compilation Tests | 153 | 87.8% |
| V1 C# Snippet Compilation Tests | 64 | 90.5% |
| Beta C# Snippet Compilation Tests - Known Issues | 40 | 0% |
| V1 C# Snippet Compilation Tests - Known Issues | 51 | 0% |

In this model, the target is to get to 100% for the first two initially, while the last two represent the technical debt.

[AB#4682](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4682)