### PR TITLE
Add teamsApp update to known issues

### DIFF
--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -2,6 +2,7 @@
 
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -395,6 +396,7 @@ namespace TestsCommon
                 { "update-settings-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, "Naming inconsistency in variables. See https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/299 for more details") },
                 { "update-synchronizationschema-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
                 { "update-synchronizationtemplate-csharp-Beta-compiles", new KnownIssue(HTTPMethodWrong, GetMethodWrongMessage(PUT, PATCH)) },
+                { "update-teamsapp-csharp-V1-compiles", new KnownIssue(Metadata, $"teamsApp needs hasStream=true. In addition to that, we need these fixed: {Environment.NewLine}https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/160 {Environment.NewLine}https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/336") },
                 { "update-tokenissuancepolicy-csharp-Beta-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("TokenIssuancePolicy", "Type")) },
                 { "update-tokenissuancepolicy-csharp-V1-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("TokenIssuancePolicy", "Type")) },
                 { "update-tokenlifetimepolicy-csharp-Beta-compiles", new KnownIssue(HTTP, GetPropertyNotFoundMessage("TokenLifetimePolicy", "Type")) },


### PR DESCRIPTION
There are three different issues preventing to successfully create the snippet for [teamsApp update](https://docs.microsoft.com/en-us/graph/api/teamsapp-update?view=graph-rest-1.0&tabs=http#request)
1. Metadata needs `hasStream=true` for `teamsApp` entity
2. Snippet Generation needs to specify `Content-type` from the HTTP snippet. https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/336
3. Microsoft.Graph.Core shouldn't override media `Content-type` if explicitly specified. https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/160

cc: @darrelmiller @pixieofhugs 