### PR TITLE
Infrastructure for running Get Tests in C# V1 and Beta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zengin @baywet @nikithauc @peombwa @MIchaelMainer @ddyett
+* @zengin @baywet @nikithauc @peombwa @MIchaelMainer @ddyett @finsharp

--- a/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
+++ b/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
@@ -25,7 +25,7 @@ namespace CSharpArbitraryDllTests
         [TestCaseSource(typeof(SnippetCompileArbitraryDllTests), nameof(ArbitraryDllTestData))]
         public void Test(LanguageTestData testData)
         {
-            CSharpTestRunner.Run(testData);
+            CSharpTestRunner.Compile(testData);
         }
     }
 }

--- a/CsharpBetaExecutionTests/AssemblyInfo.cs
+++ b/CsharpBetaExecutionTests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using NUnit.Framework;
+[assembly: Parallelizable(ParallelScope.All)]

--- a/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj
+++ b/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
+++ b/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using TestsCommon;
@@ -28,9 +29,9 @@ namespace CsharpBetaExecutionTests
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
         [TestCaseSource(typeof(SnippetExecutionBetaTests), nameof(TestDataBeta))]
-        public void Test(ExecutionTestData testData)
+        public async Task Test(ExecutionTestData testData)
         {
-            CSharpTestRunner.Execute(testData);
+            await CSharpTestRunner.Execute(testData);
         }
     }
 }

--- a/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
+++ b/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
@@ -1,25 +1,23 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-
+﻿using System.Collections.Generic;
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
-using System.Collections.Generic;
 using TestsCommon;
 
-namespace CsharpV1KnownFailureTests
+namespace CsharpBetaExecutionTests
 {
     [TestFixture]
-    public class KnownFailuresV1
+    public class SnippetExecutionBetaTests
     {
         /// <summary>
-        /// Gets TestCaseData for V1 known failures
+        /// Gets TestCaseData for Beta
         /// TestCaseData contains snippet file name, version and test case name
         /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
+        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetExecutionTestData(
             new RunSettings
             {
-                Version = Versions.V1,
+                Version = Versions.Beta,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = true
+                KnownFailuresRequested = false
             });
 
         /// <summary>
@@ -29,10 +27,10 @@ namespace CsharpV1KnownFailureTests
         /// <param name="docsLink">documentation page where the snippet is shown</param>
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
-        [TestCaseSource(typeof(KnownFailuresV1), nameof(TestDataV1))]
-        public void Test(LanguageTestData testData)
+        [TestCaseSource(typeof(SnippetExecutionBetaTests), nameof(TestDataBeta))]
+        public void Test(ExecutionTestData testData)
         {
-            CSharpTestRunner.Compile(testData);
+            CSharpTestRunner.Execute(testData);
         }
     }
 }

--- a/CsharpBetaExecutionTests/Test.runsettings
+++ b/CsharpBetaExecutionTests/Test.runsettings
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>

--- a/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
+++ b/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
@@ -32,7 +32,7 @@ namespace CsharpBetaKnownFailureTests
         [TestCaseSource(typeof(KnownFailuresBeta), nameof(TestDataBeta))]
         public void Test(LanguageTestData testData)
         {
-            CSharpTestRunner.Run(testData);
+            CSharpTestRunner.Compile(testData);
         }
     }
 }

--- a/CsharpBetaTests/SnippetCompileBetaTests.cs
+++ b/CsharpBetaTests/SnippetCompileBetaTests.cs
@@ -32,7 +32,7 @@ namespace CsharpBetaTests
         [TestCaseSource(typeof(SnippetCompileBetaTests), nameof(TestDataBeta))]
         public void Test(LanguageTestData testData)
         {
-            CSharpTestRunner.Run(testData);
+            CSharpTestRunner.Compile(testData);
         }
     }
 }

--- a/CsharpV1ExecutionTests/AssemblyInfo.cs
+++ b/CsharpV1ExecutionTests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using NUnit.Framework;
+[assembly: Parallelizable(ParallelScope.All)]

--- a/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj
+++ b/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
+++ b/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
@@ -1,25 +1,23 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-
+﻿using System.Collections.Generic;
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
-using System.Collections.Generic;
 using TestsCommon;
 
