### PR TITLE
Infrastructure for fetching delegated permissions

### DIFF
--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -118,7 +118,7 @@ public class GraphSDKTest
 
             // Compile Code
             var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData.FileName, testData.DllPath);
-            var executionResultsModel = await microsoftGraphCSharpCompiler.ExecuteSnippet(codeToCompile, testData.Version);
+            var executionResultsModel = await microsoftGraphCSharpCompiler.ExecuteSnippet(codeToCompile, testData.Version).ConfigureAwait(false);
             var compilationOutputMessage = new CompilationOutputMessage(
                 executionResultsModel.CompilationResult,
                 codeToCompile,

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -40,6 +40,11 @@ public class GraphSDKTest
         //insert-code-here
         #endregion
     }
+
+    public HttpRequestMessage GetRequestMessage(IAuthenticationProvider authProvider)
+    {
+        //return-request-message
+    }
 }";
 
         /// <summary>
@@ -177,6 +182,32 @@ public class GraphSDKTest
             return codeToCompile;
         }
 
+        /// <summary>
+        /// Modifies snippet to return HttpRequestMessage object so that we can extract the generated URL
+        /// </summary>
+        /// <param name="codeSnippet">code snippet</param>
+        /// <returns>Code snippet that returns an HttpRequstMessage</returns>
+        private static string ReturnHttpRequestMessage(string codeSnippet)
+        {
+            string resultVariable = null;
+            try
+            {
+                resultVariable = ResultVariableRegex.Match(codeSnippet).Groups[1].Value;
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("result variable is not found!" + Environment.NewLine + e.Message);
+            }
+
+            codeSnippet = codeSnippet.Replace("await graphClient", "graphClient")
+                .Replace(".GetAsync();", $@".GetHttpRequestMessage();
+
+        return {resultVariable};");
+
+            return codeSnippet;
+        }
+
+
         private static (string, string) GetCodeToCompile(string fileContent, Func<string, string> postTransform = null)
         {
             var match = CSharpSnippetRegex.Match(fileContent);
@@ -189,6 +220,10 @@ public class GraphSDKTest
                 .Replace("\r\n\r\n\r\n", "\r\n\r\n");       // do not have two consecutive empty lines
 
             var codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(codeSnippetFormatted, SDKShellTemplate);
+
+            // have another tranformation to insert GetRequestMessage method
+            codeToCompile = codeToCompile.Replace("//return-request-message", "//insert-code-here");
+            codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(ReturnHttpRequestMessage(codeSnippetFormatted), codeToCompile);
 
             if (postTransform == null)
             {

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -186,7 +186,8 @@ public class GraphSDKTest
         /// Modifies snippet to return HttpRequestMessage object so that we can extract the generated URL
         /// </summary>
         /// <param name="codeSnippet">code snippet</param>
-        /// <returns>Code snippet that returns an HttpRequstMessage</returns>
+        /// <returns>Code snippet that returns an HttpRequestMessage</returns>
+
         private static string ReturnHttpRequestMessage(string codeSnippet)
         {
             string resultVariable = null;

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -1,5 +1,5 @@
 steps:
-  - pwsh: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1 -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret)'
+  - pwsh: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1 -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret) -Authority $(Authority) -Username $(Username) -Password $(Password)'
     workingDirectory: 'msgraph-sdk-raptor'
     displayName: 'Transform app settings with the secrets'
 

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -214,6 +214,8 @@ namespace MsGraphSDKSnippetsCompiler
             var app = PublicClientApplicationBuilder.Create(clientId).WithAuthority(authority).Build();
 
             var securePassword = new SecureString();
+
+            // convert plain password into a secure string.
             password.ToList().ForEach(c => securePassword.AppendChar(c));
 
             try
@@ -223,8 +225,8 @@ namespace MsGraphSDKSnippetsCompiler
             }
             catch (Exception e)
             {
-                var PrefixLength = "https://graph.microsoft.com/".Length;
-                var scopeShortNames = scopes.Select(s => s[PrefixLength..]).ToArray();
+                var prefixLength = "https://graph.microsoft.com/".Length;
+                var scopeShortNames = scopes.Select(s => s[prefixLength..]).ToArray();
                 throw new AggregateException(new AggregateException("scopes: " + string.Join(", ", scopeShortNames), e));
             }
         }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -18,6 +18,9 @@ using System.Runtime.Loader;
 using System.Threading.Tasks;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Security;
