### PR TITLE
JSON representation of the IDTree object

### DIFF
--- a/TestsCommon.Tests/IDTreeTests.cs
+++ b/TestsCommon.Tests/IDTreeTests.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace TestsCommon.Tests
+{
+    public class IDTreeTests
+    {
+        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.EqualTestCases))]
+        public void Equal(IDTree a, IDTree b) => Assert.IsTrue(a.Equals(b));
+
+        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.NotEqualTestCases))]
+        public void NotEqual(IDTree a, IDTree b) => Assert.IsFalse(a.Equals(b));
+
+        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.LosslessSerializationTestCases))]
+        public void LosslessSerialization(IDTree a)
+        {
+            a.Equals(JsonSerializer.Deserialize<IDTree>(JsonSerializer.Serialize(a)));
+        }
+    }
+
+    public static class IDTreeTestCases
+    {
+        private static readonly IDTree NullTree = null;
+        private static readonly IDTree EmptyTree = new IDTree(null);
+        private static readonly IDTree EmptyTree2 = new IDTree(null);
+
+        private static readonly IDTree OneItemTree = new IDTree(null)
+        {
+            ["application"] = new IDTree("(application)")
+        };
+
+        private static readonly IDTree OneItemTree2 = new IDTree(null)
+        {
+            ["application"] = new IDTree("(application)")
+        };
+
+        private static readonly IDTree TwoItemTree = new IDTree(null)
+        {
+            ["application"] = new IDTree("(application)"),
+            ["team"] = new IDTree("(team)")
+        };
+
+        private static readonly IDTree DepthTwoTree = new IDTree(null)
+        {
+            ["application"] = new IDTree("(application)")
+            {
+                ["child"] = new IDTree("(application_child)")
+            }
+        };
+
+        private static readonly IDTree DepthTwoTree2 = new IDTree(null)
+        {
+            ["application"] = new IDTree("(application)")
+            {
+                ["child"] = new IDTree("(application_child)")
+            }
+        };
+
+        private static readonly IDTree OneItemTreeValueDifferent = new IDTree(null)
+        {
+            ["application"] = new IDTree("(application2)")
+        };
+
+        private static readonly IDTree OneItemTreeKeyDifferent = new IDTree(null)
+        {
+            ["application2"] = new IDTree("(application)")
+        };
+
+        private static readonly IDTree ComplexTree = new IDTree(null)
+        {
+            ["application"] = new IDTree("<application>"),
+            ["team"] = new IDTree("<team>")
+            {
+                ["channel"] = new IDTree("<team_channel>")
+                {
+                    ["conversationMember"] = new IDTree("<team_channel_conversationMember>")
+                },
+                ["conversationMember"] = new IDTree("<team_conversationMember>")
+            },
+            ["chat"] = new IDTree("<chat>")
+            {
+                ["conversationMember"] = new IDTree("<chat_conversationMember>")
+            },
+            ["callRecords.callRecord"] = new IDTree("<callRecords.callRecord>")
+        };
+
+        public static IEnumerable<TestCaseData> EqualTestCases()
+        {
+            yield return new TestCaseData(EmptyTree, EmptyTree2);
+
+            yield return new TestCaseData(OneItemTree, OneItemTree2);
+            yield return new TestCaseData(OneItemTree2, OneItemTree);
+
+            yield return new TestCaseData(DepthTwoTree, DepthTwoTree2);
+            yield return new TestCaseData(DepthTwoTree2, DepthTwoTree);
+        }
+
+        public static IEnumerable<TestCaseData> NotEqualTestCases()
+        {
+            yield return new TestCaseData(EmptyTree, NullTree);
+            yield return new TestCaseData(OneItemTree, NullTree);
+
+            // check for same-value false equivelance
+            yield return new TestCaseData(OneItemTree, OneItemTreeKeyDifferent);
+            yield return new TestCaseData(OneItemTreeKeyDifferent, OneItemTree);
+
+            // check for same-key false equivelance
+            yield return new TestCaseData(OneItemTree, OneItemTreeValueDifferent);
+            yield return new TestCaseData(OneItemTreeValueDifferent, OneItemTree);
+
+            // check for subset or superset false equivelance with breadth
+            yield return new TestCaseData(OneItemTree, TwoItemTree);
+            yield return new TestCaseData(TwoItemTree, OneItemTree);
+
+            // check for subset or superset false equivelance with depth
+            yield return new TestCaseData(OneItemTree, DepthTwoTree);
+            yield return new TestCaseData(DepthTwoTree, OneItemTree);
+        }
+
+        public static IEnumerable<TestCaseData> LosslessSerializationTestCases()
+        {
+            yield return new TestCaseData(EmptyTree);
+            yield return new TestCaseData(OneItemTree);
+            yield return new TestCaseData(TwoItemTree);
+            yield return new TestCaseData(DepthTwoTree);
+            yield return new TestCaseData(ComplexTree);
+        }
+    }
+}

