### PR TITLE
- fixes a bug where starting the process before attaching events could make java sequence fail

### DIFF
--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
@@ -122,7 +122,6 @@ application {
                     WorkingDirectory = rootPath,
                 },
             };
-            javacProcess.Start();
             var stdOuputSB = new StringBuilder();
             var stdErrSB = new StringBuilder();
             using var outputWaitHandle = new AutoResetEvent(false);
@@ -148,6 +147,7 @@ application {
                     stdErrSB.Append(e.Data);
                 }
             };
+            javacProcess.Start();
             javacProcess.BeginOutputReadLine();
             javacProcess.BeginErrorReadLine();
             var hasExited = javacProcess.WaitForExit(20000);


### PR DESCRIPTION
This bug probably causes the following error when running the tests
```
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.ObjectDisposedException: Safe handle has been closed
```

The recommendation is to start the process after subscribing to the events.
https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.beginoutputreadline?view=net-5.0#remarks