### PR TITLE
ID replacer

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,21 @@
+name: Run Unit Tests
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.x
+    - name: Unit Tests
+      run: dotnet test ./TestsCommon.Tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.x
+        dotnet-version: 5.0.x
     - name: Unit Tests
       run: dotnet test ./TestsCommon.Tests

--- a/TestsCommon.Tests/IdentiferReplacerTests.cs
+++ b/TestsCommon.Tests/IdentiferReplacerTests.cs
@@ -18,7 +18,8 @@ namespace TestsCommon.Tests
                     {
                         ["conversationMember"] = new IDTree("<team_channel_conversationMember>")
                     }
-                }
+                },
+                ["callRecords.callRecord"] = new IDTree("<callRecords.callRecord>")
             };
 
             idReplacer = new IdentifierReplacer(ids);
@@ -28,6 +29,8 @@ namespace TestsCommon.Tests
                   "https://graph.microsoft.com/v1.0/applications/<application>/owners")]
         [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}",
                   "https://graph.microsoft.com/v1.0/teams/<team>/channels/<team_channel>/members/<team_channel_conversationMember>")]
+        [TestCase("https://graph.microsoft.com/v1.0/communications/callRecords/{callRecords.callRecord-id}?$expand=sessions($expand=segments)",
+                  "https://graph.microsoft.com/v1.0/communications/callRecords/<callRecords.callRecord>?$expand=sessions($expand=segments)")]
         public void TestIds(string snippetUrl, string expectedUrl)
         {
             var newUrl = idReplacer.ReplaceIds(snippetUrl);

--- a/TestsCommon.Tests/IdentiferReplacerTests.cs
+++ b/TestsCommon.Tests/IdentiferReplacerTests.cs
@@ -9,7 +9,7 @@ namespace TestsCommon.Tests
         [SetUp]
         public void Setup()
         {
-            var ids = new IDTree(null)
+            var tree = new IDTree(null)
             {
                 ["application"] = new IDTree("<application>"),
                 ["team"] = new IDTree("<team>")
@@ -17,12 +17,17 @@ namespace TestsCommon.Tests
                     ["channel"] = new IDTree("<team_channel>")
                     {
                         ["conversationMember"] = new IDTree("<team_channel_conversationMember>")
-                    }
+                    },
+                    ["conversationMember"] = new IDTree("<team_conversationMember>")
+                },
+                ["chat"] = new IDTree("<chat>")
+                {
+                    ["conversationMember"] = new IDTree("<chat_conversationMember>")
                 },
                 ["callRecords.callRecord"] = new IDTree("<callRecords.callRecord>")
             };
 
-            idReplacer = new IdentifierReplacer(ids);
+            idReplacer = new IdentifierReplacer(tree);
         }
 
         [TestCase("https://graph.microsoft.com/v1.0/applications/{application-id}/owners",
@@ -31,6 +36,10 @@ namespace TestsCommon.Tests
                   "https://graph.microsoft.com/v1.0/teams/<team>/channels/<team_channel>/members/<team_channel_conversationMember>")]
         [TestCase("https://graph.microsoft.com/v1.0/communications/callRecords/{callRecords.callRecord-id}?$expand=sessions($expand=segments)",
                   "https://graph.microsoft.com/v1.0/communications/callRecords/<callRecords.callRecord>?$expand=sessions($expand=segments)")]
+        [TestCase("https://graph.microsoft.com/v1.0/chats/{chat-id}/members/{conversationMember-id}",
+                  "https://graph.microsoft.com/v1.0/chats/<chat>/members/<chat_conversationMember>")]
+        [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/members/{conversationMember-id}",
+                  "https://graph.microsoft.com/v1.0/teams/<team>/members/<team_conversationMember>")]
         public void TestIds(string snippetUrl, string expectedUrl)
         {
             var newUrl = idReplacer.ReplaceIds(snippetUrl);

--- a/TestsCommon.Tests/IdentiferReplacerTests.cs
+++ b/TestsCommon.Tests/IdentiferReplacerTests.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+
+namespace TestsCommon.Tests
+{
+    public class Tests
+    {
+        private IdentifierReplacer idReplacer;
+
+        [SetUp]
+        public void Setup()
+        {
+            var ids = new IDTree(null)
+            {
+                ["application"] = new IDTree("<application>"),
+                ["team"] = new IDTree("<team>")
+                {
+                    ["channel"] = new IDTree("<team_channel>")
+                    {
+                        ["conversationMember"] = new IDTree("<team_channel_conversationMember>")
+                    }
+                }
+            };
+
+            idReplacer = new IdentifierReplacer(ids);
+        }
+
+        [TestCase("https://graph.microsoft.com/v1.0/applications/{application-id}/owners",
+                  "https://graph.microsoft.com/v1.0/applications/<application>/owners")]
+        [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}",
+                  "https://graph.microsoft.com/v1.0/teams/<team>/channels/<team_channel>/members/<team_channel_conversationMember>")]
+        public void TestIds(string snippetUrl, string expectedUrl)
+        {
+            var newUrl = idReplacer.ReplaceIds(snippetUrl);
+            Assert.AreEqual(expectedUrl, newUrl);
+        }
+    }
+}