-namespace CsharpV1KnownFailureTests
+namespace CsharpV1ExecutionTests
 {
     [TestFixture]
-    public class KnownFailuresV1
+    public class SnippetExecutionV1Tests
     {
         /// <summary>
-        /// Gets TestCaseData for V1 known failures
+        /// Gets TestCaseData for V1
         /// TestCaseData contains snippet file name, version and test case name
         /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
+        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetExecutionTestData(
             new RunSettings
             {
                 Version = Versions.V1,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = true
+                KnownFailuresRequested = false
             });
 
         /// <summary>
@@ -29,10 +27,10 @@ namespace CsharpV1KnownFailureTests
         /// <param name="docsLink">documentation page where the snippet is shown</param>
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
-        [TestCaseSource(typeof(KnownFailuresV1), nameof(TestDataV1))]
-        public void Test(LanguageTestData testData)
+        [TestCaseSource(typeof(SnippetExecutionV1Tests), nameof(TestDataV1))]
+        public void Test(ExecutionTestData testData)
         {
-            CSharpTestRunner.Compile(testData);
+            CSharpTestRunner.Execute(testData);
         }
     }
 }

--- a/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
+++ b/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using TestsCommon;
@@ -28,9 +29,9 @@ namespace CsharpV1ExecutionTests
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
         [TestCaseSource(typeof(SnippetExecutionV1Tests), nameof(TestDataV1))]
-        public void Test(ExecutionTestData testData)
+        public async Task Test(ExecutionTestData testData)
         {
-            CSharpTestRunner.Execute(testData);
+            await CSharpTestRunner.Execute(testData);
         }
     }
 }

--- a/CsharpV1ExecutionTests/Test.runsettings
+++ b/CsharpV1ExecutionTests/Test.runsettings
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>

