### PR TITLE
Add .NET 5 tooling step to fix E2E pipelines

### DIFF
--- a/azure-pipelines/beta-end-to-end.yml
+++ b/azure-pipelines/beta-end-to-end.yml
@@ -67,6 +67,7 @@ steps:
   - template: e2e-templates/checkouts.yml
   - template: e2e-templates/snippet-generation.yml
   - template: e2e-templates/sdk-generation.yml
+  - template: common-templates/use-dotnet.sdk.yml
   - template: e2e-templates/regular-tests.yml
   - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:
     - template: e2e-templates/known-failure-tests.yml

--- a/azure-pipelines/beta-end-to-end.yml
+++ b/azure-pipelines/beta-end-to-end.yml
@@ -67,7 +67,7 @@ steps:
   - template: e2e-templates/checkouts.yml
   - template: e2e-templates/snippet-generation.yml
   - template: e2e-templates/sdk-generation.yml
-  - template: common-templates/use-dotnet.sdk.yml
+  - template: common-templates/use-dotnet-sdk.yml
   - template: e2e-templates/regular-tests.yml
   - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:
     - template: e2e-templates/known-failure-tests.yml

--- a/azure-pipelines/common-templates/use-dotnet-sdk.yml
+++ b/azure-pipelines/common-templates/use-dotnet-sdk.yml
@@ -1,0 +1,7 @@
+steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk'
+  inputs:
+    packageType: sdk
+    version: 5.0.100
+    installationPath: $(Agent.ToolsDirectory)/dotnet

--- a/azure-pipelines/compile-run-tests-template.yml
+++ b/azure-pipelines/compile-run-tests-template.yml
@@ -2,12 +2,7 @@ parameters:
   projectFileName: JavaV1Tests
   runName: 'V1 Java Snippet Compilation Tests'
 steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
-  inputs:
-    packageType: sdk
-    version: 5.0.100
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+- template: common-templates/use-dotnet-sdk.yml
 
 - task: DotNetCoreCLI@2
   inputs:

--- a/azure-pipelines/v1-end-to-end.yml
+++ b/azure-pipelines/v1-end-to-end.yml
@@ -67,6 +67,7 @@ steps:
   - template: e2e-templates/checkouts.yml
   - template: e2e-templates/snippet-generation.yml
   - template: e2e-templates/sdk-generation.yml
+  - template: common-templates/use-dotnet.sdk.yml
   - template: e2e-templates/regular-tests.yml
   - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:
     - template: e2e-templates/known-failure-tests.yml

--- a/azure-pipelines/v1-end-to-end.yml
+++ b/azure-pipelines/v1-end-to-end.yml
@@ -67,7 +67,7 @@ steps:
   - template: e2e-templates/checkouts.yml
   - template: e2e-templates/snippet-generation.yml
   - template: e2e-templates/sdk-generation.yml
-  - template: common-templates/use-dotnet.sdk.yml
+  - template: common-templates/use-dotnet-sdk.yml
   - template: e2e-templates/regular-tests.yml
   - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:
     - template: e2e-templates/known-failure-tests.yml


### PR DESCRIPTION
Moving to .NET 5 requires an explicit step since the workers in Azure DevOps don't have it by default.