--- a/TestsCommon.Tests/IDTreeTests.cs
+++ b/TestsCommon.Tests/IDTreeTests.cs
@@ -33,26 +33,26 @@ namespace TestsCommon.Tests
     public static class IDTreeTestCases
     {
         private static readonly IDTree NullTree = null;
-        private static readonly IDTree EmptyTree = new IDTree(null);
-        private static readonly IDTree EmptyTree2 = new IDTree(null);
+        private static readonly IDTree EmptyTree = new IDTree();
+        private static readonly IDTree EmptyTree2 = new IDTree();
 
-        private static readonly IDTree OneItemTree = new IDTree(null)
+        private static readonly IDTree OneItemTree = new IDTree()
         {
             ["application"] = new IDTree("(application)")
         };
 
-        private static readonly IDTree OneItemTree2 = new IDTree(null)
+        private static readonly IDTree OneItemTree2 = new IDTree()
         {
             ["application"] = new IDTree("(application)")
         };
 
-        private static readonly IDTree TwoItemTree = new IDTree(null)
+        private static readonly IDTree TwoItemTree = new IDTree()
         {
             ["application"] = new IDTree("(application)"),
             ["team"] = new IDTree("(team)")
         };
 
-        private static readonly IDTree DepthTwoTree = new IDTree(null)
+        private static readonly IDTree DepthTwoTree = new IDTree()
         {
             ["application"] = new IDTree("(application)")
             {
@@ -60,7 +60,7 @@ namespace TestsCommon.Tests
             }
         };
 
-        private static readonly IDTree DepthTwoTree2 = new IDTree(null)
+        private static readonly IDTree DepthTwoTree2 = new IDTree()
         {
             ["application"] = new IDTree("(application)")
             {
@@ -68,17 +68,17 @@ namespace TestsCommon.Tests
             }
         };
 
-        private static readonly IDTree OneItemTreeValueDifferent = new IDTree(null)
+        private static readonly IDTree OneItemTreeValueDifferent = new IDTree()
         {
             ["application"] = new IDTree("(application2)")
         };
 
-        private static readonly IDTree OneItemTreeKeyDifferent = new IDTree(null)
+        private static readonly IDTree OneItemTreeKeyDifferent = new IDTree()
         {
             ["application2"] = new IDTree("(application)")
         };
 
-        private static readonly IDTree ComplexTree = new IDTree(null)
+        private static readonly IDTree ComplexTree = new IDTree()
         {
             ["application"] = new IDTree("(application)"),
             ["team"] = new IDTree("(team)")
@@ -97,7 +97,6 @@ namespace TestsCommon.Tests
         };
 
         private static readonly string SerializedComplexTree = @"{
-    ""_value"": null,
     ""application"": {
     ""_value"": ""(application)""
     },

--- a/TestsCommon.Tests/IDTreeTests.cs
+++ b/TestsCommon.Tests/IDTreeTests.cs
@@ -68,6 +68,14 @@ namespace TestsCommon.Tests
             }
         };
 
