### PR TITLE
Add more known issues in Beta

### DIFF
--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -36,75 +36,64 @@ namespace TestsCommon
 
     public static class KnownIssues
     {
-        /// <summary>
-        /// Known issue message for cases where composable functions feature is missing in SDK
-        /// </summary>
+        #region SDK issues
+
         private const string FeatureNotSupported = "Range composable functions are not supported by SDK\r\n"
             + "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/490";
-
-        /// <summary>
-        /// Known issue message for cases where types from different namespaces are referenced.
-        /// </summary>
+        private const string SearchHeaderIsNotSupported = "Search header is not supported by the SDK";
+        private const string CountIsNotSupported = "OData $count is not supported by the SDK at the moment";
+        private const string MissingContentProperty = "IReportRootGetM365AppPlatformUserCountsRequestBuilder is missing Content property";
         private const string NamespacesSupport = "Multiple namespaces are not yet supported.";
 
-        /// <summary>
-        /// Known issue message for cases where HTTP snippet input should be fixed
-        /// </summary>
+        #endregion
+
+        #region HTTP Snippet Issues
         private const string HttpSnippetWrong = "Http snippet should be fixed";
-
-        /// <summary>
-        /// /// Known issue message for cases where Metadata should be fixed
-        /// </summary>
-        private const string MetadataWrong = "Metadata should be fixed";
-
-        /// <summary>
-        /// Known issue message for cases where HTTP sample needs to modify the URL to end with /$ref
-        /// </summary>
         private const string RefNeeded = "URL needs to end with /$ref for reference types";
+        private const string RefShouldBeRemoved = "URL shouldn't end with /$ref";
+        #endregion
 
-        /// <summary>
-        /// Snippet generation flattens issue.
-        /// </summary>
-        private const string SnippetGenerationFlattens = "Snippet generation flattens the nested Odata queries, see https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/287 for more details";
+        #region Metadata Issues
+        private const string MetadataWrong = "Metadata should be fixed";
+        private const string IdentityRiskEvents = "identityRiskEvents not defined in metadata.";
+        #endregion
 
-        /// <summary>
-        /// SDK team as owner
-        /// </summary>
+        #region Metadata Preprocessing Issues
+        private const string ProposedNewTimeIsDropped = "Metadata preprocessing is dropping `ProposedNewTime`." +
+            " See https://github.com/microsoftgraph/msgraph-metadata/issues/21";
+        #endregion
+
+        #region Snipppet Generation Issues
+        private const string SnippetGenerationFlattens = "Snippet generation flattens the nested Odata queries." +
+            " See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/287";
+        private const string SnippetGenerationAdditionalData = "Open types should use additional data for non-existent properties." +
+            " See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/296";
+        private const string SnippetGenerationCreateAsyncSupport = "Snippet generation doesn't use CreateAsync" +
+            " See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/301";
+        private const string SnippetGenerationTypeHint = "Type hint is missing in null assignments" +
+            " See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/297";
+        private const string SnippetGenerationReferenceCreation = "Reference creation should use id instead of full object" +
+            " See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/300";
+        private const string SnippetGenerationRequestObjectDisambiguation = "Snippet generation should rename objects that end with Request to end with RequestObject" +
+            " See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/298";
+        #endregion
+
+        #region Test Owner values (to categorize results in Azure DevOps)
         private const string SDK = nameof(SDK);
-
-        /// <summary>
-        /// Owner value where HTTP snippet needs fixing
-        /// </summary>
         private const string HTTP = nameof(HTTP);
-
-        /// <summary>
-        /// Owner value where HTTP snippet URL needs fixing to have camelCase
-        /// </summary>
         private const string HTTPCamelCase = nameof(HTTPCamelCase);
-
-        /// <summary>
-        /// Owner value where HTTP snippet needs to fix HTTP method
-        /// </summary>
         private const string HTTPMethodWrong = nameof(HTTPMethodWrong);
-
-        /// <summary>
-        /// Oner value where Metadata needs fixing
-        /// </summary>
         private const string Metadata = nameof(Metadata);
-
-        /// <summary>
-        /// Snippet generation has a bug
-        /// </summary>
+        private const string MetadataPreprocessing = nameof(MetadataPreprocessing);
         private const string SnippetGeneration = nameof(SnippetGeneration);
+        #endregion
 
         #region HTTP methods
-
         private const string DELETE = nameof(DELETE);
         private const string PUT = nameof(PUT);
         private const string POST = nameof(POST);
         private const string GET = nameof(GET);
         private const string PATCH = nameof(PATCH);
-
         #endregion
 
         /// <summary>
@@ -170,6 +159,7 @@ namespace TestsCommon
             return new Dictionary<string, KnownIssue>()
             {
                 { "administrativeunit-delta-csharp-Beta-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("administrativeunits", "administrativeUnits")) },
+                { "call-transfer-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationAdditionalData) },
                 { "call-transfer-csharp-V1-compiles", new KnownIssue(Metadata, "v1 metadata doesn't have endpointType for invitationParticipantInfo") },
                 { "call-updatemetadata-csharp-Beta-compiles", new KnownIssue(Metadata, "updateMetadata doesn't exist in metadata") },
                 { "create-acceptedsender-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("group", "acceptedSender")) },
@@ -178,26 +168,41 @@ namespace TestsCommon
                 { "create-alloweduser-from-printers-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("printerShare", "allowedUsers"))},
                 { "create-certificatebasedauthconfiguration-from-certificatebasedauthconfiguration-csharp-Beta-compiles", new KnownIssue(HTTP, RefNeeded) },
                 { "create-certificatebasedauthconfiguration-from-certificatebasedauthconfiguration-csharp-V1-compiles", new KnownIssue(HTTP, RefNeeded) },
+                { "create-claimsmappingpolicy-from-serviceprincipal-csharp-Beta-compiles", new KnownIssue(HTTP, RefNeeded) },
                 { "create-directoryobject-from-featurerolloutpolicy-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("featureRolloutPolicy", "appliesTo"))},
+                { "create-directoryobject-from-orgcontact-csharp-Beta-compiles", new KnownIssue(HTTP, RefNeeded) },
                 { "create-educationrubric-from-educationassignment-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("educationAssignment", "rubric"))},
                 { "create-educationschool-from-educationroot-csharp-Beta-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("EducationSchool", "Status")) },
+                { "create-externalitem-from-connections-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationCreateAsyncSupport) },
+                { "create-homerealmdiscoverypolicy-from-serviceprincipal-csharp-Beta-compiles", new KnownIssue(HTTP, RefNeeded) },
                 { "create-item-attachment-from-eventmessage-csharp-Beta-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": Item needs to be an OutlookItem object, not a string") },
                 { "create-item-attachment-from-eventmessage-csharp-V1-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": Item needs to be an OutlookItem object, not a string") },
+                { "create-manager-for-user-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationReferenceCreation) },
                 { "create-manager-from-group-csharp-V1-compiles", new KnownIssue(SnippetGeneration, "See issue: https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/289") },
+                { "create-onpremisesagentgroup-from-publishedresource-csharp-Beta-compiles", new KnownIssue(HTTP, RefShouldBeRemoved) },
+                { "create-printer-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationTypeHint) },
                 { "create-rangeborder-from-rangeformat-csharp-Beta-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "create-rangeborder-from-rangeformat-csharp-V1-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "create-reference-attachment-with-post-csharp-V1-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("ReferenceAttachment", "SourceUrl, ProviderType, Permission and IsFolder")) },
                 { "create-rejectedsender-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("group", "rejectedSender")) },
                 { "create-rejectedsenders-from-group-csharp-V1-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("group", "rejectedSender")) },
+                { "create-schema-from-connection-async-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationCreateAsyncSupport) },
                 { "create-serviceprincipal-from-serviceprincipals-csharp-Beta-compiles", new KnownIssue(HTTP, GetCasingIssueMessage("serviceprincipal", "servicePrincipal")) },
                 { "create-serviceprincipal-from-serviceprincipals-csharp-V1-compiles", new KnownIssue(HTTP, GetCasingIssueMessage("serviceprincipal", "servicePrincipal")) },
                 { "create-tablecolumn-from-table-csharp-Beta-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": Id should be string not int") },
                 { "create-tablecolumn-from-table-csharp-V1-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": Id should be string not int") },
+                { "create-team-post-full-payload-csharp-Beta-compiles", new KnownIssue(HTTP, "name should be displayName on teamsTab objects") },
+                { "create-tokenlifetimepolicy-from-application-csharp-Beta-compiles", new KnownIssue(HTTP, RefNeeded) },
                 { "delete-acceptedsenders-from-group-csharp-V1-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("group", "acceptedSender")) },
                 { "delete-alloweduser-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("printer", "allowedUsers")) },
                 { "delete-directoryobject-from-directoryrole-csharp-Beta-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("directoryroles", "directoryRoles")) },
                 { "delete-directoryobject-from-featurerolloutpolicy-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("featureRolloutPolicy", "appliesTo")) },
                 { "delete-educationrubric-from-educationassignment-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("educationAssignment", "rubric"))},
+                { "delete-permission-csharp-Beta-compiles", new KnownIssue(HTTP, "HTTP sample needs to remove `root` from the URL") },
+                { "delete-publishedresource-csharp-Beta-compiles", new KnownIssue(HTTP, RefShouldBeRemoved) },
+                { "directoryobject-delta-csharp-Beta-compiles", new KnownIssue(Metadata, "Delta is not defined on directoryObject, but on user and group") },
+                { "event-decline-csharp-Beta-compiles", new KnownIssue(MetadataPreprocessing, ProposedNewTimeIsDropped) },
+                { "event-tentativelyaccept-csharp-Beta-compiles", new KnownIssue(MetadataPreprocessing, ProposedNewTimeIsDropped) },
                 { "follow-site-csharp-Beta-compiles", new KnownIssue(SDK, "SDK doesn't convert actions defined on collections to methods. https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/250") },
                 { "follow-site-csharp-V1-compiles", new KnownIssue(SDK, "SDK doesn't convert actions defined on collections to methods. https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/250") },
                 { "get-borders-csharp-Beta-compiles", new KnownIssue(SDK, FeatureNotSupported) },
@@ -210,14 +215,22 @@ namespace TestsCommon
                 { "get-callrecord-sessions-csharp-V1-compiles", new KnownIssue(SDK, NamespacesSupport) },
                 { "get-callrecord-sessions-expanded-csharp-Beta-compiles", new KnownIssue(SDK, NamespacesSupport) },
                 { "get-callrecord-sessions-expanded-csharp-V1-compiles", new KnownIssue(SDK, NamespacesSupport) },
+                { "get-count-group-only-csharp-Beta-compiles", new KnownIssue(SDK, CountIsNotSupported) },
+                { "get-count-only-csharp-Beta-compiles", new KnownIssue(SDK, CountIsNotSupported) },
+                { "get-count-user-only-csharp-Beta-compiles", new KnownIssue(SDK, CountIsNotSupported) },
                 { "get-endpoint-csharp-V1-compiles", new KnownIssue(HTTP, "This is only available in Beta") },
                 { "get-endpoints-csharp-V1-compiles", new KnownIssue(HTTP, "This is only available in Beta") },
                 { "get-formatprotection-csharp-Beta-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "get-formatprotection-csharp-V1-compiles", new KnownIssue(SDK, FeatureNotSupported) },
+                { "get-group-transitivemembers-count-csharp-Beta-compiles", new KnownIssue(SDK, CountIsNotSupported) },
+                { "get-identityriskevent-csharp-Beta-compiles", new KnownIssue(HTTP, IdentityRiskEvents) },
+                { "get-identityriskevents-csharp-Beta-compiles", new KnownIssue(HTTP, IdentityRiskEvents) },
                 { "get-message-in-mime-csharp-Beta-compiles", new KnownIssue(Metadata, "Message entity doesn't have hasStream=true.") },
                 { "get-message-in-mime-csharp-V1-compiles", new KnownIssue(Metadata, "Message entity doesn't have hasStream=true.") },
                 { "get-opentypeextension-3-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationFlattens) },
                 { "get-opentypeextension-3-csharp-V1-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationFlattens) },
+                { "get-phone-count-csharp-Beta-compiles", new KnownIssue(SDK, SearchHeaderIsNotSupported) },
+                { "get-pr-count-csharp-Beta-compiles", new KnownIssue(SDK, SearchHeaderIsNotSupported) },
                 { "get-rangeborder-csharp-Beta-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "get-rangeborder-csharp-V1-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "get-rangebordercollection-csharp-Beta-compiles", new KnownIssue(SDK, FeatureNotSupported) },
@@ -235,6 +248,14 @@ namespace TestsCommon
                 { "get-scopedadministratorof-csharp-Beta-compiles", new KnownIssue(Metadata, GetTypeNotDefinedMessage("ScopedAdministratorOf")) },
                 { "get-singlevaluelegacyextendedproperty-1-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationFlattens) },
                 { "get-singlevaluelegacyextendedproperty-1-csharp-V1-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationFlattens) },
+                { "get-store-csharp-Beta-compiles", new KnownIssue(SDK, NamespacesSupport) },
+                { "get-team-count-csharp-Beta-compiles", new KnownIssue(SDK, SearchHeaderIsNotSupported) },
+                { "get-tier-count-csharp-Beta-compiles", new KnownIssue(SDK, SearchHeaderIsNotSupported) },
+                { "get-user-memberof-count-only-csharp-Beta-compiles", new KnownIssue(SDK, CountIsNotSupported) },
+                { "get-user-oauth2permissiongrants-csharp-Beta-compiles", new KnownIssue(Metadata, "Oauth2PermissionGrants are not defined for user") },
+                { "get-video-count-csharp-Beta-compiles", new KnownIssue(SDK, SearchHeaderIsNotSupported) },
+                { "get-wa-count-csharp-Beta-compiles", new KnownIssue(SDK, SearchHeaderIsNotSupported) },
+                { "get-web-count-csharp-Beta-compiles", new KnownIssue(SDK, SearchHeaderIsNotSupported) },
                 { "informationprotectionlabel-evaluateapplication-csharp-Beta-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("informationprotection","informationProtection")) },
                 { "informationprotectionlabel-evaluateclassificationresults-csharp-Beta-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("informationprotection","informationProtection")) },
                 { "informationprotectionlabel-evaluateremoval-csharp-Beta-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("informationprotection","informationProtection")) },
@@ -244,9 +265,13 @@ namespace TestsCommon
                 { "nameditem-range-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
                 { "oauth2permissiongrant-delta-csharp-Beta-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("oAuth2permissiongrants","oAuth2PermissionGrants")) },
                 { "oauth2permissiongrant-delta-csharp-V1-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("oAuth2permissiongrants","oAuth2PermissionGrants")) },
+                { "participant-configuremixer-csharp-Beta-compiles", new KnownIssue(Metadata, "ConfigureMixer doesn't exist in metadata") },
+                { "post-privilegedroleassignmentrequest-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationRequestObjectDisambiguation) },
                 { "post-reply-csharp-Beta-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": Odata.Type for concreate Attachment type should be added") },
                 { "post-reply-csharp-V1-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": Odata.Type for concreate Attachment type should be added") },
                 { "printer-getcapabilities-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
+                { "put-privilegedrolesettings-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationCreateAsyncSupport) },
+                { "put-regionalandlanguagesettings-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationCreateAsyncSupport) },
                 { "range-cell-csharp-V1-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "range-clear-csharp-Beta-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "range-clear-csharp-V1-compiles", new KnownIssue(SDK, FeatureNotSupported) },
@@ -283,6 +308,13 @@ namespace TestsCommon
                 { "remove-group-from-rejectedsenderslist-of-group-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("group", "rejectedSender")) },
                 { "remove-rejectedsender-from-group-csharp-V1-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("group", "rejectedSender")) },
                 { "remove-user-from-rejectedsenderslist-of-group-csharp-Beta-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("group", "rejectedSender")) },
+                { "removeonpremisesagentfromanonpremisesagentgroup-csharp-Beta-compiles", new KnownIssue(HTTP, RefShouldBeRemoved) },
+                { "reportroot-getm365appplatformusercounts-csv-csharp-Beta-compiles", new KnownIssue(SDK, MissingContentProperty) },
+                { "reportroot-getm365appplatformusercounts-json-csharp-Beta-compiles", new KnownIssue(SDK, MissingContentProperty) },
+                { "reportroot-getm365appusercoundetail-csharp-Beta-compiles", new KnownIssue(SDK, MissingContentProperty) },
+                { "reportroot-getm365appusercountdetail-csharp-Beta-compiles", new KnownIssue(SDK, MissingContentProperty) },
+                { "reportroot-getm365appusercounts-csv-csharp-Beta-compiles", new KnownIssue(SDK, MissingContentProperty) },
+                { "reportroot-getm365appusercounts-json-csharp-Beta-compiles", new KnownIssue(SDK, MissingContentProperty) },
                 { "schedule-put-schedulinggroups-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "securescorecontrolprofiles-update-csharp-Beta-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": A list of SecureScoreControlStateUpdate objects should be provided instead of placeholder string.") },
                 { "serviceprincipal-addkey-csharp-V1-compiles", new KnownIssue(HTTP, GetCasingIssueMessage("serviceprincipal", "servicePrincipal")) },
@@ -291,6 +323,7 @@ namespace TestsCommon
                 { "serviceprincipal-removekey-csharp-V1-compiles", new KnownIssue(HTTP, GetCasingIssueMessage("serviceprincipal", "servicePrincipal")) },
                 { "shift-get-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "shift-put-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
+                { "synchronizationschema-parseexpression-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationTypeHint) },
                 { "table-databodyrange-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
                 { "table-headerrowrange-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
                 { "table-headerrowrange-csharp-V1-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
@@ -304,6 +337,8 @@ namespace TestsCommon
                 { "tablecolumn-totalrowrange-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
                 { "tablecolumn-totalrowrange-csharp-V1-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
                 { "tablerow-range-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(POST, GET)) },
+                { "tablerowcollection-add-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationTypeHint) },
+                { "team-put-schedule-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SnippetGenerationCreateAsyncSupport) },
                 { "timeoff-put-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "timeoff-put-csharp-V1-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "timeoffreason-put-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
@@ -320,6 +355,7 @@ namespace TestsCommon
                 { "update-formatprotection-csharp-V1-compiles", new KnownIssue(SDK, FeatureNotSupported) },
                 { "update-homerealmdiscoverypolicy-csharp-Beta-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("HomeRealmDiscoveryPolicy", "Type")) },
                 { "update-homerealmdiscoverypolicy-csharp-V1-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("HomeRealmDiscoveryPolicy", "Type")) },
+                { "update-openidconnectprovider-csharp-Beta-compiles", new KnownIssue(HTTP, "OpenIdConnectProvider should be specified") },
                 { "update-openshift-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "update-page-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, "See issue: https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/288") },
                 { "update-page-csharp-V1-compiles", new KnownIssue(SnippetGeneration, "See issue: https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/288") },
@@ -352,6 +388,7 @@ namespace TestsCommon
                 { "update-room-csharp-V1-compiles", new KnownIssue(HTTP, HttpSnippetWrong + ": Capacity should be int, isWheelchairAccessible should be renamed as isWheelChairAccessible") },
                 { "update-roomlist-csharp-Beta-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("roomlist", "roomList")) },
                 { "update-roomlist-csharp-V1-compiles", new KnownIssue(HTTPCamelCase, GetCasingIssueMessage("roomlist", "roomList")) },
+                { "update-settings-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, "Naming inconsistency in variables. See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/299 for more details") },
                 { "update-synchronizationschema-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "update-synchronizationtemplate-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "update-tokenissuancepolicy-csharp-Beta-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("TokenIssuancePolicy", "Type")) },

--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
     <PackageReference Include="Microsoft.Graph" Version="3.9.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.5" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.22.0-preview" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="0.23.0-preview" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.17.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.CodeDom" Version="4.7.0" />

--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
     <PackageReference Include="Microsoft.Graph" Version="3.9.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.5" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.20.0-preview" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="0.22.0-preview" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.17.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.CodeDom" Version="4.7.0" />


### PR DESCRIPTION
- Spent some time with @MIchaelMainer to analyze some of the remaining Beta issues.
- Initial pass on issues are completed both for V1 and Beta. I will make another pass on the known issues since I understand the overall system better now.
- I also removed some of the summary tags as most of the names/string constants were self explanatory. Instead I grouped them under `#region`s.

With this change, Beta/V1 tests should all pass 🤞, except for the ones marked as known.