### PR TITLE
Staging AGS pipelines

### DIFF
--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -253,6 +253,7 @@ namespace TestsCommon
                 { "delete-userflowlanguagepage-csharp-Beta-compiles", new KnownIssue(SDK, StreamRequestDoesNotSupportDelete) },
                 { "get-endpoints-csharp-Beta-compiles", new KnownIssue(SnippetGeneration, SameBlockNames) },
                 { "update-accesspackageassignmentpolicy-csharp-Beta-compiles", new KnownIssue(SDK, PutAsyncIsNotSupported) },
+                { "create-externalitem-from-connections-csharp-Beta-compiles", new KnownIssue(SDK, PutAsyncIsNotSupported) },
             };
         }
         /// <summary>

--- a/azure-pipelines/e2e-templates/checkouts.yml
+++ b/azure-pipelines/e2e-templates/checkouts.yml
@@ -1,21 +1,25 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 # repository checkout steps for end to end validation pipelines
+parameters:
+  - name: shouldRunSnippetGeneration
+    type: boolean
+    default: true
 
 steps:
-  - checkout: microsoft-graph-devx-api
-    displayName: checkout GE api
-    fetchDepth: 1
-    persistCredentials: true
+  - ${{ if eq(parameters.shouldRunSnippetGeneration, true) }}:
+    - checkout: microsoft-graph-devx-api
+      displayName: checkout GE api
+      fetchDepth: 1
+      persistCredentials: true
+    - checkout: apidoctor
+      displayName: checkout apidoctor
+      fetchDepth: 1
+      submodules: recursive
+      persistCredentials: true
 
   - checkout: microsoft-graph-docs
     displayName: checkout docs
     fetchDepth: 1
-    persistCredentials: true
-
-  - checkout: apidoctor
-    displayName: checkout apidoctor
-    fetchDepth: 1
-    submodules: recursive
     persistCredentials: true
 
   - checkout: msgraph-metadata

--- a/azure-pipelines/e2e-templates/checkouts.yml
+++ b/azure-pipelines/e2e-templates/checkouts.yml
@@ -11,6 +11,8 @@ steps:
       displayName: checkout GE api
       fetchDepth: 1
       persistCredentials: true
+
+  - ${{ if eq(parameters.shouldRunSnippetGeneration, true) }}:
     - checkout: apidoctor
       displayName: checkout apidoctor
       fetchDepth: 1

--- a/azure-pipelines/e2e-templates/steps.yml
+++ b/azure-pipelines/e2e-templates/steps.yml
@@ -2,12 +2,18 @@ parameters:
   - name: shouldRunKnownFailures
     type: boolean
     default: true
+  - name: shouldRunSnippetGeneration
+    type: boolean
+    default: true
 
 steps:
   - template: checkouts.yml
+    parameters:
+      shouldRunSnippetGeneration: {{ parameters.shouldRunSnippetGeneration }}
   - template: ../common-templates/use-dotnet-sdk.yml
   - template: sdk-generation.yml
-  - template: snippet-generation.yml
+  - ${{ if eq(parameters.shouldRunSnippetGeneration, true) }}:
+    - template: snippet-generation.yml
   - template: regular-tests.yml
   - ${{ if eq(parameters.shouldRunKnownFailures, true) }}:
     - template: known-failure-tests.yml

--- a/azure-pipelines/e2e-templates/steps.yml
+++ b/azure-pipelines/e2e-templates/steps.yml
@@ -9,7 +9,7 @@ parameters:
 steps:
   - template: checkouts.yml
     parameters:
-      shouldRunSnippetGeneration: {{ parameters.shouldRunSnippetGeneration }}
+      shouldRunSnippetGeneration: ${{ parameters.shouldRunSnippetGeneration }}
   - template: ../common-templates/use-dotnet-sdk.yml
   - template: sdk-generation.yml
   - ${{ if eq(parameters.shouldRunSnippetGeneration, true) }}:

--- a/azure-pipelines/staging-beta-ags.yml
+++ b/azure-pipelines/staging-beta-ags.yml
@@ -37,6 +37,7 @@ resources:
       endpoint: microsoftgraph
       name: microsoftgraph/msgraph-metadata
 