+        private static readonly IDTree DepthTwoWithNullChild = new IDTree()
+        {
+            ["application"] = new IDTree("(application)")
+            {
+                ["child"] = null
+            }
+        };
+
         private static readonly IDTree OneItemTreeValueDifferent = new IDTree()
         {
             ["application"] = new IDTree("(application2)")
@@ -154,6 +162,8 @@ namespace TestsCommon.Tests
             // check for subset or superset false equivelance with depth
             yield return new TestCaseData(OneItemTree, DepthTwoTree);
             yield return new TestCaseData(DepthTwoTree, OneItemTree);
+
+            yield return new TestCaseData(DepthTwoWithNullChild, DepthTwoTree);
         }
 
         public static IEnumerable<TestCaseData> LosslessSerializationTestCases()

--- a/TestsCommon.Tests/IdentiferReplacerTests.cs
+++ b/TestsCommon.Tests/IdentiferReplacerTests.cs
@@ -9,23 +9,9 @@ namespace TestsCommon.Tests
         [SetUp]
         public void Setup()
         {
-            var tree = new IDTree(null)
-            {
-                ["application"] = new IDTree("<application>"),
-                ["team"] = new IDTree("<team>")
-                {
-                    ["channel"] = new IDTree("<team_channel>")
-                    {
-                        ["conversationMember"] = new IDTree("<team_channel_conversationMember>")
-                    },
-                    ["conversationMember"] = new IDTree("<team_conversationMember>")
-                },
-                ["chat"] = new IDTree("<chat>")
-                {
-                    ["conversationMember"] = new IDTree("<chat_conversationMember>")
-                },
-                ["callRecords.callRecord"] = new IDTree("<callRecords.callRecord>")
-            };
+            // identifiers.json holds sample tree constructed from V1 urls
+            var identifiersJson = System.IO.File.ReadAllText("identifiers.json");
+            var tree = System.Text.Json.JsonSerializer.Deserialize<IDTree>(identifiersJson);
 
             idReplacer = new IdentifierReplacer(tree);
         }

--- a/TestsCommon.Tests/TestsCommon.Tests.csproj
+++ b/TestsCommon.Tests/TestsCommon.Tests.csproj
@@ -16,4 +16,10 @@
     <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="identifiers.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/TestsCommon.Tests/identifiers.json