--- a/TestsCommon.Tests/TestsCommon.Tests.csproj
+++ b/TestsCommon.Tests/TestsCommon.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestsCommon/IDTree.cs
+++ b/TestsCommon/IDTree.cs
@@ -2,6 +2,26 @@
 
 namespace TestsCommon
 {
+    /// <summary>
+    /// Tree data structure to represent ID placeholders in graph URLs.
+    ///
+    /// Example URLs:
+    ///   https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}
+    ///   https://graph.microsoft.com/v1.0/communications/callRecords/{callRecords.callRecord-id}?$expand=sessions($expand=segments)
+    ///   https://graph.microsoft.com/v1.0/chats/{chat-id}/members/{conversationMember-id}
+    ///
+    /// Corresponding tree representation:
+    ///
+    ///                                 root
+    ///                               /  |  \
+    ///                              /   |   \
+    ///                             /    |    \
+    ///                         chat   team   callRecords.callRecord
+    ///                          /       |
+    ///         conversationMember    channel
+    ///                                  |
+    ///                             conversationMember
+    /// </summary>
     public class IDTree : Dictionary<string, IDTree>
     {
         public string Value { get; set; }

--- a/TestsCommon/IDTree.cs
+++ b/TestsCommon/IDTree.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace TestsCommon
+{
+    public class IDTree : Dictionary<string, IDTree>
+    {
+        public string Value { get; set; }
+        public IDTree(string value) { Value = value; }
+    }
+}
+

--- a/TestsCommon/IdentifierReplacer.cs
+++ b/TestsCommon/IdentifierReplacer.cs
@@ -23,7 +23,7 @@ namespace TestsCommon
 
         /// <summary>
         /// Replaces ID placeholders of the form {name-id} by looking up name in the IDTree.
-        /// If there are more than one placeholder, it traverses through the tree, e.g.
+        /// If there is more than one placeholder, it traverses through the tree, e.g.
         /// For input string "sites/{site-id}/lists/{list-id}",
         ///   {site-id} is replaced by root->site entry from the IDTree.
         ///   {list-id} is replaced by root->site->list entry from the IDTree.

--- a/TestsCommon/IdentifierReplacer.cs
+++ b/TestsCommon/IdentifierReplacer.cs
@@ -5,7 +5,15 @@ namespace TestsCommon
 {
     public class IdentifierReplacer
     {
+        /// <summary>
+        /// tree of IDs that appear in sample Graph URLs
+        /// </summary>
         private readonly IDTree tree;
+
+        /// <summary>
+        /// regular expression to match strings like {namespace.type-id}
+        /// also extracts namespace.type part separately so that we can use it as a lookup key.
+        /// </summary>
         private readonly Regex idRegex = new Regex(@"{([A-Za-z\.]+)\-id}", RegexOptions.Compiled);
 
         public IdentifierReplacer(IDTree tree)
@@ -13,6 +21,15 @@ namespace TestsCommon
             this.tree = tree;
         }
 
+        /// <summary>
+        /// Replaces ID placeholders of the form {name-id} by looking up name in the IDTree.
+        /// If there are more than one placeholder, it traverses through the tree, e.g.
+        /// For input string "sites/{site-id}/lists/{list-id}",
+        ///   {site-id} is replaced by root->site entry from the IDTree.
+        ///   {list-id} is replaced by root->site->list entry from the IDTree.
+        /// </summary>
+        /// <param name="input">String containing ID placeholders</param>
+        /// <returns>input string, but its placeholders replaced from IDTree</returns>
         public string ReplaceIds(string input)
         {
             if (input == null)
@@ -24,8 +41,8 @@ namespace TestsCommon
             IDTree currentIdNode = tree;
             foreach (Match match in matches)
             {
-                var id = match.Groups[0].Value; // e.g. {application-id}
-                var idType = match.Groups[1].Value; // e.g. extract application from {application-id}
+                var id = match.Groups[0].Value;     // e.g. {site-id}
+                var idType = match.Groups[1].Value; // e.g. extract site from {site-id}
 
                 currentIdNode = currentIdNode[idType];
                 input = input.Replace(id, currentIdNode.Value);

--- a/TestsCommon/IdentifierReplacer.cs
+++ b/TestsCommon/IdentifierReplacer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace TestsCommon
+{
+    public class IdentifierReplacer
+    {
+        private readonly IDTree tree;
+        private readonly Regex idRegex = new Regex(@"{([A-Za-z\.]+)\-id}", RegexOptions.Compiled);
+
+        public IdentifierReplacer(IDTree tree)
+        {
+            this.tree = tree;
+        }
+
+        public string ReplaceIds(string input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var matches = idRegex.Matches(input);
+            IDTree currentIdNode = tree;
+            foreach (Match match in matches)
+            {
+                var id = match.Groups[0].Value; // e.g. {application-id}
+                var idType = match.Groups[1].Value; // e.g. extract application from {application-id}
+
+                currentIdNode = currentIdNode[idType];
+                input = input.Replace(id, currentIdNode.Value);
+            }
+
+            return input;
+        }
+    }
+}

--- a/msgraph-sdk-raptor.sln
+++ b/msgraph-sdk-raptor.sln
@@ -32,7 +32,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpBetaExecutionTests", "CsharpBetaExecutionTests\CsharpBetaExecutionTests.csproj", "{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsharpBetaExecutionTests", "CsharpBetaExecutionTests\CsharpBetaExecutionTests.csproj", "{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestsCommon.Tests", "TestsCommon.Tests\TestsCommon.Tests.csproj", "{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -92,6 +94,10 @@ Global
 		{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{295FB66C-5A96-4FDE-BB01-38E3DC91AD87}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes #233

- Adds an `IDTree` object to read the JSON object into. (Json reader, if needed, will be implemented after finalizing the data structure for #200)
- Adds an `IdentifierReplacer`, which consumes `IDTree` and strings with placeholder IDs, and outputs strings with real IDs.
- Adds unit test cases from V1 sample URLs
  - Note that `<team_channel_conversationMember>`, `<team_conversationMember>` and `<chat_conversationMember>` values can all be the same, but we keep separate entries to cover the case of chosen chat id value affecting conversationMember id value.
- Adds a GitHub action to run the unit tests