--- a/CsharpV1Tests/SnippetCompileV1Tests.cs
+++ b/CsharpV1Tests/SnippetCompileV1Tests.cs
@@ -32,7 +32,7 @@ namespace CsharpV1Tests
         [TestCaseSource(typeof(SnippetCompileV1Tests), nameof(TestDataV1))]
         public void Test(LanguageTestData testData)
         {
-            CSharpTestRunner.Run(testData);
+            CSharpTestRunner.Compile(testData);
         }
     }
 }

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace TestsCommon
 {
@@ -99,7 +100,7 @@ public class GraphSDKTest
         /// 4. Attempts to compile and reports errors if there is any
         /// </summary>
         /// <param name="executionTestData">Test data containing information such as snippet file name</param>
-        public static void Execute(ExecutionTestData executionTestData)
+        public async static Task Execute(ExecutionTestData executionTestData)
         {
             if (executionTestData == null)
             {
@@ -112,7 +113,7 @@ public class GraphSDKTest
 
             // Compile Code
             var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData.FileName, testData.DllPath);
-            var executionResultsModel = microsoftGraphCSharpCompiler.ExecuteSnippet(codeToCompile, testData.Version);
+            var executionResultsModel = await microsoftGraphCSharpCompiler.ExecuteSnippet(codeToCompile, testData.Version);
             var compilationOutputMessage = new CompilationOutputMessage(
                 executionResultsModel.CompilationResult,
                 codeToCompile,

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -44,15 +44,23 @@ public class GraphSDKTest
         /// <summary>
         /// matches csharp snippet from C# snippets markdown output
         /// </summary>
-        private const string Pattern = @"```csharp(.*)```";
+        private const string CSharpSnippetPattern = @"```csharp(.*)```";
 
         /// <summary>
         /// compiled version of the C# markdown regular expression
         /// uses Singleline so that (.*) matches new line characters as well
         /// </summary>
-        private static readonly Regex RegExp = new Regex(Pattern, RegexOptions.Singleline | RegexOptions.Compiled);
+        private static readonly Regex CSharpSnippetRegex = new Regex(CSharpSnippetPattern, RegexOptions.Singleline | RegexOptions.Compiled);
 
+        /// <summary>
+        /// matches result variable name from code snippets
+        /// </summary>
+        private const string ResultVariablePattern = "var ([a-zA-Z0-9]+) = await graphClient";
 
+        /// <summary>
+        /// compiled version of the regex matching result variable name from code snippets
+        /// </summary>
+        private static readonly Regex ResultVariableRegex = new Regex(ResultVariablePattern, RegexOptions.Singleline | RegexOptions.Compiled);
 
         /// <summary>
         /// 1. Fetches snippet from docs repo
@@ -140,11 +148,10 @@ public class GraphSDKTest
 
         private static string CaptureUriAndHeadersInException(string codeToCompile)
         {
-            var resultVariablePattern = "var ([a-zA-Z0-9]+) = await graphClient";
             string resultVariable = null;
             try
             {
-                resultVariable = Regex.Match(codeToCompile, resultVariablePattern).Groups[1].Value;
+                resultVariable = ResultVariableRegex.Match(codeToCompile).Groups[1].Value;
             }
             catch (Exception e)
             {
@@ -171,7 +178,7 @@ public class GraphSDKTest
 
         private static (string, string) GetCodeToCompile(string fileContent, Func<string, string> postTransform = null)
         {
-            var match = RegExp.Match(fileContent);
+            var match = CSharpSnippetRegex.Match(fileContent);
             Assert.IsTrue(match.Success, "Csharp snippet file is not in expected format!");
 
             var codeSnippetFormatted = match.Groups[1].Value

--- a/TestsCommon/LanguageTestData.cs
+++ b/TestsCommon/LanguageTestData.cs
@@ -23,5 +23,11 @@ namespace TestsCommon
         string DllPath,
         string JavaCoreVersion,
         string JavaLibVersion,
-        string JavaPreviewLibPath);
+        string JavaPreviewLibPath,
+        string TestName,
+        string Owner);
+
+    public record ExecutionTestData(
+        LanguageTestData LanguageTestData,
+        string FileContent);
 }

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -471,7 +471,7 @@ namespace TestsCommon
         {
             return from testData in GetLanguageTestData(runSettings)
                    where !(testData.IsKnownIssue ^ runSettings.KnownFailuresRequested) // select known issues if requested
-                   select new TestCaseData(testData).SetName(testData.TestName).SetProperty("Owner", testData.TestName);
+                   select new TestCaseData(testData).SetName(testData.TestName).SetProperty("Owner", testData.Owner);
         }
 
         /// <summary>
@@ -490,7 +490,7 @@ namespace TestsCommon
                    let executionTestData = new ExecutionTestData(testData, fileContent)
                    where !testData.IsKnownIssue // select compiling tests
                    && fileContent.Contains("GetAsync()") // select only the get tests
-                   select new TestCaseData(executionTestData).SetName(testData.TestName).SetProperty("Owner", testData.TestName);
+                   select new TestCaseData(executionTestData).SetName(testData.TestName).SetProperty("Owner", testData.Owner);
         }
 
         private static IEnumerable<LanguageTestData> GetLanguageTestData(RunSettings runSettings)

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -469,6 +469,32 @@ namespace TestsCommon
         /// </returns>
         public static IEnumerable<TestCaseData> GetTestCaseData(RunSettings runSettings)
         {
+            return from testData in GetLanguageTestData(runSettings)
+                   where !(testData.IsKnownIssue ^ runSettings.KnownFailuresRequested) // select known issues if requested
+                   select new TestCaseData(testData).SetName(testData.TestName).SetProperty("Owner", testData.TestName);
+        }
+
+        /// <summary>
+        /// For each snippet file creates a test case which takes the file name and version as reference
+        /// Test case name is also set to to unique name based on file name
+        /// </summary>
+        /// <param name="runSettings">Test run settings</param>
+        /// <returns>
+        /// TestCaseData to be consumed by C# execution tests
+        /// </returns>
+        public static IEnumerable<TestCaseData> GetExecutionTestData(RunSettings runSettings)
+        {
+            return from testData in GetLanguageTestData(runSettings)
+                   let fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(testData.Version, runSettings.Language), testData.FileName)
+                   let fileContent = File.ReadAllText(fullPath)
+                   let executionTestData = new ExecutionTestData(testData, fileContent)
+                   where !testData.IsKnownIssue // select compiling tests
+                   && fileContent.Contains("GetAsync()") // select only the get tests
+                   select new TestCaseData(executionTestData).SetName(testData.TestName).SetProperty("Owner", testData.TestName);
+        }
+
+        private static IEnumerable<LanguageTestData> GetLanguageTestData(RunSettings runSettings)
+        {
             if (runSettings == null)
             {
                 throw new ArgumentNullException(nameof(runSettings));
@@ -489,18 +515,18 @@ namespace TestsCommon
                    let knownIssue = isKnownIssue ? knownIssues[knownIssueLookupKey] : null
                    let knownIssueMessage = knownIssue?.Message ?? string.Empty
                    let owner = knownIssue?.Owner ?? string.Empty
-                   let testCaseData = new LanguageTestData(
-                       version,
-                       isKnownIssue,
-                       knownIssueMessage,
-                       docsLink,
-                       fileName,
-                       runSettings.DllPath,
-                       runSettings.JavaCoreVersion,
-                       runSettings.JavaLibVersion,
-                       runSettings.JavaPreviewLibPath)
-                   where !(isKnownIssue ^ runSettings.KnownFailuresRequested) // select known issues if requested
-                   select new TestCaseData(testCaseData).SetName(testName).SetProperty("Owner", owner);
+                   select new LanguageTestData(
+                           version,
+                           isKnownIssue,
+                           knownIssueMessage,
+                           docsLink,
+                           fileName,
+                           runSettings.DllPath,
+                           runSettings.JavaCoreVersion,
+                           runSettings.JavaLibVersion,
+                           runSettings.JavaPreviewLibPath,
+                           testName,
+                           owner);
         }
     }
 }

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -1,0 +1,7 @@
+steps:
+  - pwsh: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1 -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret)'
+    workingDirectory: 'msgraph-sdk-raptor'
+    displayName: 'Transform app settings with the secrets'
+
+  - pwsh: |
+    Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -4,4 +4,4 @@ steps:
     displayName: 'Transform app settings with the secrets'
 
   - pwsh: |