+++ b/TestsCommon.Tests/identifiers.json
@@ -1,0 +1,435 @@
+{
+  "_value": null,
+  "application": {
+    "_value": "<application>"
+  },
+  "calendarGroup": {
+    "_value": "<calendarGroup>"
+  },
+  "team": {
+    "_value": "<team>",
+    "channel": {
+      "_value": "<team_channel>",
+      "conversationMember": {
+        "_value": "<team_channel_conversationMember>"
+      }
+    },
+    "teamsAppInstallation": {
+      "_value": "<team_teamsAppInstallation>"
+    },
+    "offerShiftRequest": {
+      "_value": "<team_offerShiftRequest>"
+    },
+    "openShift": {
+      "_value": "<team_openShift>"
+    },
+    "openShiftChangeRequest": {
+      "_value": "<team_openShiftChangeRequest>"
+    },
+    "swapShiftsChangeRequest": {
+      "_value": "<team_swapShiftsChangeRequest>"
+    },
+    "timeOffRequest": {
+      "_value": "<team_timeOffRequest>"
+    },
+    "schedulingGroup": {
+      "_value": "<team_schedulingGroup>"
+    },
+    "shift": {
+      "_value": "<team_shift>"
+    },
+    "conversationMember": {
+      "_value": "<team_conversationMember>"
+    },
+    "timeOff": {
+      "_value": "<team_timeOff>"
+    },
+    "timeOffReason": {
+      "_value": "<team_timeOffReason>"
+    }
+  },
+  "contactFolder": {
+    "_value": "<contactFolder>"
+  },
+  "orgContact": {
+    "_value": "<orgContact>"
+  },
+  "driveItem": {
+    "_value": "<driveItem>",
+    "workbookNamedItem": {
+      "_value": "<driveItem_workbookNamedItem>",
+      "workbookRangeBorder": {
+        "_value": "<driveItem_workbookNamedItem_workbookRangeBorder>"
+      }
+    },
+    "workbookWorksheet": {
+      "_value": "<driveItem_workbookWorksheet>",
+      "workbookChart": {
+        "_value": "<driveItem_workbookWorksheet_workbookChart>",
+        "workbookChartSeries": {
+          "_value": "<driveItem_workbookWorksheet_workbookChart_workbookChartSeries>",
+          "workbookChartPoint": {
+            "_value": "<driveItem_workbookWorksheet_workbookChart_workbookChartSeries_workbookChartPoint>"
+          }
+        }
+      }
+    },
+    "workbookTable": {
+      "_value": "<driveItem_workbookTable>",
+      "workbookTableColumn": {
+        "_value": "<driveItem_workbookTable_workbookTableColumn>"
+      },
+      "workbookTableRow": {
+        "_value": "<driveItem_workbookTable_workbookTableRow>"
+      }
+    },
+    "permission": {
+      "_value": "<driveItem_permission>"
+    },
+    "thumbnailSet": {
+      "_value": "<driveItem_thumbnailSet>",
+      "thumbnailSet": {
+        "_value": "<driveItem_thumbnailSet_thumbnailSet>"
+      }
+    },
+    "workbookComment": {
+      "_value": "<driveItem_workbookComment>",
+      "workbookCommentReply": {
+        "_value": "<driveItem_workbookComment_workbookCommentReply>"
+      }
+    },
+    "driveItemVersion": {
+      "_value": "<driveItem_driveItemVersion>"
+    },
+    "workbookOperation": {
+      "_value": "<driveItem_workbookOperation>"
+    }
+  },
+  "subscription": {
+    "_value": "<subscription>"
+  },
+  "educationClass": {
+    "_value": "<educationClass>"
+  },
+  "educationSchool": {
+    "_value": "<educationSchool>"
+  },
+  "site": {
+    "_value": "<site>",
+    "list": {
+      "_value": "<site_list>",
+      "listItem": {
+        "_value": "<site_list_listItem>",
+        "listItemVersion": {
+          "_value": "<site_list_listItem_listItemVersion>"
+        }
+      }
+    },
+    "permission": {
+      "_value": "<site_permission>"
+    }
+  },
+  "event": {
+    "_value": "<event>"
+  },
+  "message": {
+    "_value": "<message>",
+    "attachment": {
+      "_value": "<message_attachment>"
+    },
+    "extension": {
+      "_value": "<message_extension>"
+    }
+  },
+  "group": {
+    "_value": "<group>",
+    "conversation": {
+      "_value": "<group_conversation>"
+    },
+    "conversationThread": {
+      "_value": "<group_conversationThread>",
+      "post": {
+        "_value": "<group_conversationThread_post>",
+        "extension": {
+          "_value": "<group_conversationThread_post_extension>"
+        }
+      }
+    },
+    "event": {
+      "_value": "<group_event>",
+      "extension": {
+        "_value": "<group_event_extension>"
+      }
+    }
+  },
+  "drive": {
+    "_value": "<drive>",
+    "driveItem": {
+      "_value": "<drive_driveItem>"
+    }
+  },
+  "activityBasedTimeoutPolicy": {
+    "_value": "<activityBasedTimeoutPolicy>"
+  },
+  "administrativeUnit": {
+    "_value": "<administrativeUnit>",
+    "scopedRoleMembership": {
+      "_value": "<administrativeUnit_scopedRoleMembership>"
+    }
+  },
+  "agreement": {
+    "_value": "<agreement>"
+  },
+  "alert": {
+    "_value": "<alert>"
+  },
+  "appConsentRequest": {
+    "_value": "<appConsentRequest>",
+    "userConsentRequest": {
+      "_value": "<appConsentRequest_userConsentRequest>"
+    }
+  },
+  "applicationTemplate": {
+    "_value": "<applicationTemplate>"
+  },
+  "claimsMappingPolicy": {
+    "_value": "<claimsMappingPolicy>"
+  },
+  "homeRealmDiscoveryPolicy": {
+    "_value": "<homeRealmDiscoveryPolicy>"
+  },
+  "tokenIssuancePolicy": {
+    "_value": "<tokenIssuancePolicy>"
+  },
+  "tokenLifetimePolicy": {
+    "_value": "<tokenLifetimePolicy>"
+  },
+  "plannerPlan": {
+    "_value": "<plannerPlan>"
+  },
+  "user": {
+    "_value": "<user>",
+    "calendarPermission": {
+      "_value": "<user_calendarPermission>"
+    },
+    "microsoftAuthenticatorAuthenticationMethod": {
+      "_value": "<user_microsoftAuthenticatorAuthenticationMethod>"
+    },
+    "windowsHelloForBusinessAuthenticationMethod": {
+      "_value": "<user_windowsHelloForBusinessAuthenticationMethod>"
+    },
+    "userScopeTeamsAppInstallation": {
+      "_value": "<user_userScopeTeamsAppInstallation>"
+    }
+  },
+  "call": {
+    "_value": "<call>",
+    "participant": {
+      "_value": "<call_participant>"
+    }
+  },
+  "callRecords.callRecord": {
+    "_value": "<callRecords.callRecord>"
+  },
+  "organization": {
+    "_value": "<organization>",
+    "certificateBasedAuthConfiguration": {
+      "_value": "<organization_certificateBasedAuthConfiguration>"
+    },
+    "organizationalBrandingLocalization": {
+      "_value": "<organization_organizationalBrandingLocalization>"
+    }
+  },
+  "conditionalAccessPolicy": {
+    "_value": "<conditionalAccessPolicy>"
+  },
+  "contact": {
+    "_value": "<contact>"
+  },
+  "contract": {
+    "_value": "<contract>"
+  },
+  "chat": {
+    "_value": "<chat>",
+    "conversationMember": {
+      "_value": "<chat_conversationMember>"
+    },
+    "teamsAppInstallation": {
+      "_value": "<chat_teamsAppInstallation>"
+    },
+    "teamsTab": {
+      "_value": "<chat_teamsTab>"
+    }
+  },
+  "namedLocation": {
+    "_value": "<namedLocation>"
+  },
+  "dataPolicyOperation": {
+    "_value": "<dataPolicyOperation>"
+  },
+  "device": {
+    "_value": "<device>"
+  },
+  "directoryObject": {
+    "_value": "<directoryObject>"
+  },
+  "directoryAudit": {
+    "_value": "<directoryAudit>"
+  },
+  "directoryRole": {
+    "_value": "<directoryRole>"
+  },
+  "directoryRoleTemplate": {
+    "_value": "<directoryRoleTemplate>"
+  },
+  "printer": {
+    "_value": "<printer>",
+    "printJob": {
+      "_value": "<printer_printJob>",
+      "printDocument": {
+        "_value": "<printer_printJob_printDocument>"
+      }
+    },
+    "printTaskTrigger": {
+      "_value": "<printer_printTaskTrigger>"
+    }
+  },
+  "domain": {
+    "_value": "<domain>"
+  },
+  "educationUser": {
+    "_value": "<educationUser>"
+  },
+  "threatAssessmentRequest": {
+    "_value": "<threatAssessmentRequest>"
+  },
+  "featureRolloutPolicy": {
+    "_value": "<featureRolloutPolicy>"
+  },
+  "authenticationMethodConfiguration": {
+    "_value": "<authenticationMethodConfiguration>"
+  },
+  "groupLifecyclePolicy": {
+    "_value": "<groupLifecyclePolicy>"
+  },
+  "groupSetting": {
+    "_value": "<groupSetting>"
+  },
+  "groupSettingTemplate": {
+    "_value": "<groupSettingTemplate>"
+  },
+  "identityProvider": {
+    "_value": "<identityProvider>"
+  },
+  "todoTaskList": {
+    "_value": "<todoTaskList>",
+    "todoTask": {
+      "_value": "<todoTaskList_todoTask>",
+      "linkedResource": {
+        "_value": "<todoTaskList_todoTask_linkedResource>"
+      }
+    }
+  },
+  "mailFolder": {
+    "_value": "<mailFolder>",
+    "messageRule": {
+      "_value": "<mailFolder_messageRule>"
+    }
+  },
+  "notebook": {
+    "_value": "<notebook>"
+  },
+  "onenoteOperation": {
+    "_value": "<onenoteOperation>"
+  },
+  "outlookCategory": {
+    "_value": "<outlookCategory>"
+  },
+  "servicePrincipal": {
+    "_value": "<servicePrincipal>"
+  },
+  "permissionGrantPolicy": {
+    "_value": "<permissionGrantPolicy>"
+  },
+  "workbookWorksheet": {
+    "_value": "<workbookWorksheet>",
+    "workbookPivotTable": {
+      "_value": "<workbookWorksheet_workbookPivotTable>"
+    }
+  },
+  "plannerTask": {
+    "_value": "<plannerTask>"
+  },
+  "plannerBucket": {
+    "_value": "<plannerBucket>"
+  },
+  "printConnector": {
+    "_value": "<printConnector>"
+  },
+  "printerShare": {
+    "_value": "<printerShare>"
+  },
+  "printOperation": {
+    "_value": "<printOperation>"
+  },
+  "printService": {
+    "_value": "<printService>",
+    "printServiceEndpoint": {
+      "_value": "<printService_printServiceEndpoint>"
+    }
+  },
+  "printTaskDefinition": {
+    "_value": "<printTaskDefinition>",
+    "printTask": {
+      "_value": "<printTaskDefinition_printTask>"
+    }
+  },
+  "printUsageByPrinter": {
+    "_value": "<printUsageByPrinter>"
+  },
+  "printUsageByUser": {
+    "_value": "<printUsageByUser>"
+  },
+  "onenoteResource": {
+    "_value": "<onenoteResource>"
+  },
+  "place": {
+    "_value": "<place>"
+  },
+  "schemaExtension": {
+    "_value": "<schemaExtension>"
+  },
+  "onenoteSection": {
+    "_value": "<onenoteSection>"
+  },
+  "sectionGroup": {
+    "_value": "<sectionGroup>"
+  },
+  "secureScore": {
+    "_value": "<secureScore>"
+  },
+  "secureScoreControlProfile": {
+    "_value": "<secureScoreControlProfile>"
+  },
+  "sharedDriveItem": {
+    "_value": "<sharedDriveItem>"
+  },
+  "signIn": {
+    "_value": "<signIn>"
+  },
+  "subscribedSku": {
+    "_value": "<subscribedSku>"
+  },
+  "teamsApp": {
+    "_value": "<teamsApp>",
+    "teamsAppDefinition": {
+      "_value": "<teamsApp_teamsAppDefinition>"
+    }
+  },
+  "presence": {
+    "_value": "<presence>"
+  },
+  "workforceIntegration": {
+    "_value": "<workforceIntegration>"
+  }
+}

