### PR TITLE
Use c#9 features

### DIFF
--- a/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
+++ b/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
-using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
-using System.IO;
 using TestsCommon;
 
 namespace CSharpArbitraryDllTests

--- a/TestsCommon/CompilationOutputMessage.cs
+++ b/TestsCommon/CompilationOutputMessage.cs
@@ -9,54 +9,13 @@ namespace TestsCommon
     /// <summary>
     /// String represenation of compilation errors
     /// </summary>
-    public class CompilationOutputMessage
+    /// <param name="Model">Compilation result</param>
+    /// <param name="Code">Code that was attempted to be compiled</param>
+    /// <param name="DocsLink">documentation page where the snippet is shown</param>
+    /// <param name="KnownIssueMessage">message for known issue</param>
+    /// <param name="IsKnownIssue">whether issue is known</param>
+    public record CompilationOutputMessage (CompilationResultsModel Model, string Code, string DocsLink, string KnownIssueMessage, bool IsKnownIssue)
     {
-        /// <summary>
-        /// Compilation result
-        /// </summary>
-        private readonly CompilationResultsModel Model;
-
-        /// <summary>
-        /// Code that was attempted to be compiled
-        /// </summary>
-        private readonly string Code;
-
-        /// <summary>
-        /// Docs page where the snippet is shown
-        /// </summary>
-        private readonly string DocsLink;
-
-        /// <summary>
-        /// Message for known issue
-        /// </summary>
-        private readonly string KnownIssueMessage;
-
-        /// <summary>
-        /// Whether the issue is known or not
-        /// </summary>
-        private readonly bool IsKnownIssue;
-
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="model">Compilation result</param>
-        /// <param name="code">Code that was attempted to be compiled</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="knownIssueMessage">message for known issue</param>
-        public CompilationOutputMessage(
-            CompilationResultsModel model,
-            string code,
-            string docsLink,
-            string knownIssueMessage,
-            bool isKnownIssue)
-        {
-            Model = model;
-            Code = code;
-            DocsLink = docsLink;
-            KnownIssueMessage = knownIssueMessage;
-            IsKnownIssue = isKnownIssue;
-        }
-
         /// <summary>
         /// String representation of compilation result
         /// </summary>

--- a/TestsCommon/GraphDocsDirectory.cs
+++ b/TestsCommon/GraphDocsDirectory.cs
@@ -15,7 +15,7 @@ namespace TestsCommon
         /// <summary>
         /// Represents where the snippets are stored. Expected to refer to a single directory for each assembly.
         /// </summary>
-        private static string SnippetsDirectory = null;
+        private static string SnippetsDirectory;
 
         /// <summary>
         /// Sets snippets directory only once and refers to the string if it is already set
@@ -34,7 +34,7 @@ namespace TestsCommon
             }
 
             var msGraphDocsRepoLocation = GetSourcesDirectory();
-            SnippetsDirectory = Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}includes{Path.DirectorySeparatorChar}snippets{Path.DirectorySeparatorChar}{language.ToString().ToLowerInvariant()}");
+            SnippetsDirectory = Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}includes{Path.DirectorySeparatorChar}snippets{Path.DirectorySeparatorChar}{language.AsString()}");
 
             return SnippetsDirectory;
         }

