### PR TITLE
Add scheduled runs for PROD

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@
 # All files
 [*]
 indent_style = space
+trim_trailing_whitespace = true
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4

--- a/azure-pipelines/beta-end-to-end.yml
+++ b/azure-pipelines/beta-end-to-end.yml
@@ -12,36 +12,36 @@ schedules:
   always: true
 
 resources:
- repositories:
-   - repository: microsoft-graph-docs
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/microsoft-graph-docs
-     ref: master
-   - repository: apidoctor
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/apidoctor
-     ref: master
-   - repository: microsoft-graph-explorer-api
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/microsoft-graph-explorer-api
-     ref: dev
-   - repository: MSGraph-SDK-Code-Generator
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/MSGraph-SDK-Code-Generator
-     ref: master
-   - repository: msgraph-sdk-dotnet
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/msgraph-sdk-dotnet
-     ref: dev
-   - repository: msgraph-metadata
-     type: github
-     endpoint: microsoftgraph
-     name: microsoftgraph/msgraph-metadata
+  repositories:
+    - repository: microsoft-graph-docs
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/microsoft-graph-docs
+      ref: master
+    - repository: apidoctor
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/apidoctor
+      ref: master
+    - repository: microsoft-graph-explorer-api
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/microsoft-graph-explorer-api
+      ref: dev
+    - repository: MSGraph-SDK-Code-Generator
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/MSGraph-SDK-Code-Generator
+      ref: master
+    - repository: msgraph-sdk-dotnet
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/msgraph-sdk-dotnet
+      ref: dev
+    - repository: msgraph-metadata
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/msgraph-metadata
 
 parameters:
 - name: shouldRunKnownFailures
@@ -64,11 +64,6 @@ variables:
       metadataVersion: 'beta'
 
 steps:
-  - template: e2e-templates/checkouts.yml
-  - template: common-templates/use-dotnet-sdk.yml
-  - template: e2e-templates/sdk-generation.yml
-  - template: e2e-templates/snippet-generation.yml
-  - template: e2e-templates/regular-tests.yml
-  - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:
-    - template: e2e-templates/known-failure-tests.yml
-  - template: e2e-templates/generate-type-summary.yml
+  - template: e2e-templates/steps.yml
+    parameters:
+      shouldRunKnownFailures: ${{ parameters.shouldRunKnownFailures }}

--- a/azure-pipelines/e2e-templates/steps.yml
+++ b/azure-pipelines/e2e-templates/steps.yml
@@ -1,0 +1,14 @@
+parameters:
+  - name: shouldRunKnownFailures
+    type: boolean
+    default: true
+
+steps:
+  - template: checkouts.yml
+  - template: ../common-templates/use-dotnet-sdk.yml
+  - template: sdk-generation.yml
+  - template: snippet-generation.yml
+  - template: regular-tests.yml
+  - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:
+    - template: known-failure-tests.yml
+  - template: generate-type-summary.yml

--- a/azure-pipelines/java-beta-compile-tests-known-issues.yml
+++ b/azure-pipelines/java-beta-compile-tests-known-issues.yml
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 trigger: none # disable triggers based on commits.
+pr:
+  branches:
+    include:
+      - dev
+      - main
+
 name: 'Beta Java Snippet Compilation Tests - Known Issues'
 
 resources:

--- a/azure-pipelines/java-beta-compile-tests.yml
+++ b/azure-pipelines/java-beta-compile-tests.yml
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 trigger: none # disable triggers based on commits.
+pr:
+  branches:
+    include:
+      - dev
+      - main
+
 name: 'Beta Java Snippet Compilation Tests'
 
 resources:

--- a/azure-pipelines/java-preview-compile-tests-known-issues.yml
+++ b/azure-pipelines/java-preview-compile-tests-known-issues.yml
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 trigger: none # disable triggers based on commits.
+pr:
+  branches:
+    include:
+      - dev
+      - main
+
 name: 'Preview Java Snippet Compilation Tests - Known Issues'
 
 resources:

--- a/azure-pipelines/java-preview-compile-tests.yml
+++ b/azure-pipelines/java-preview-compile-tests.yml
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 trigger: none # disable triggers based on commits.
+pr:
+  branches:
+    include:
+      - dev
+      - main
+
 name: 'Preview Java Snippet Compilation Tests'
 
 resources:

--- a/azure-pipelines/java-v1-compile-tests-known-issues.yml
+++ b/azure-pipelines/java-v1-compile-tests-known-issues.yml
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 trigger: none # disable triggers based on commits.
+pr:
+  branches:
+    include:
+      - dev
+      - main
+
 name: 'V1 Java Snippet Compilation Tests - Known Issues'
 
 resources:

--- a/azure-pipelines/java-v1-compile-tests.yml
+++ b/azure-pipelines/java-v1-compile-tests.yml
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 trigger: none # disable triggers based on commits.
+pr:
+  branches:
+    include:
+      - dev
+      - main
+
 name: 'V1 Java Snippet Compilation Tests'
 
 resources:

--- a/azure-pipelines/prod-beta-end-to-end.yml
+++ b/azure-pipelines/prod-beta-end-to-end.yml
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-# contains an end to end validation pipeline using C# compilation tests for staging V1 metadata
+# contains an end to end validation pipeline using C# compilation tests for PROD beta metadata
 
 trigger: none
 pr: none
 schedules:
 - cron: "0 12 * * *" # everyday at noon
-  displayName: 'Daily Staging V1 Validation Pipeline'
+  displayName: 'Daily PROD Beta Validation Pipeline'
   branches:
     include:
     - dev
@@ -32,7 +32,7 @@ resources:
       type: github
       endpoint: microsoftgraph
       name: microsoftgraph/MSGraph-SDK-Code-Generator
-      ref: master
+      ref: dev
     - repository: msgraph-sdk-dotnet
       type: github
       endpoint: microsoftgraph
@@ -43,27 +43,14 @@ resources:
       endpoint: microsoftgraph
       name: microsoftgraph/msgraph-metadata
 
-parameters:
-- name: shouldRunKnownFailures
-  displayName: 'Should we run known failure tests?'
-  type: boolean
-  default: true
-
-- name: metadataURL
-  displayName: 'URL for metadata for which SDK generation will happen:'
-  type: string
-  default: 'https://graph.microsoft.com/stagingv1.0/$metadata'
-
 pool:
   vmImage: 'ubuntu-latest'
 
 variables:
   - template: e2e-templates/variables.yml
     parameters:
-      metadataURL: ${{ parameters.metadataURL }}
-      metadataVersion: 'v1.0'
+      metadataURL: 'https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/beta_metadata.xml'
+      metadataVersion: 'beta'
 
 steps:
   - template: e2e-templates/steps.yml
-    parameters:
-      shouldRunKnownFailures: ${{ parameters.shouldRunKnownFailures }}

--- a/azure-pipelines/prod-v1-end-to-end.yml
+++ b/azure-pipelines/prod-v1-end-to-end.yml
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-# contains an end to end validation pipeline using C# compilation tests for staging V1 metadata
+# contains an end to end validation pipeline using C# compilation tests for PROD V1 metadata
 
 trigger: none
 pr: none
 schedules:
 - cron: "0 12 * * *" # everyday at noon
-  displayName: 'Daily Staging V1 Validation Pipeline'
+  displayName: 'Daily PROD V1 Validation Pipeline'
   branches:
     include:
     - dev
@@ -32,7 +32,7 @@ resources:
       type: github
       endpoint: microsoftgraph
       name: microsoftgraph/MSGraph-SDK-Code-Generator
-      ref: master
+      ref: dev
     - repository: msgraph-sdk-dotnet
       type: github
       endpoint: microsoftgraph
@@ -43,27 +43,14 @@ resources:
       endpoint: microsoftgraph
       name: microsoftgraph/msgraph-metadata
 
-parameters:
-- name: shouldRunKnownFailures
-  displayName: 'Should we run known failure tests?'
-  type: boolean
-  default: true
-
-- name: metadataURL
-  displayName: 'URL for metadata for which SDK generation will happen:'
-  type: string
-  default: 'https://graph.microsoft.com/stagingv1.0/$metadata'
-
 pool:
   vmImage: 'ubuntu-latest'
 
 variables:
   - template: e2e-templates/variables.yml
     parameters:
-      metadataURL: ${{ parameters.metadataURL }}
+      metadataURL: 'https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/v1.0_metadata.xml'
       metadataVersion: 'v1.0'
 
 steps:
   - template: e2e-templates/steps.yml
-    parameters:
-      shouldRunKnownFailures: ${{ parameters.shouldRunKnownFailures }}


### PR DESCRIPTION
- Moves the changes from #159 to `dev`
- Adds .editorconfig rule to remove trailing white spaces
  - Commit: https://github.com/microsoftgraph/msgraph-sdk-raptor/commit/2a44b6cff1746ee27d4da006dd58aa183a9465ef
- Enables Java tests only if the target branches are `dev` or `main`.
  - Fixes #160
  - Commit: https://github.com/microsoftgraph/msgraph-sdk-raptor/commit/cb99a525841962b180b4c5fe4f299e575f099777