--- a/TestsCommon.Tests/identifiers.json
+++ b/TestsCommon.Tests/identifiers.json
@@ -1,5 +1,4 @@
 {
-  "_value": null,
   "application": {
     "_value": "<application>"
   },

--- a/TestsCommon/IDTree.cs
+++ b/TestsCommon/IDTree.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Linq;
 
 namespace TestsCommon
 {
@@ -22,10 +26,77 @@ namespace TestsCommon
     ///                                  |
     ///                             conversationMember
     /// </summary>
-    public class IDTree : Dictionary<string, IDTree>
+    [JsonConverter(typeof(IDTreeConverter))]
+    public class IDTree : Dictionary<string, IDTree>, IEquatable<IDTree>
     {
         public string Value { get; set; }
         public IDTree(string value) { Value = value; }
+
+        public bool Equals(IDTree other)
+        {
+            return other != null &&
+                Value == other.Value &&
+                Keys.Count == other.Keys.Count &&
+                Keys.All(key => other.ContainsKey(key) && this[key].Equals(other[key]));
+        }
+
+        public override bool Equals(object obj) => Equals(obj as IDTree);
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
+    public class IDTreeConverter : JsonConverter<IDTree>
+    {
+        public override IDTree Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException();
+            }
+
+            IDTree tree = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return tree;
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    break;
+                }
+
+                var propertyName = reader.GetString();
+                if (propertyName == "_value")
+                {
+                    reader.Read();
+                    tree = new IDTree(reader.GetString());
+                }
+                else
+                {
+                    IDTree subTree = JsonSerializer.Deserialize<IDTree>(ref reader, options);
+                    tree[propertyName] = subTree;
+                }
+            }
+
+            throw new JsonException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, IDTree tree, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("_value");
+            writer.WriteStringValue(tree.Value);
+            foreach (KeyValuePair<string, IDTree> item in tree)
+            {
+                writer.WritePropertyName(item.Key);
+                Write(writer, item.Value, options);
+            }
+            writer.WriteEndObject();
+            writer.Flush();
+        }
     }
 }
 