--- a/TestsCommon/LanguageTestData.cs
+++ b/TestsCommon/LanguageTestData.cs
@@ -2,48 +2,48 @@
 
 namespace TestsCommon
 {
-    public class LanguageTestData
+    public record LanguageTestData
     {
         /// <summary>
         /// Docs version e.g. V1 or Beta
         /// </summary>
-        public Versions Version { get; set; }
+        public Versions Version { get; init; }
 
         /// <summary>
         /// Whether the test case is failing due to a known issue
         /// </summary>
-        public bool IsKnownIssue { get; set; }
+        public bool IsKnownIssue { get; init; }
 
         /// <summary>
         /// Message to represent known issue
         /// </summary>
-        public string KnownIssueMessage { get; set; }
+        public string KnownIssueMessage { get; init; }
 
         /// <summary>
         /// Documentation link where snippet is shown
         /// </summary>
-        public string DocsLink { get; set; }
+        public string DocsLink { get; init; }
 
         /// <summary>
         /// Snippet file name
         /// </summary>
-        public string FileName { get; set; }
+        public string FileName { get; init; }
 
         /// <summary>
         /// Optional dll path to load Microsoft.Graph from a local resource instead of published nuget
         /// </summary>
-        public string DllPath { get; set; }
+        public string DllPath { get; init; }
         /// <summary>
         /// Optional. Version to use for the java core library. Ignored when using JavaPreviewLibPath
         /// </summary>
-        public string JavaCoreVersion { get; set; }
+        public string JavaCoreVersion { get; init; }
         /// <summary>
         /// Optional. Version to use for the java service library. Ignored when using JavaPreviewLibPath
         /// </summary>
-        public string JavaLibVersion { get; set; }
+        public string JavaLibVersion { get; init; }
         /// <summary>
         /// Optional. Folder container the java core and java service library repositories so the unit testing uses that local version instead.
         /// </summary>
-        public string JavaPreviewLibPath { get; set; }
+        public string JavaPreviewLibPath { get; init; }
     }
 }

--- a/TestsCommon/LanguageTestData.cs
+++ b/TestsCommon/LanguageTestData.cs
@@ -2,48 +2,26 @@
 
 namespace TestsCommon
 {
-    public record LanguageTestData
-    {
-        /// <summary>
-        /// Docs version e.g. V1 or Beta
-        /// </summary>
-        public Versions Version { get; init; }
-
-        /// <summary>
-        /// Whether the test case is failing due to a known issue
-        /// </summary>
-        public bool IsKnownIssue { get; init; }
-
-        /// <summary>
-        /// Message to represent known issue
-        /// </summary>
-        public string KnownIssueMessage { get; init; }
-
-        /// <summary>
-        /// Documentation link where snippet is shown
-        /// </summary>
-        public string DocsLink { get; init; }
-
-        /// <summary>
-        /// Snippet file name
-        /// </summary>
-        public string FileName { get; init; }
-
-        /// <summary>
-        /// Optional dll path to load Microsoft.Graph from a local resource instead of published nuget
-        /// </summary>
-        public string DllPath { get; init; }
-        /// <summary>
-        /// Optional. Version to use for the java core library. Ignored when using JavaPreviewLibPath
-        /// </summary>
-        public string JavaCoreVersion { get; init; }
-        /// <summary>
-        /// Optional. Version to use for the java service library. Ignored when using JavaPreviewLibPath
-        /// </summary>
-        public string JavaLibVersion { get; init; }
-        /// <summary>
-        /// Optional. Folder container the java core and java service library repositories so the unit testing uses that local version instead.
-        /// </summary>
-        public string JavaPreviewLibPath { get; init; }
-    }
+    /// <summary>
+    /// Test Data
+    /// </summary>
+    /// <param name="Version">Docs version e.g. V1 or Beta</param>
+    /// <param name="IsKnownIssue">Whether the test case is failing due to a known issue</param>
+    /// <param name="KnownIssueMessage">Message to represent known issue</param>
+    /// <param name="DocsLink">Documentation link where snippet is shown</param>
+    /// <param name="FileName">Snippet file name</param>
+    /// <param name="DllPath">Optional dll path to load Microsoft.Graph from a local resource instead of published nuget</param>
+    /// <param name="JavaCoreVersion">Optional. Version to use for the java core library. Ignored when using JavaPreviewLibPath</param>
+    /// <param name="JavaLibVersion">Optional. Version to use for the java service library. Ignored when using JavaPreviewLibPath</param>
+    /// <param name="JavaPreviewLibPath">Optional. Folder container the java core and java service library repositories so the unit testing uses that local version instead.</param>
+    public record LanguageTestData(
+        Versions Version,
+        bool IsKnownIssue,
+        string KnownIssueMessage,
+        string DocsLink,
+        string FileName,
+        string DllPath,
+        string JavaCoreVersion,
+        string JavaLibVersion,
+        string JavaPreviewLibPath);
 }