-    Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json
+      Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -5,3 +5,4 @@ steps:
 
   - pwsh: |
       Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json
+    displayName: 'Show app settings'

--- a/azure-pipelines/compile-run-tests-template.yml
+++ b/azure-pipelines/compile-run-tests-template.yml
@@ -1,6 +1,7 @@
 parameters:
   projectFileName: JavaV1Tests
   runName: 'V1 Java Snippet Compilation Tests'
+  testType: 'Compilation'
 steps:
 - template: common-templates/use-dotnet-sdk.yml
 
@@ -17,7 +18,7 @@ steps:
     projects: '**/${{ parameters.projectFileName }}.csproj'
     arguments: '--configuration $(buildConfiguration) --logger trx --results-directory $(Agent.TempDirectory) --settings $(Build.SourcesDirectory)/msgraph-sdk-raptor/${{ parameters.projectFileName}}/Test.runsettings'
     publishTestResults: false
-  displayName: '${{ parameters.projectFileName }} Compilation Tests'
+  displayName: '${{ parameters.projectFileName }} ${{ parameters.testType }} Tests'
   continueOnError: true
 
 - task: PublishTestResults@2

--- a/azure-pipelines/csharp-beta-execution-tests.yml
+++ b/azure-pipelines/csharp-beta-execution-tests.yml
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+name: 'Beta C# Snippet Execution Tests'
+
+resources:
+ repositories:
+   - repository: microsoft-graph-docs
+     type: github
+     endpoint: microsoftgraph
+     name: microsoftgraph/microsoft-graph-docs
+     ref: master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- template: common-templates/checkout.yml
+- template: common-templates/transform-app-settings.yml
+- template: compile-run-tests-template.yml
+  parameters:
+    projectFileName: CsharpBetaExecutionTests
+    runName: 'Beta C# Snippet Execution Tests $(testRunTitle)'
+    testType: 'Execution'

--- a/azure-pipelines/csharp-v1-execution-tests.yml
+++ b/azure-pipelines/csharp-v1-execution-tests.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 trigger: none # disable triggers based on commits.
-name: 'V1 C# Snippet Compilation Tests'
+name: 'V1 C# Snippet Execution Tests'
 
 resources:
  repositories:

--- a/azure-pipelines/csharp-v1-execution-tests.yml
+++ b/azure-pipelines/csharp-v1-execution-tests.yml
@@ -20,3 +20,8 @@ variables:
 steps:
 - template: common-templates/checkout.yml
 - template: common-templates/transform-app-settings.yml
+- template: compile-run-tests-template.yml
+  parameters:
+    projectFileName: CsharpV1ExecutionTests
+    runName: 'V1 C# Snippet Execution Tests $(testRunTitle)'
+    testType: 'Execution'

