### PR TITLE
NuGet prerelease package updater

### DIFF
--- a/.github/workflows/prerelease-package-updater.yaml
+++ b/.github/workflows/prerelease-package-updater.yaml
@@ -26,10 +26,10 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           commit-message: Update prerelease dependencies
-          committer: GitHub <noreply@github.com>
+          committer: Microsoft Graph DevX Tooling <GraphTooling@service.microsoft.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
-          branch: example-patches
+          branch: prerelease-updates
           delete-branch: true
           title: 'Updated prerelease dependencies'
           body: |

--- a/.github/workflows/prerelease-package-updater.yaml
+++ b/.github/workflows/prerelease-package-updater.yaml
@@ -3,6 +3,8 @@
 name: "update prerelease packages"
 
 on:
+  repository_dispatch:
+    types: update-prerelease-packages
   schedule:
     - cron: "0 12 * * *" # everyday at noon
 

--- a/.github/workflows/prerelease-package-updater.yaml
+++ b/.github/workflows/prerelease-package-updater.yaml
@@ -30,6 +30,7 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: prerelease-updates
+          branch-suffix: timestamp
           delete-branch: true
           title: 'Updated prerelease dependencies'
           body: |

--- a/.github/workflows/prerelease-package-updater.yaml
+++ b/.github/workflows/prerelease-package-updater.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.x'
+          dotnet-version: '5.0.x'
 
       - name: search for updates
         shell: pwsh

--- a/.github/workflows/prerelease-package-updater.yaml
+++ b/.github/workflows/prerelease-package-updater.yaml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.*'
+
       - name: search for updates
         shell: pwsh
         run: |

--- a/.github/workflows/prerelease-package-updater.yaml
+++ b/.github/workflows/prerelease-package-updater.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+name: "update prerelease packages"
+
+on:
+  schedule:
+    - cron: "0 12 * * *" # everyday at noon
+
+jobs:
+  update-prerelease-packages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: search for updates
+        shell: pwsh
+        run: |
+          & .\scripts\PrereleasePackageUpdater.ps1
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PAT }}
+          commit-message: Update prerelease dependencies
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: example-patches
+          delete-branch: true
+          title: 'Updated prerelease dependencies'
+          body: |
+            Please review if only prerelease packages are updated to newer versions
+          labels: |
+            prerelease update
+          reviewers: zengin
+          draft: false
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/prerelease-package-updater.yaml
+++ b/.github/workflows/prerelease-package-updater.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.*'
+          dotnet-version: '5.x'
 
       - name: search for updates
         shell: pwsh

--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
-    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.5" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.32.0-preview" />
+    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.6" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="0.33.0-preview" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.CodeDom" Version="5.0.0" />

--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -1,33 +1,28 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>MsGraphSDKSnippetsCompiler</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
-    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.6" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.33.0-preview" />
+    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.5" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="0.32.0-preview" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.CodeDom" Version="5.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
-
   <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
     <ItemGroup>
       <ReferencePath Condition="'%(FileName)' == 'Microsoft.Graph.Beta'">
@@ -35,5 +30,4 @@
       </ReferencePath>
     </ItemGroup>
   </Target>
-  
 </Project>

--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
-    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.6" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.33.0-preview" />
+    <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.5" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="0.32.0-preview" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.CodeDom" Version="5.0.0" />

--- a/scripts/PrereleasePackageUpdater.ps1
+++ b/scripts/PrereleasePackageUpdater.ps1
@@ -1,0 +1,54 @@
+# updates prerelease dependencies for packages listed below as $packages
+# expected to be run where working directory is the root of the repo
+
+$packages = "Microsoft.Graph.Beta","Microsoft.Graph.Auth"
+
+$projectFile = "msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj"
+$fullFileName = Resolve-Path $projectFile
+
+Write-Host "Searching latest updates including prerelease for $projectFile. NuGet packages in search are:"
+Write-Host ($packages -join [System.Environment]::NewLine)
+
+# Read .csproj file as UTF-8
+$project = New-Object -TypeName XML
+$utf8Encoding = (New-Object System.Text.UTF8Encoding($false))
+$streamReader = New-Object System.IO.StreamReader($fullFileName, $utf8Encoding, $false)
+$project.Load($streamReader)
+$streamReader.Close()
+
+$packageReferences = $project.Project.ItemGroup.PackageReference 
+
+$updated = $false
+foreach ($package in $packages)
+{
+    # get latest nuget package version
+    $lowerCasePackage = $package.ToLower()
+    $nugetUrl = "https://api.nuget.org/v3/registration5-gz-semver2/$lowerCasePackage/index.json"
+    $res = Invoke-RestMethod $nugetUrl
+    $latestVersion = $res.items.items.catalogEntry.version[-1]
+    Write-Host "Found version $latestVersion in NuGet server for $package"
+
+    # get version from project file
+    $packageReference = $packageReferences | Where-Object { $_.Include -eq $package }
+    $projectVersion = $packageReference | Select-Object -ExpandProperty Version
+    Write-Host "Found version $projectVersion in the project file for $package"
+
+    if ($latestVersion -eq $projectVersion)
+    {
+        Write-Host "Latest version is the same as project version for $package"
+    }
+    else
+    {
+        $packageReference.Version = $latestVersion
+        $updated = $true;
+    }
+}
+
+if ($updated)
+{
+    $project.Save($fullFileName)
+}
+else
+{
+    Write-Host "There are no updated dependencies"
+}