--- a/TestsCommon/RunSettings.cs
+++ b/TestsCommon/RunSettings.cs
@@ -10,13 +10,13 @@ namespace TestsCommon
     /// <summary>
     /// Converts a runsettings file into an object after validating settings
     /// </summary>
-    public class RunSettings
+    public record RunSettings
     {
-        public Versions Version { get; set; }
-        public string DllPath { get; set; }
-        public bool KnownFailuresRequested { get; set; }
-        public Languages Language { get; set; }
-        public string JavaCoreVersion { get; set; } = "1.0.5";
+        public Versions Version { get; init; }
+        public string DllPath { get; init; }
+        public bool KnownFailuresRequested { get; init; }
+        public Languages Language { get; init; }
+        public string JavaCoreVersion { get; init; } = "1.0.5";
         private string _javaLibVersion;
         public string JavaLibVersion
         {
@@ -32,7 +32,7 @@ namespace TestsCommon
                 _javaLibVersion = value;
             }
         }
-        public string JavaPreviewLibPath { get; set; }
+        public string JavaPreviewLibPath { get; init; }
         private const string dashdash = "---";
         public RunSettings() { }
 
@@ -72,17 +72,13 @@ namespace TestsCommon
                 Version = VersionString.GetVersion(versionString);
             if (!string.IsNullOrEmpty(knownFailuresRequested) && !knownFailuresRequested.Contains(dashdash))
                 KnownFailuresRequested = bool.Parse(knownFailuresRequested);
-            InitJavaParameters(parameters);
-        }
 
-        private void InitJavaParameters(TestParameters parameters)
-        {
             JavaCoreVersion = InitializeParameter(parameters, nameof(JavaCoreVersion)) ?? JavaCoreVersion;
             JavaLibVersion = InitializeParameter(parameters, nameof(JavaLibVersion)); // we don't have the Graph version information just yet as it could be provided later with parameter initizaliation
             JavaPreviewLibPath = InitializeParameter(parameters, nameof(JavaPreviewLibPath)) ?? JavaPreviewLibPath;
         }
 