+using System.Net;
+using System.Text.Json;
 
 namespace MsGraphSDKSnippetsCompiler
 {
@@ -124,20 +127,39 @@ namespace MsGraphSDKSnippetsCompiler
             {
                 try
                 {
+                    var requiresDelegatedPermissions = RequiresDelegatedPermissions(codeSnippet);
                     var config = AppSettings.Config();
                     var clientId = config.GetSection("ClientID").Value;
 
                     dynamic instance = assembly.CreateInstance("GraphSDKTest");
                     IAuthenticationProvider authProvider;
 
-                    var tenantId = config.GetSection("TenantID").Value;
-                    var clientSecret = config.GetSection("ClientSecret").Value;
-                    IConfidentialClientApplication confidentialClientApp = ConfidentialClientApplicationBuilder
-                        .Create(clientId)
-                        .WithTenantId(tenantId)
-                        .WithClientSecret(clientSecret)
-                        .Build();
-                    authProvider = new ClientCredentialProvider(confidentialClientApp, DefaultAuthScope);
+                    if (requiresDelegatedPermissions)
+                    {
+                        // delegated permissions
+                        HttpRequestMessage httpRequestMessage = instance.GetRequestMessage(null);
+                        var scopes = GetScopes(httpRequestMessage);
+                        var authority = config.GetSection("Authority").Value;
+                        var username = config.GetSection("Username").Value;
+                        var password = config.GetSection("Password").Value;
+                        var token = GetATokenForGraph(clientId, authority, username, password, scopes).ConfigureAwait(false).GetAwaiter().GetResult();
+                        authProvider = new DelegateAuthenticationProvider(async request =>
+                        {
+                            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+                        });
+                    }
+                    else
+                    {
+                        // application permissions
+                        var tenantId = config.GetSection("TenantID").Value;
+                        var clientSecret = config.GetSection("ClientSecret").Value;
+                        IConfidentialClientApplication confidentialClientApp = ConfidentialClientApplicationBuilder
+                            .Create(clientId)
+                            .WithTenantId(tenantId)
+                            .WithClientSecret(clientSecret)
+                            .Build();
+                        authProvider = new ClientCredentialProvider(confidentialClientApp, DefaultAuthScope);
+                    }
 
                     await (instance.Main(authProvider) as Task);
                     success = true;
@@ -154,6 +176,59 @@ namespace MsGraphSDKSnippetsCompiler
 
             return new ExecutionResultsModel(compilationResult, success, exceptionMessage);
         }
+
+        /// <summary>
+        /// Calls DevX Api to get required premissions
+        /// </summary>
+        /// <param name="httpRequestMessage"></param>
+        /// <returns></returns>
+        static string[] GetScopes(HttpRequestMessage httpRequestMessage)
+        {
+            var path = httpRequestMessage.RequestUri.LocalPath;
+            var versionSegmentLength = "/v1.0".Length;
+            if (path.StartsWith("/v1.0") || path.StartsWith("/beta"))
+            {
+                path = path[versionSegmentLength..];
+            }
+
+            var webClient = new WebClient();
+            webClient.Headers.Add("Accept-Language", "en-US");
+            var url = $"https://graphexplorerapi.azurewebsites.net/permissions?requesturl={path}&method={httpRequestMessage.Method}";
+            var responseString = webClient.DownloadString(url);
+            var json = JsonSerializer.Deserialize<Scope[]>(responseString);
+
+            return json.ToList().Select(x => "https://graph.microsoft.com/" + x.value).ToArray();
+        }
+
+        /// <summary>
+        /// Acquires a token for given context
+        /// </summary>
+        /// <param name="clientId">Client ID of the application</param>
+        /// <param name="authority">token authority, such as: https://login.microsoftonline.com/contoso.onmicrosoft.com</param>
+        /// <param name="username">username of the user for which the token is requested</param>
+        /// <param name="password">password of the user for which the token is requested</param>
+        /// <param name="scopes">requested scopes in the token</param>
+        /// <returns>token for the given context</returns>
+        static async Task<string> GetATokenForGraph(string clientId, string authority, string username, string password, string[] scopes)
+        {
+            var app = PublicClientApplicationBuilder.Create(clientId).WithAuthority(authority).Build();
+
+            var securePassword = new SecureString();
+            password.ToList().ForEach(c => securePassword.AppendChar(c));
+
+            try
+            {
+                var result = await app.AcquireTokenByUsernamePassword(scopes, username, securePassword).ExecuteAsync();
+                return result.AccessToken;
+            }
+            catch (Exception e)
+            {
+                var PrefixLength = "https://graph.microsoft.com/".Length;
+                var scopeShortNames = scopes.Select(s => s[PrefixLength..]).ToArray();
+                throw new AggregateException(new AggregateException("scopes: " + string.Join(", ", scopeShortNames), e));
+            }
+        }
+
 
         /// <summary>
         ///     Gets the result of the Compilation.Emit method.
@@ -186,6 +261,19 @@ namespace MsGraphSDKSnippetsCompiler
                 : emitResult.Diagnostics.Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error);
 
             return new CompilationResultsModel(emitResult.Success, failures, _markdownFileName);
+        }
+
+        /// <summary>
+        /// Determines whether code snippet requires delegated permissions (as opposed to application permissions)
+        /// </summary>
+        /// <param name="codeSnippet">code snippet</param>
+        /// <returns>true if the snippet requires delegated permissions</returns>
+        private static bool RequiresDelegatedPermissions(string codeSnippet)
+        {
+            // TODO: https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/164
+            return codeSnippet.Contains("graphClient.Me") ||
+                codeSnippet.Contains("graphClient.Education.Me") ||
+                codeSnippet.Contains("graphClient.Users[\"");
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
@@ -1,0 +1,11 @@
+﻿namespace MsGraphSDKSnippetsCompiler.Models
+{
+    /// <summary>
+    /// Model from https://github.com/microsoftgraph/microsoft-graph-explorer-api/blob/dev/GraphExplorerPermissionsService/Models/ScopeInformation.cs
+    /// </summary>
+    public class Scope
+    {
+        public string value { get; set; }
+        public bool isAdmin { get; set; }
+    }
+}

--- a/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
@@ -3,9 +3,5 @@
     /// <summary>
     /// Model from https://github.com/microsoftgraph/microsoft-graph-explorer-api/blob/dev/GraphExplorerPermissionsService/Models/ScopeInformation.cs
     /// </summary>
-    public class Scope
-    {
-        public string value { get; set; }
-        public bool isAdmin { get; set; }
-    }
+    public record Scope (string value, bool isAdmin);
 }