--- a/scripts/PrereleasePackageUpdater.ps1
+++ b/scripts/PrereleasePackageUpdater.ps1
@@ -3,7 +3,7 @@
 
 $packages = "Microsoft.Graph.Beta","Microsoft.Graph.Auth"
 
-$projectFile = (Resolve-Path "msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj").Path
+$projectFile = "msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj"
 
 foreach ($package in $packages)
 {

--- a/scripts/PrereleasePackageUpdater.ps1
+++ b/scripts/PrereleasePackageUpdater.ps1
@@ -1,11 +1,9 @@
 # updates prerelease dependencies for packages listed below as $packages
 # expected to be run where working directory is the root of the repo
 
-Write-Host "Working directory: $PWD"
-
 $packages = "Microsoft.Graph.Beta","Microsoft.Graph.Auth"
 
-$projectFile = "msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj"
+$projectFile = (Resolve-Path "msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj").Path
 
 foreach ($package in $packages)
 {

--- a/scripts/PrereleasePackageUpdater.ps1
+++ b/scripts/PrereleasePackageUpdater.ps1
@@ -4,51 +4,9 @@
 $packages = "Microsoft.Graph.Beta","Microsoft.Graph.Auth"
 
 $projectFile = "msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj"
-$fullFileName = Resolve-Path $projectFile
 
-Write-Host "Searching latest updates including prerelease for $projectFile. NuGet packages in search are:"
-Write-Host ($packages -join [System.Environment]::NewLine)
-
-# Read .csproj file as UTF-8
-$project = New-Object -TypeName XML
-$utf8Encoding = (New-Object System.Text.UTF8Encoding($false))
-$streamReader = New-Object System.IO.StreamReader($fullFileName, $utf8Encoding, $false)
-$project.Load($streamReader)
-$streamReader.Close()
-
-$packageReferences = $project.Project.ItemGroup.PackageReference 
-
-$updated = $false
 foreach ($package in $packages)
 {
-    # get latest nuget package version
-    $lowerCasePackage = $package.ToLower()
-    $nugetUrl = "https://api.nuget.org/v3/registration5-gz-semver2/$lowerCasePackage/index.json"
-    $res = Invoke-RestMethod $nugetUrl
-    $latestVersion = $res.items.items.catalogEntry.version[-1]
-    Write-Host "Found version $latestVersion in NuGet server for $package"
-
-    # get version from project file
-    $packageReference = $packageReferences | Where-Object { $_.Include -eq $package }
-    $projectVersion = $packageReference | Select-Object -ExpandProperty Version
-    Write-Host "Found version $projectVersion in the project file for $package"
-
-    if ($latestVersion -eq $projectVersion)
-    {
-        Write-Host "Latest version is the same as project version for $package"
-    }
-    else
-    {
-        $packageReference.Version = $latestVersion
-        $updated = $true;
-    }
-}
-
-if ($updated)
-{
-    $project.Save($fullFileName)
-}
-else
-{
-    Write-Host "There are no updated dependencies"
+    dotnet remove $projectFile package $package
+    dotnet add $projectFile package $package --prerelease
 }

--- a/scripts/PrereleasePackageUpdater.ps1
+++ b/scripts/PrereleasePackageUpdater.ps1
@@ -1,6 +1,8 @@
 # updates prerelease dependencies for packages listed below as $packages
 # expected to be run where working directory is the root of the repo
 
+Write-Host "Working directory: $PWD"
+
 $packages = "Microsoft.Graph.Beta","Microsoft.Graph.Auth"
 
 $projectFile = "msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj"


### PR DESCRIPTION
Dependabot doesn't look like to be implementing the feature for updating preview packages in the near future.

According to [this comment](https://github.com/dependabot/dependabot-core/issues/1842#issuecomment-624529062), they only allow updating from a production release to a preview release if their main versions are the same, e.g.
```
from 1.1.0 to 1.1.0.preview
```
which doesn't seem to fit the SemVer spec. See 11.3 [here](https://semver.org/#spec-item-11) which basically says
```
1.1.0.preview < 1.1.0
```

Anyways, my quick fix here is a GitHub action and an accompanying Powershell script, which fetches the latest NuGet packages for `Microsoft.Graph.Beta` and `Microsoft.Graph.Auth` libraries regardless of their prerelease status. No intelligence is built into understanding the version numbers, I simply grab the latest package.

I also use `peter-evans/create-pull-request@v3` GitHub action for creating a PR. It handles all the git operations I want:
- No-op if there is no changes
- Auto branching, committing and pushing
- Specific unique branch naming (timestamp suffix)

I reformatted the csproj file to set the baseline and decreased the version numbers to give this a go in the main repo as well. 

Action can be seen in action here: https://github.com/zengin/msgraph-sdk-raptor/pull/4