--- a/TestsCommon/IDTree.cs
+++ b/TestsCommon/IDTree.cs
@@ -89,10 +89,10 @@ namespace TestsCommon
             writer.WriteStartObject();
             writer.WritePropertyName("_value");
             writer.WriteStringValue(tree.Value);
-            foreach (KeyValuePair<string, IDTree> item in tree)
+            foreach (var key in tree.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
             {
-                writer.WritePropertyName(item.Key);
-                Write(writer, item.Value, options);
+                writer.WritePropertyName(key);
+                Write(writer, tree[key], options);
             }
             writer.WriteEndObject();
             writer.Flush();

--- a/TestsCommon/IDTree.cs
+++ b/TestsCommon/IDTree.cs
@@ -47,7 +47,7 @@ namespace TestsCommon
             return other != null &&
                 Value == other.Value &&
                 Keys.Count == other.Keys.Count &&
-                Keys.All(key => other.ContainsKey(key) && this[key].Equals(other[key]));
+                Keys.All(key => other.ContainsKey(key) && (this[key]?.Equals(other[key]) ?? false));
         }
 
         public override bool Equals(object obj) => Equals(obj as IDTree);

--- a/TestsCommon/IDTree.cs
+++ b/TestsCommon/IDTree.cs
@@ -91,7 +91,7 @@ namespace TestsCommon
                 }
             }
 
