### PR TITLE
Select read-only permissions in token requests

### DIFF
--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -46,7 +46,7 @@ namespace MsGraphSDKSnippetsCompiler
         }
 
         /// <summary>
-        ///     Returns CompilationResultsModel which has the results status and the compilation diagnostics. 
+        ///     Returns CompilationResultsModel which has the results status and the compilation diagnostics.
         /// </summary>
         /// <param name="codeSnippet">The code snippet to be compiled.</param>
         /// <returns>CompilationResultsModel</returns>
@@ -113,7 +113,7 @@ namespace MsGraphSDKSnippetsCompiler
         }
 
         /// <summary>
-        ///     Returns CompilationResultsModel which has the results status and the compilation diagnostics. 
+        ///     Returns CompilationResultsModel which has the results status and the compilation diagnostics.
         /// </summary>
         /// <param name="codeSnippet">The code snippet to be compiled.</param>
         /// <returns>CompilationResultsModel</returns>
@@ -202,7 +202,11 @@ namespace MsGraphSDKSnippetsCompiler
 
             var scopes = JsonSerializer.Deserialize<Scope[]>(responseString);
 
-            return scopes.ToList().Select(x => $"https://graph.microsoft.com/{ x.value }").ToArray();
+            return scopes
+                .ToList()
+                .Where(x => x.value.Contains("Read") && !x.value.Contains("Write"))
+                .Select(x => $"https://graph.microsoft.com/{ x.value }")
+                .ToArray();
         }
 
         /// <summary>
@@ -257,7 +261,7 @@ namespace MsGraphSDKSnippetsCompiler
         }
 
         /// <summary>
-        ///     Checks whether the EmitResult is successfull and returns an instance of CompilationResultsModel. 
+        ///     Checks whether the EmitResult is successfull and returns an instance of CompilationResultsModel.
         /// </summary>
         /// <param name="emitResult">The result of the Compilation.Emit method.</param>
         private CompilationResultsModel GetCompilationResults(EmitResult emitResult)


### PR DESCRIPTION
Fixes #192

Because we are using an application with read-only permissions (due to limitations in permissions backend), this PR filters out write permissions from the permissions API response before making a token request.

| Version | Pass rate before | Pass rate after |
| --- | --- | --- |
| Beta | [104 / 760](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=41487&view=ms.vss-test-web.build-test-results-tab) | [124 / 760](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=41489&view=ms.vss-test-web.build-test-results-tab) |
| V1 | [53 / 447](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=41486&view=ms.vss-test-web.build-test-results-tab) | [68 / 447](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=41488&view=ms.vss-test-web.build-test-results-tab) |