--- a/azure-pipelines/csharp-v1-execution-tests.yml
+++ b/azure-pipelines/csharp-v1-execution-tests.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+name: 'V1 C# Snippet Compilation Tests'
+
+resources:
+ repositories:
+   - repository: microsoft-graph-docs
+     type: github
+     endpoint: microsoftgraph
+     name: microsoftgraph/microsoft-graph-docs
+     ref: master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- template: common-templates/checkout.yml
+- template: common-templates/transform-app-settings.yml

--- a/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
@@ -5,5 +5,6 @@ namespace MsGraphSDKSnippetsCompiler
     public interface IMicrosoftGraphSnippetsCompiler
     {
         CompilationResultsModel CompileSnippet(string codeSnippet, Versions version);
+        ExecutionResultsModel ExecuteSnippet(string codeSnippet, Versions version);
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
@@ -1,10 +1,11 @@
-﻿using MsGraphSDKSnippetsCompiler.Models;
+﻿using System.Threading.Tasks;
+using MsGraphSDKSnippetsCompiler.Models;
 
 namespace MsGraphSDKSnippetsCompiler
 {
     public interface IMicrosoftGraphSnippetsCompiler
     {
         CompilationResultsModel CompileSnippet(string codeSnippet, Versions version);
-        ExecutionResultsModel ExecuteSnippet(string codeSnippet, Versions version);
+        Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version);
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -65,7 +65,7 @@ namespace MsGraphSDKSnippetsCompiler
             };
 
             //Use the right Microsoft Graph Version
-            if (_dllPath != null && _dllPath != string.Empty)
+            if (!string.IsNullOrEmpty(_dllPath))
             {
                 if (!System.IO.File.Exists(_dllPath))
                 {
@@ -87,7 +87,8 @@ namespace MsGraphSDKSnippetsCompiler
                assemblyName,
                syntaxTrees: new[] { syntaxTree },
                references: metadataReferences,
-               options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+               options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                                .WithOptimizationLevel(OptimizationLevel.Release));
 
             var (emitResult, assembly) = GetEmitResult(compilation);
             CompilationResultsModel results = GetCompilationResults(emitResult);

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -29,6 +29,13 @@ namespace MsGraphSDKSnippetsCompiler
         private readonly string _markdownFileName;
         private readonly string _dllPath;
 
+        /// for hiding bearer token
+        private const string AuthHeaderPattern = "Authorization: Bearer .*";
+        private const string AuthHeaderReplacement = "Authorization: Bearer <token>";
+        private static readonly Regex AuthHeaderRegex = new Regex(AuthHeaderPattern, RegexOptions.Compiled);
+
+        private const string DefaultAuthScope = "https://graph.microsoft.com/.default";
+
         public MicrosoftGraphCSharpCompiler(string markdownFileName, string dllPath)
         {
             _markdownFileName = markdownFileName;
@@ -130,7 +137,7 @@ namespace MsGraphSDKSnippetsCompiler
                         .WithTenantId(tenantId)
                         .WithClientSecret(clientSecret)
                         .Build();
-                    authProvider = new ClientCredentialProvider(confidentialClientApp, "https://graph.microsoft.com/.default");
+                    authProvider = new ClientCredentialProvider(confidentialClientApp, DefaultAuthScope);
 
                     var task = instance.Main(authProvider) as Task;
                     task.Wait();
@@ -141,7 +148,7 @@ namespace MsGraphSDKSnippetsCompiler
                     exceptionMessage = ae.InnerException.Message + Environment.NewLine + ae.InnerException.InnerException.Message;
                     if (!bool.Parse(AppSettings.Config().GetSection("IsLocalRun").Value))
                     {
-                        exceptionMessage = Regex.Replace(exceptionMessage, "Authorization: Bearer .*", "Authorization: Bearer <token>");
+                        exceptionMessage = AuthHeaderRegex.Replace(exceptionMessage, AuthHeaderReplacement);
                     }
                 }
             }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -114,7 +114,7 @@ namespace MsGraphSDKSnippetsCompiler
         /// </summary>
         /// <param name="codeSnippet">The code snippet to be compiled.</param>
         /// <returns>CompilationResultsModel</returns>
-        public ExecutionResultsModel ExecuteSnippet(string codeSnippet, Versions version)
+        public async Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version)
         {
             var (compilationResult, assembly) = CompileSnippetAndGetAssembly(codeSnippet, version);
 
@@ -139,13 +139,12 @@ namespace MsGraphSDKSnippetsCompiler
                         .Build();
                     authProvider = new ClientCredentialProvider(confidentialClientApp, DefaultAuthScope);
 
-                    var task = instance.Main(authProvider) as Task;
-                    task.Wait();
+                    await (instance.Main(authProvider) as Task);
                     success = true;
                 }