-            throw new JsonException();
+            throw new JsonException("Unexpected JSON object. See identifiers.json file for a sample JSON in the TestCommon.Tests project.");
         }
 
         public override void Write(Utf8JsonWriter writer, IDTree tree, JsonSerializerOptions options)

--- a/TestsCommon/IDTree.cs
+++ b/TestsCommon/IDTree.cs
@@ -30,7 +30,17 @@ namespace TestsCommon
     public class IDTree : Dictionary<string, IDTree>, IEquatable<IDTree>
     {
         public string Value { get; set; }
-        public IDTree(string value) { Value = value; }
+        public IDTree(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException($"{nameof(value)} can't be null or empty!");
+            }
+
+            Value = value;
+        }
+
+        public IDTree() { }
 
         public bool Equals(IDTree other)
         {
@@ -54,7 +64,7 @@ namespace TestsCommon
                 throw new JsonException();
             }
 
-            IDTree tree = null;
+            IDTree tree = new IDTree();
 
             while (reader.Read())
             {
@@ -72,7 +82,7 @@ namespace TestsCommon
                 if (propertyName == "_value")
                 {
                     reader.Read();
-                    tree = new IDTree(reader.GetString());
+                    tree.Value = reader.GetString();
                 }
                 else
                 {
@@ -87,8 +97,12 @@ namespace TestsCommon
         public override void Write(Utf8JsonWriter writer, IDTree tree, JsonSerializerOptions options)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("_value");
-            writer.WriteStringValue(tree.Value);
+            if (tree.Value is not null)
+            {
+                writer.WritePropertyName("_value");
+                writer.WriteStringValue(tree.Value);
+            }
+
             foreach (var key in tree.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
             {
                 writer.WritePropertyName(key);


### PR DESCRIPTION
Fixes #235 

- Implements custom JSON reader and writer
  - outputs `Value` into `_value` property
  - sorts keys in the dictionary of child items and outputs them recursively
- Implements IEquatable interface for comparing two `IDTree` objects.
- Adds equality and serialization tests.
- Adds a sample JSON file representing the serialized version of the ID tree extracted from V1 graph URLs.