+parameters:
 - name: metadataURL
   displayName: 'URL for metadata for which SDK generation will happen:'
   type: string

--- a/azure-pipelines/staging-beta-ags.yml
+++ b/azure-pipelines/staging-beta-ags.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# contains an end to end validation pipeline using C# compilation tests for staging beta metadata
+
+trigger: none
+pr: none
+name: 'Staging Beta Validation Pipeline'
+
+resources:
+  repositories:
+    - repository: microsoft-graph-docs
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/microsoft-graph-docs
+      ref: master
+    - repository: apidoctor
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/apidoctor
+      ref: master
+    - repository: microsoft-graph-devx-api
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/microsoft-graph-devx-api
+      ref: dev
+    - repository: MSGraph-SDK-Code-Generator
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/MSGraph-SDK-Code-Generator
+      ref: main
+    - repository: msgraph-sdk-dotnet
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/msgraph-sdk-dotnet
+      ref: dev
+    - repository: msgraph-metadata
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/msgraph-metadata
+
+- name: metadataURL
+  displayName: 'URL for metadata for which SDK generation will happen:'
+  type: string
+  default: 'https://graph.microsoft.com/stagingbeta/$metadata'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  - template: e2e-templates/variables.yml
+    parameters:
+      metadataURL: ${{ parameters.metadataURL }}
+      metadataVersion: 'beta'
+
+steps:
+  - template: e2e-templates/steps.yml
+    parameters:
+      shouldRunKnownFailures: false

--- a/azure-pipelines/staging-beta-ags.yml
+++ b/azure-pipelines/staging-beta-ags.yml
@@ -56,3 +56,4 @@ steps:
   - template: e2e-templates/steps.yml
     parameters:
       shouldRunKnownFailures: false
+      shouldRunSnippetGeneration: false

--- a/azure-pipelines/staging-v1-ags.yml
+++ b/azure-pipelines/staging-v1-ags.yml
@@ -37,6 +37,7 @@ resources:
       endpoint: microsoftgraph
       name: microsoftgraph/msgraph-metadata
 
+parameters:
 - name: metadataURL
   displayName: 'URL for metadata for which SDK generation will happen:'
   type: string

--- a/azure-pipelines/staging-v1-ags.yml
+++ b/azure-pipelines/staging-v1-ags.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+# contains an end to end validation pipeline using C# compilation tests for staging V1 metadata
+
+trigger: none
+pr: none
+name: 'Staging V1 Validation Pipeline'
+
+resources:
+  repositories:
+    - repository: microsoft-graph-docs
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/microsoft-graph-docs
+      ref: master
+    - repository: apidoctor
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/apidoctor
+      ref: master
+    - repository: microsoft-graph-devx-api
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/microsoft-graph-devx-api
+      ref: dev
+    - repository: MSGraph-SDK-Code-Generator
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/MSGraph-SDK-Code-Generator
+      ref: main
+    - repository: msgraph-sdk-dotnet
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/msgraph-sdk-dotnet
+      ref: dev
+    - repository: msgraph-metadata
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/msgraph-metadata
+
+- name: metadataURL
+  displayName: 'URL for metadata for which SDK generation will happen:'
+  type: string
+  default: 'https://graph.microsoft.com/stagingv1.0/$metadata'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  - template: e2e-templates/variables.yml
+    parameters:
+      metadataURL: ${{ parameters.metadataURL }}
+      metadataVersion: 'v1.0'
+
+steps:
+  - template: e2e-templates/steps.yml
+    parameters:
+      shouldRunKnownFailures: false

--- a/azure-pipelines/staging-v1-ags.yml
+++ b/azure-pipelines/staging-v1-ags.yml
@@ -56,3 +56,4 @@ steps:
   - template: e2e-templates/steps.yml
     parameters:
       shouldRunKnownFailures: false
+      shouldRunSnippetGeneration: false


### PR DESCRIPTION
Added two new pipelines to be triggered by AGS upon deployment. These pipelines exclude known issues from the test suite. They are expected to pass with 100% for each deployment.

I still keep the original staging pipelines that run daily to keep track of known issues. I am also not running snippet generation step for these pipelines to avoid randomization from docs repo check-ins.

Fixes #198

Also added one more known issue (part of #196)