-                catch (AggregateException ae)
+                catch (Exception e)
                 {
-                    exceptionMessage = ae.InnerException.Message + Environment.NewLine + ae.InnerException.InnerException.Message;
+                    exceptionMessage = e.Message + Environment.NewLine + e.InnerException.Message;
                     if (!bool.Parse(AppSettings.Config().GetSection("IsLocalRun").Value))
                     {
                         exceptionMessage = AuthHeaderRegex.Replace(exceptionMessage, AuthHeaderReplacement);

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -120,8 +120,6 @@ namespace MsGraphSDKSnippetsCompiler
                     var clientId = config.GetSection("ClientID").Value;
 
                     dynamic instance = assembly.CreateInstance("GraphSDKTest");
-
-                    var me = true;
                     IAuthenticationProvider authProvider;
 
                     var tenantId = config.GetSection("TenantID").Value;

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -17,6 +17,7 @@ using System.Net.Http;
 using System.Runtime.Loader;
 using System.Threading.Tasks;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace MsGraphSDKSnippetsCompiler
 {
@@ -139,6 +140,10 @@ namespace MsGraphSDKSnippetsCompiler
                 catch (AggregateException ae)
                 {
                     exceptionMessage = ae.InnerException.Message + Environment.NewLine + ae.InnerException.InnerException.Message;
+                    if (!bool.Parse(AppSettings.Config().GetSection("IsLocalRun").Value))
+                    {
+                        exceptionMessage = Regex.Replace(exceptionMessage, "Authorization: Bearer .*", "Authorization: Bearer <token>");
+                    }
                 }
             }
 

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
@@ -162,6 +162,11 @@ application {
             );
         }
 
+        public ExecutionResultsModel ExecuteSnippet(string codeSnippet, Versions version)
+        {
+            throw new NotImplementedException("not yet implemented for Java");
+        }
+
         private const string errorsSuffix = "FAILURE";
         private static readonly Regex notesFilterRegex = new Regex(@"^Note:\s[^\n]*$", RegexOptions.Compiled | RegexOptions.Multiline);
         private static readonly Regex doubleLineReturnCleanupRegex = new Regex(@"\n{2,}", RegexOptions.Compiled | RegexOptions.Multiline);

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
@@ -162,7 +162,7 @@ application {
             );
         }
 
-        public ExecutionResultsModel ExecuteSnippet(string codeSnippet, Versions version)
+        public async Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version)
         {
             throw new NotImplementedException("not yet implemented for Java");
         }

--- a/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
@@ -4,4 +4,6 @@ using System.Collections.Generic;
 namespace MsGraphSDKSnippetsCompiler.Models
 {
     public record CompilationResultsModel(bool IsSuccess, IEnumerable<Diagnostic> Diagnostics, string MarkdownFileName);
+    public record ExecutionResultsModel(CompilationResultsModel CompilationResult, bool Success, string ExceptionMessage = null);
+
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
@@ -5,5 +5,4 @@ namespace MsGraphSDKSnippetsCompiler.Models
 {
     public record CompilationResultsModel(bool IsSuccess, IEnumerable<Diagnostic> Diagnostics, string MarkdownFileName);
     public record ExecutionResultsModel(CompilationResultsModel CompilationResult, bool Success, string ExceptionMessage = null);
-
 }

--- a/msgraph-sdk-raptor-compiler-lib/appsettings.json
+++ b/msgraph-sdk-raptor-compiler-lib/appsettings.json
@@ -1,5 +1,8 @@
 {
   "IsLocalRun": false,
   "GenerateLinqPadOutputInLocalRun": true,
-  "DocsRepoCheckoutDirectory": "C:/github"
+  "DocsRepoCheckoutDirectory": "C:/github",
+  "TenantID": "",
+  "ClientID": "",
+  "ClientSecret": ""
 }

--- a/msgraph-sdk-raptor.sln
+++ b/msgraph-sdk-raptor.sln
@@ -25,10 +25,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JavaV1KnownFailureTests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JavaBetaKnownFailureTests", "JavaBetaKnownFailureTests\JavaBetaKnownFailureTests.csproj", "{B96E4BBA-697D-4B7D-80B5-4DBE2D0A4757}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsharpV1ExecutionTests", "CsharpV1ExecutionTests\CsharpV1ExecutionTests.csproj", "{B9785BF3-EAC8-4881-B428-D6868BB3AD9A}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C5324E4B-456A-46FE-99B4-63FEA5A026B9}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpBetaExecutionTests", "CsharpBetaExecutionTests\CsharpBetaExecutionTests.csproj", "{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -80,6 +84,14 @@ Global
 		{B96E4BBA-697D-4B7D-80B5-4DBE2D0A4757}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B96E4BBA-697D-4B7D-80B5-4DBE2D0A4757}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B96E4BBA-697D-4B7D-80B5-4DBE2D0A4757}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9785BF3-EAC8-4881-B428-D6868BB3AD9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9785BF3-EAC8-4881-B428-D6868BB3AD9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9785BF3-EAC8-4881-B428-D6868BB3AD9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9785BF3-EAC8-4881-B428-D6868BB3AD9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/scripts/transformAppSettings.ps1