--- a/msgraph-sdk-raptor-compiler-lib/appsettings.json
+++ b/msgraph-sdk-raptor-compiler-lib/appsettings.json
@@ -1,7 +1,7 @@
 {
   "IsLocalRun": false,
   "GenerateLinqPadOutputInLocalRun": true,
-  "DocsRepoCheckoutDirectory": "C:/github",
+  "DocsRepoCheckoutDirectory": "",
   "TenantID": "",
   "ClientID": "",
   "ClientSecret": "",

--- a/msgraph-sdk-raptor-compiler-lib/appsettings.json
+++ b/msgraph-sdk-raptor-compiler-lib/appsettings.json
@@ -4,5 +4,8 @@
   "DocsRepoCheckoutDirectory": "C:/github",
   "TenantID": "",
   "ClientID": "",
-  "ClientSecret": ""
+  "ClientSecret": "",
+  "Authority": "",
+  "Username": "",
+  "Password": ""
 }

--- a/scripts/transformAppSettings.ps1
+++ b/scripts/transformAppSettings.ps1
@@ -4,7 +4,10 @@ param(
     [string]$DocsRepoCheckoutDirectory = "C:/github",
     [Parameter(Mandatory=$true)][string]$TenantID,
     [Parameter(Mandatory=$true)][string]$ClientID,
-    [Parameter(Mandatory=$true)][string]$ClientSecret
+    [Parameter(Mandatory=$true)][string]$ClientSecret,
+    [Parameter(Mandatory=$true)][string]$Username,
+    [Parameter(Mandatory=$true)][string]$Password,
+    [Parameter(Mandatory=$true)][string]$Authority
 )
 
 $json = @{
@@ -14,6 +17,9 @@ $json = @{
     IsLocalRun = $IsLocalRun;
     GenerateLinqPadOutputInLocalRun = $GenerateLinqPadOutputInLocalRun;
     DocsRepoCheckoutDirectory = $DocsRepoCheckoutDirectory;
+    Username = $Username;
+    Password = $Password;
+    Authority = $Authority;
 }
 
 $repoRoot = (Get-Item $MyInvocation.MyCommand.Source).Directory.Parent.FullName


### PR DESCRIPTION
- Adds a new method into the snippet decoration to extract HttpRequestMessage and URL.
- Modifies snippet to return `HttpRequestMessage` using the template above.
- Has a simple logic deciding on delegated vs. application permissions. Full extent of this logic will be covered by #164 
- Calls DevX API to fetch required permissions after getting the URL from compiled snippet.
- Extends `appsettings.json` to hold authority, username and password. These are required to fetch a token with delegated permissions.
- Fixes #165

cc: @irvinesunday (please review if there are any issues with calling the DevX API)