-        private string InitializeParameter(TestParameters parameters, string parameterName)
+        private static string InitializeParameter(TestParameters parameters, string parameterName)
         {
             var value = parameters.Get(parameterName);
 

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -622,18 +622,16 @@ namespace TestsCommon
                    let knownIssue = isKnownIssue ? knownIssues[knownIssueLookupKey] : null
                    let knownIssueMessage = knownIssue?.Message ?? string.Empty
                    let owner = knownIssue?.Owner ?? string.Empty
-                   let testCaseData = new LanguageTestData
-                   {
-                       Version = version,
-                       IsKnownIssue = isKnownIssue,
-                       KnownIssueMessage = knownIssueMessage,
-                       DocsLink = docsLink,
-                       FileName = fileName,
-                       DllPath = runSettings.DllPath,
-                       JavaCoreVersion = runSettings.JavaCoreVersion,
-                       JavaLibVersion = runSettings.JavaLibVersion,
-                       JavaPreviewLibPath = runSettings.JavaPreviewLibPath,
-                   }
+                   let testCaseData = new LanguageTestData(
+                       version,
+                       isKnownIssue,
+                       knownIssueMessage,
+                       docsLink,
+                       fileName,
+                       runSettings.DllPath,
+                       runSettings.JavaCoreVersion,
+                       runSettings.JavaLibVersion,
+                       runSettings.JavaPreviewLibPath)
                    where !(isKnownIssue ^ runSettings.KnownFailuresRequested) // select known issues if requested
                    select new TestCaseData(testCaseData).SetName(testName).SetProperty("Owner", owner);
         }

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -10,30 +10,8 @@ using System.Text.RegularExpressions;
 
 namespace TestsCommon
 {
-    public class KnownIssue
-    {
-        /// <summary>
-        /// owner of known issue
-        /// This field is used to categorize known test failures, so that we can redirect issues faster
-        /// </summary>
-        public string Owner { get; set; }
-
-        /// <summary>
-        /// known issue message
-        /// </summary>
-        public string Message { get; set; }
-
-        /// <summary>
-        /// known issue constructor
-        /// </summary>
-        /// <param name="owner">owner of known issue</param>
-        /// <param name="message">known issue message</param>
-        public KnownIssue(string owner, string message)
-        {
-            Owner = owner;
-            Message = message;
-        }
-    }
+    // Owner is used to categorize known test failures, so that we can redirect issues faster
+    public record KnownIssue (string Owner, string Message);
 
     public static class KnownIssues
     {
@@ -141,14 +119,10 @@ namespace TestsCommon
         /// Returns a mapping of issues of which the source comes from service/documentation/metadata and are common accross langauges
         /// </summary>
         /// <param name="language">language to generate the exception from</param>
-        /// <param name="versionEnum">version to get the known issues for</param>
         /// <returns>mapping of issues of which the source comes from service/documentation/metadata and are common accross langauges</returns>
-        public static Dictionary<string, KnownIssue> GetCommonIssues(Languages language, Versions versionEnum)
+        public static Dictionary<string, KnownIssue> GetCommonIssues(Languages language)
         {
-#pragma warning disable CA1308 // Normalize strings to uppercase
-            var lng = language.ToString().ToLowerInvariant();
-#pragma warning restore CA1308 // Normalize strings to uppercase
-            var version = versionEnum == Versions.V1 ? "V1" : "Beta";
+            var lng = language.AsString();
             return new Dictionary<string, KnownIssue>()
             {
                 { $"convert-team-from-group-{lng}-V1-compiles", new KnownIssue(HTTP, "isFavoriteByDefault is only available in Beta. https://github.com/microsoftgraph/microsoft-graph-docs/issues/10145") },
@@ -580,7 +554,7 @@ namespace TestsCommon
                 Languages.CSharp => GetCSharpIssues(version),
                 Languages.Java => GetJavaIssues(version),
                 _ => new Dictionary<string, KnownIssue>(),
-            }).Union(GetCommonIssues(language, version)).ToDictionary(x => x.Key, x => x.Value);
+            }).Union(GetCommonIssues(language)).ToDictionary(x => x.Key, x => x.Value);
         }
     }
     /// <summary>
@@ -598,9 +572,7 @@ namespace TestsCommon
             var documentationLinks = new Dictionary<string, string>();
             var documentationDirectory = GraphDocsDirectory.GetDocumentationDirectory(version);
             var files = Directory.GetFiles(documentationDirectory);
-#pragma warning disable CA1308 // Normalize strings to uppercase
-            var languageName = language.ToString().ToLowerInvariant();
-#pragma warning restore CA1308 // Normalize strings to uppercase
+            var languageName = language.AsString();
             var SnippetLinkPattern = @$"includes\/snippets\/{languageName}\/(.*)\-{languageName}\-snippets\.md";
             var SnippetLinkRegex = new Regex(SnippetLinkPattern, RegexOptions.Compiled);
             foreach (var file in files)

--- a/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
@@ -3,10 +3,5 @@ using System.Collections.Generic;
 
 namespace MsGraphSDKSnippetsCompiler.Models
 {
-    public class CompilationResultsModel
-    {
-        public bool IsSuccess { get; set; }
-        public IEnumerable<Diagnostic> Diagnostics { get; set; }
-        public string MarkdownFileName { get; set; }
-    }
+    public record CompilationResultsModel(bool IsSuccess, IEnumerable<Diagnostic> Diagnostics, string MarkdownFileName);
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/LanguagesAndVersions.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/LanguagesAndVersions.cs
@@ -13,6 +13,11 @@ namespace MsGraphSDKSnippetsCompiler.Models
         ObjC
     }
 
+    public static class LanguagesExtension
+    {
+        public static string AsString(this Languages language) => language.ToString().ToLowerInvariant();
+    }
+
     /// <summary>
     /// Microsoft Graph Documetation Versions
     /// </summary>


### PR DESCRIPTION
- Converted types to record types whenever applicable.
- Changed `set`s to `init`s to ensure immutability.
- Addressed a few compiler warnings.