+++ b/scripts/transformAppSettings.ps1
@@ -1,0 +1,23 @@
+param(
+    [bool]$IsLocalRun = $false,
+    [bool]$GenerateLinqPadOutputInLocalRun = $false,
+    [string]$DocsRepoCheckoutDirectory = "C:/github",
+    [string]$TenantID,
+    [string]$ClientID,
+    [string]$ClientSecret
+)
+
+$json = @{
+    TenantID = $TenantID;
+    ClientID = $ClientID;
+    ClientSecret = $ClientSecret;
+    IsLocalRun = $IsLocalRun;
+    GenerateLinqPadOutputInLocalRun = $GenerateLinqPadOutputInLocalRun;
+    DocsRepoCheckoutDirectory = $DocsRepoCheckoutDirectory;
+}
+
+$repoRoot = (Get-Item $MyInvocation.MyCommand.Source).Directory.Parent.FullName
+$libDir = Join-Path $repoRoot "msgraph-sdk-raptor-compiler-lib"
+$appSettings = Join-Path $libDir "appsettings.json"
+
+($json | ConvertTo-Json) > $appSettings

--- a/scripts/transformAppSettings.ps1
+++ b/scripts/transformAppSettings.ps1
@@ -2,7 +2,7 @@ param(
     [bool]$IsLocalRun = $false,
     [bool]$GenerateLinqPadOutputInLocalRun = $false,
     [string]$DocsRepoCheckoutDirectory = "C:/github",
-   [Parameter(Mandatory=$true)][string]$TenantID,
+    [Parameter(Mandatory=$true)][string]$TenantID,
     [Parameter(Mandatory=$true)][string]$ClientID,
     [Parameter(Mandatory=$true)][string]$ClientSecret
 )


### PR DESCRIPTION
- renamed test run name for compilation tests from `Run` to `Compile`
- introduced a new test type called `Execute`
- created two new projects that call `Execute` (C# V1 and Beta)
- `Execute` test does the following:
  - changes snippet decoration to extract request url for logging purposes
  - creates an Assembly from `Compile` phase
  - creates a ClientCredentialProvider using secrets from `appsettings.json`
  - calls the main method in the generated Assembly using the auth provider
  - if no exception is thrown, the test passes
  - if an exception is thrown, it is logged with the compiled snippet
- added two new pipelines for executing these tests:
  -  [V1 C# Snippet Execution Tests](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=38054&view=ms.vss-test-web.build-test-results-tab)
  -  [Beta C# Snippet Execution Tests](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=38050&view=ms.vss-test-web.build-test-results-tab)
  - Pipelines use secret variables in Azure DevOps and they are fed in to `appsettings.json` file using `scripts/transformAppSettings.ps1` script.
- Test data selection logic ignores known issues of compilation as it doesn't make sense to run those tests for execution (i.e. compilation is a prerequisite for execution)
- added @finsharp as code owner

Note: This PR doesn't address the delegated permissions scenario, it only uses application permissions. Delegated permissions will be addressed with a separate PR.
Fixes #143
Fixes #146 