### PR TITLE
[Snippet Generation] Add custom metadata support

### DIFF
--- a/azure-pipelines/beta-end-to-end.yml
+++ b/azure-pipelines/beta-end-to-end.yml
@@ -65,8 +65,8 @@ variables:
 
 steps:
   - template: e2e-templates/checkouts.yml
-  - template: e2e-templates/snippet-generation.yml
   - template: e2e-templates/sdk-generation.yml
+  - template: e2e-templates/snippet-generation.yml
   - template: common-templates/use-dotnet-sdk.yml
   - template: e2e-templates/regular-tests.yml
   - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:

--- a/azure-pipelines/e2e-templates/snippet-generation.yml
+++ b/azure-pipelines/e2e-templates/snippet-generation.yml
@@ -39,4 +39,4 @@ steps:
       $apidoctorPath = (Get-ChildItem $apidoctorBinDirectory apidoc.exe -Recurse).FullName
       Write-Host "Path to apidoctor tool: $apidoctorPath"
 
-      & $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "C:\Program Files\Git\bin\git.exe"
+      & $apidoctorPath generate-snippets --ignore-warnings --path . --snippet-generator-path $snippetGeneratorPath --lang $(snippetLanguages) --git-path "C:\Program Files\Git\bin\git.exe" --custom-metadata-path $(Build.SourcesDirectory)\metadata\metadata.xml

--- a/azure-pipelines/v1-end-to-end.yml
+++ b/azure-pipelines/v1-end-to-end.yml
@@ -65,8 +65,8 @@ variables:
 
 steps:
   - template: e2e-templates/checkouts.yml
-  - template: e2e-templates/snippet-generation.yml
   - template: e2e-templates/sdk-generation.yml
+  - template: e2e-templates/snippet-generation.yml
   - template: common-templates/use-dotnet-sdk.yml
   - template: e2e-templates/regular-tests.yml
   - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:


### PR DESCRIPTION
Step 3 of the proposed solution in https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/383

- Reorders snippet generation and sdk generation steps to make local path for transformed metadata available in snippet generation step
- Specifies custom metadata path input to apidoctor call

[Tests before the fix](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=33474&view=ms.vss-test-web.build-test-results-tab&runId=1006694&resultId=100389&paneView=debug)
[Tests after the fix](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=33494&view=ms.vss-test-web.build-test-results-tab)

Observe that `post-ediscoverycase-csharp-arbitraryDll-Beta-compiles` test doesn't fail after the fix.