### PR TITLE
Read demo tenant and update identifiers.json

### DIFF
--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -293,7 +293,8 @@ namespace MsGraphSDKSnippetsCompiler
             return codeSnippet.Contains("graphClient.Me") ||
                 codeSnippet.Contains("graphClient.Education.Me") ||
                 codeSnippet.Contains("graphClient.Users[\"") ||
-                codeSnippet.Contains("graphClient.Planner");
+                codeSnippet.Contains("graphClient.Planner") ||
+                codeSnippet.Contains("graphClient.Print");
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -292,7 +292,8 @@ namespace MsGraphSDKSnippetsCompiler
             // TODO: https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/164
             return codeSnippet.Contains("graphClient.Me") ||
                 codeSnippet.Contains("graphClient.Education.Me") ||
-                codeSnippet.Contains("graphClient.Users[\"");
+                codeSnippet.Contains("graphClient.Users[\"") ||
+                codeSnippet.Contains("graphClient.Planner");
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -290,11 +290,24 @@ namespace MsGraphSDKSnippetsCompiler
         private static bool RequiresDelegatedPermissions(string codeSnippet)
         {
             // TODO: https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/164
-            return codeSnippet.Contains("graphClient.Me") ||
-                codeSnippet.Contains("graphClient.Education.Me") ||
-                codeSnippet.Contains("graphClient.Users[\"") ||
-                codeSnippet.Contains("graphClient.Planner") ||
-                codeSnippet.Contains("graphClient.Print");
+            const string graphClient = "graphClient.";
+            var apiPathStart = codeSnippet.IndexOf(graphClient) + graphClient.Length;
+            var apiPath = codeSnippet[apiPathStart..];
+
+            var apisWithDelegatedPermissions = new []
+            {
+                "Me",
+                "Education.Me",
+                "Users[",
+                "Planner",
+                "Print",
+                "IdentityProviders",
+                "Reports",
+                "IdentityGovernance",
+                "GroupSetting"
+            };
+
+            return apisWithDelegatedPermissions.Any(x => apiPath.StartsWith(x));
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -37,16 +37,24 @@ namespace MsGraphSDKSnippetsCompiler.Models
         /// </summary>
         private IdentifierReplacer()
         {
-            const string blobContainerName = "raptoridentifiers";
-            const string blobName = "identifiers.json";
-
             var config = AppSettings.Config();
-            var raptorStorageConnectionString = config.GetNonEmptyValue("RaptorStorageConnectionString");
-            var blobClient = new BlobClient(raptorStorageConnectionString, blobContainerName, blobName);
+            string json;
+            if (bool.Parse(config.GetSection("IsLocalRun").Value))
+            {
+                json = File.ReadAllText(@"identifiers.json");
+            }
+            else
+            {
+                const string blobContainerName = "raptoridentifiers";
+                const string blobName = "identifiers.json";
 
-            using var stream = new MemoryStream();
-            blobClient.DownloadTo(stream);
-            var json = new UTF8Encoding().GetString(stream.ToArray());
+                var raptorStorageConnectionString = config.GetNonEmptyValue("RaptorStorageConnectionString");
+                var blobClient = new BlobClient(raptorStorageConnectionString, blobContainerName, blobName);
+
+                using var stream = new MemoryStream();
+                blobClient.DownloadTo(stream);
+                json = new UTF8Encoding().GetString(stream.ToArray());
+            }
 
             tree = JsonSerializer.Deserialize<IDTree>(json);
         }

--- a/msgraph-sdk-raptor-compiler-lib/appsettings.json
+++ b/msgraph-sdk-raptor-compiler-lib/appsettings.json
@@ -8,5 +8,6 @@
   "Authority": "",
   "Username": "",
   "Password": "",
-  "RaptorStorageConnectionString": ""
+  "RaptorStorageConnectionString": "",
+  "CertificateThumbprint": ""
 }

--- a/msgraph-sdk-raptor-compiler-lib/identifiers.json
+++ b/msgraph-sdk-raptor-compiler-lib/identifiers.json
@@ -430,5 +430,8 @@
   },
   "workforceIntegration": {
     "_value": "<workforceIntegration>"
+  },
+  "oAuth2PermissionGrant": {
+    "_value": "<oAuth2PermissionGrant>"
   }
 }

--- a/msgraph-sdk-raptor-compiler-lib/identifiers.json
+++ b/msgraph-sdk-raptor-compiler-lib/identifiers.json
@@ -1,0 +1,434 @@
+{
+  "application": {
+    "_value": "<application>"
+  },
+  "calendarGroup": {
+    "_value": "<calendarGroup>"
+  },
+  "team": {
+    "_value": "<team>",
+    "channel": {
+      "_value": "<team_channel>",
+      "conversationMember": {
+        "_value": "<team_channel_conversationMember>"
+      }
+    },
+    "teamsAppInstallation": {
+      "_value": "<team_teamsAppInstallation>"
+    },
+    "offerShiftRequest": {
+      "_value": "<team_offerShiftRequest>"
+    },
+    "openShift": {
+      "_value": "<team_openShift>"
+    },
+    "openShiftChangeRequest": {
+      "_value": "<team_openShiftChangeRequest>"
+    },
+    "swapShiftsChangeRequest": {
+      "_value": "<team_swapShiftsChangeRequest>"
+    },
+    "timeOffRequest": {
+      "_value": "<team_timeOffRequest>"
+    },
+    "schedulingGroup": {
+      "_value": "<team_schedulingGroup>"
+    },
+    "shift": {
+      "_value": "<team_shift>"
+    },
+    "conversationMember": {
+      "_value": "<team_conversationMember>"
+    },
+    "timeOff": {
+      "_value": "<team_timeOff>"
+    },
+    "timeOffReason": {
+      "_value": "<team_timeOffReason>"
+    }
+  },
+  "contactFolder": {
+    "_value": "<contactFolder>"
+  },
+  "orgContact": {
+    "_value": "<orgContact>"
+  },
+  "driveItem": {
+    "_value": "<driveItem>",
+    "workbookNamedItem": {
+      "_value": "<driveItem_workbookNamedItem>",
+      "workbookRangeBorder": {
+        "_value": "<driveItem_workbookNamedItem_workbookRangeBorder>"
+      }
+    },
+    "workbookWorksheet": {
+      "_value": "<driveItem_workbookWorksheet>",
+      "workbookChart": {
+        "_value": "<driveItem_workbookWorksheet_workbookChart>",
+        "workbookChartSeries": {
+          "_value": "<driveItem_workbookWorksheet_workbookChart_workbookChartSeries>",
+          "workbookChartPoint": {
+            "_value": "<driveItem_workbookWorksheet_workbookChart_workbookChartSeries_workbookChartPoint>"
+          }
+        }
+      }
+    },
+    "workbookTable": {
+      "_value": "<driveItem_workbookTable>",
+      "workbookTableColumn": {
+        "_value": "<driveItem_workbookTable_workbookTableColumn>"
+      },
+      "workbookTableRow": {
+        "_value": "<driveItem_workbookTable_workbookTableRow>"
+      }
+    },
+    "permission": {
+      "_value": "<driveItem_permission>"
+    },
+    "thumbnailSet": {
+      "_value": "<driveItem_thumbnailSet>",
+      "thumbnailSet": {
+        "_value": "<driveItem_thumbnailSet_thumbnailSet>"
+      }
+    },
+    "workbookComment": {
+      "_value": "<driveItem_workbookComment>",
+      "workbookCommentReply": {
+        "_value": "<driveItem_workbookComment_workbookCommentReply>"
+      }
+    },
+    "driveItemVersion": {
+      "_value": "<driveItem_driveItemVersion>"
+    },
+    "workbookOperation": {
+      "_value": "<driveItem_workbookOperation>"
+    }
+  },
+  "subscription": {
+    "_value": "<subscription>"
+  },
+  "educationClass": {
+    "_value": "<educationClass>"
+  },
+  "educationSchool": {
+    "_value": "<educationSchool>"
+  },
+  "site": {
+    "_value": "<site>",
+    "list": {
+      "_value": "<site_list>",
+      "listItem": {
+        "_value": "<site_list_listItem>",
+        "listItemVersion": {
+          "_value": "<site_list_listItem_listItemVersion>"
+        }
+      }
+    },
+    "permission": {
+      "_value": "<site_permission>"
+    }
+  },
+  "event": {
+    "_value": "<event>"
+  },
+  "message": {
+    "_value": "<message>",
+    "attachment": {
+      "_value": "<message_attachment>"
+    },
+    "extension": {
+      "_value": "<message_extension>"
+    }
+  },
+  "group": {
+    "_value": "<group>",
+    "conversation": {
+      "_value": "<group_conversation>"
+    },
+    "conversationThread": {
+      "_value": "<group_conversationThread>",
+      "post": {
+        "_value": "<group_conversationThread_post>",
+        "extension": {
+          "_value": "<group_conversationThread_post_extension>"
+        }
+      }
+    },
+    "event": {
+      "_value": "<group_event>",
+      "extension": {
+        "_value": "<group_event_extension>"
+      }
+    }
+  },
+  "drive": {
+    "_value": "<drive>",
+    "driveItem": {
+      "_value": "<drive_driveItem>"
+    }
+  },
+  "activityBasedTimeoutPolicy": {
+    "_value": "<activityBasedTimeoutPolicy>"
+  },
+  "administrativeUnit": {
+    "_value": "<administrativeUnit>",
+    "scopedRoleMembership": {
+      "_value": "<administrativeUnit_scopedRoleMembership>"
+    }
+  },
+  "agreement": {
+    "_value": "<agreement>"
+  },
+  "alert": {
+    "_value": "<alert>"
+  },
+  "appConsentRequest": {
+    "_value": "<appConsentRequest>",
+    "userConsentRequest": {
+      "_value": "<appConsentRequest_userConsentRequest>"
+    }
+  },
+  "applicationTemplate": {
+    "_value": "<applicationTemplate>"
+  },
+  "claimsMappingPolicy": {
+    "_value": "<claimsMappingPolicy>"
+  },
+  "homeRealmDiscoveryPolicy": {
+    "_value": "<homeRealmDiscoveryPolicy>"
+  },
+  "tokenIssuancePolicy": {
+    "_value": "<tokenIssuancePolicy>"
+  },
+  "tokenLifetimePolicy": {
+    "_value": "<tokenLifetimePolicy>"
+  },
+  "plannerPlan": {
+    "_value": "<plannerPlan>"
+  },
+  "user": {
+    "_value": "<user>",
+    "calendarPermission": {
+      "_value": "<user_calendarPermission>"
+    },
+    "microsoftAuthenticatorAuthenticationMethod": {
+      "_value": "<user_microsoftAuthenticatorAuthenticationMethod>"
+    },
+    "windowsHelloForBusinessAuthenticationMethod": {
+      "_value": "<user_windowsHelloForBusinessAuthenticationMethod>"
+    },
+    "userScopeTeamsAppInstallation": {
+      "_value": "<user_userScopeTeamsAppInstallation>"
+    }
+  },
+  "call": {
+    "_value": "<call>",
+    "participant": {
+      "_value": "<call_participant>"
+    }
+  },
+  "callRecords.callRecord": {
+    "_value": "<callRecords.callRecord>"
+  },
+  "organization": {
+    "_value": "<organization>",
+    "certificateBasedAuthConfiguration": {
+      "_value": "<organization_certificateBasedAuthConfiguration>"
+    },
+    "organizationalBrandingLocalization": {
+      "_value": "<organization_organizationalBrandingLocalization>"
+    }
+  },
+  "conditionalAccessPolicy": {
+    "_value": "<conditionalAccessPolicy>"
+  },
+  "contact": {
+    "_value": "<contact>"
+  },
+  "contract": {
+    "_value": "<contract>"
+  },
+  "chat": {
+    "_value": "<chat>",
+    "conversationMember": {
+      "_value": "<chat_conversationMember>"
+    },
+    "teamsAppInstallation": {
+      "_value": "<chat_teamsAppInstallation>"
+    },
+    "teamsTab": {
+      "_value": "<chat_teamsTab>"
+    }
+  },
+  "namedLocation": {
+    "_value": "<namedLocation>"
+  },
+  "dataPolicyOperation": {
+    "_value": "<dataPolicyOperation>"
+  },
+  "device": {
+    "_value": "<device>"
+  },
+  "directoryObject": {
+    "_value": "<directoryObject>"
+  },
+  "directoryAudit": {
+    "_value": "<directoryAudit>"
+  },
+  "directoryRole": {
+    "_value": "<directoryRole>"
+  },
+  "directoryRoleTemplate": {
+    "_value": "<directoryRoleTemplate>"
+  },
+  "printer": {
+    "_value": "<printer>",
+    "printJob": {
+      "_value": "<printer_printJob>",
+      "printDocument": {
+        "_value": "<printer_printJob_printDocument>"
+      }
+    },
+    "printTaskTrigger": {
+      "_value": "<printer_printTaskTrigger>"
+    }
+  },
+  "domain": {
+    "_value": "<domain>"
+  },
+  "educationUser": {
+    "_value": "<educationUser>"
+  },
+  "threatAssessmentRequest": {
+    "_value": "<threatAssessmentRequest>"
+  },
+  "featureRolloutPolicy": {
+    "_value": "<featureRolloutPolicy>"
+  },
+  "authenticationMethodConfiguration": {
+    "_value": "<authenticationMethodConfiguration>"
+  },
+  "groupLifecyclePolicy": {
+    "_value": "<groupLifecyclePolicy>"
+  },
+  "groupSetting": {
+    "_value": "<groupSetting>"
+  },
+  "groupSettingTemplate": {
+    "_value": "<groupSettingTemplate>"
+  },
+  "identityProvider": {
+    "_value": "<identityProvider>"
+  },
+  "todoTaskList": {
+    "_value": "<todoTaskList>",
+    "todoTask": {
+      "_value": "<todoTaskList_todoTask>",
+      "linkedResource": {
+        "_value": "<todoTaskList_todoTask_linkedResource>"
+      }
+    }
+  },
+  "mailFolder": {
+    "_value": "<mailFolder>",
+    "messageRule": {
+      "_value": "<mailFolder_messageRule>"
+    }
+  },
+  "notebook": {
+    "_value": "<notebook>"
+  },
+  "onenoteOperation": {
+    "_value": "<onenoteOperation>"
+  },
+  "outlookCategory": {
+    "_value": "<outlookCategory>"
+  },
+  "servicePrincipal": {
+    "_value": "<servicePrincipal>"
+  },
+  "permissionGrantPolicy": {
+    "_value": "<permissionGrantPolicy>"
+  },
+  "workbookWorksheet": {
+    "_value": "<workbookWorksheet>",
+    "workbookPivotTable": {
+      "_value": "<workbookWorksheet_workbookPivotTable>"
+    }
+  },
+  "plannerTask": {
+    "_value": "<plannerTask>"
+  },
+  "plannerBucket": {
+    "_value": "<plannerBucket>"
+  },
+  "printConnector": {
+    "_value": "<printConnector>"
+  },
+  "printerShare": {
+    "_value": "<printerShare>"
+  },
+  "printOperation": {
+    "_value": "<printOperation>"
+  },
+  "printService": {
+    "_value": "<printService>",
+    "printServiceEndpoint": {
+      "_value": "<printService_printServiceEndpoint>"
+    }
+  },
+  "printTaskDefinition": {
+    "_value": "<printTaskDefinition>",
+    "printTask": {
+      "_value": "<printTaskDefinition_printTask>"
+    }
+  },
+  "printUsageByPrinter": {
+    "_value": "<printUsageByPrinter>"
+  },
+  "printUsageByUser": {
+    "_value": "<printUsageByUser>"
+  },
+  "onenoteResource": {
+    "_value": "<onenoteResource>"
+  },
+  "place": {
+    "_value": "<place>"
+  },
+  "schemaExtension": {
+    "_value": "<schemaExtension>"
+  },
+  "onenoteSection": {
+    "_value": "<onenoteSection>"
+  },
+  "sectionGroup": {
+    "_value": "<sectionGroup>"
+  },
+  "secureScore": {
+    "_value": "<secureScore>"
+  },
+  "secureScoreControlProfile": {
+    "_value": "<secureScoreControlProfile>"
+  },
+  "sharedDriveItem": {
+    "_value": "<sharedDriveItem>"
+  },
+  "signIn": {
+    "_value": "<signIn>"
+  },
+  "subscribedSku": {
+    "_value": "<subscribedSku>"
+  },
+  "teamsApp": {
+    "_value": "<teamsApp>",
+    "teamsAppDefinition": {
+      "_value": "<teamsApp_teamsAppDefinition>"
+    }
+  },
+  "presence": {
+    "_value": "<presence>"
+  },
+  "workforceIntegration": {
+    "_value": "<workforceIntegration>"
+  }
+}

--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -21,6 +21,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="identifiers.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -1,0 +1,264 @@
+$appSettingsPath = Join-Path $PSScriptRoot "../msgraph-sdk-raptor-compiler-lib/appsettings.json"
+$appSettings = Get-Content $appSettingsPath | ConvertFrom-Json
+
+if ( !$appSettings.CertificateThumbprint -or !$appSettings.ClientID -or !$appSettings.Username -or !$appSettings.TenantID)
+{
+    Write-Error -ErrorAction Stop -Message "please provide CertificateThumbprint, ClientID, Username and TenantID in appsettings.json"
+}
+
+$identifiersPath = Join-Path $PSScriptRoot "../msgraph-sdk-raptor-compiler-lib/identifiers.json"
+$identifiers = Get-Content $identifiersPath | ConvertFrom-Json
+
+$admin = "MOD Administrator"
+$domain = $appSettings.Username.Split("@")[1]
+$identifiers.domain._value = $domain
+
+function req
+{
+    param(
+        [string]$version = "v1.0",
+        [PSCustomObject]$headers = @{},
+        [string]$url
+    )
+
+    $response = Invoke-MgGraphRequest -Headers $headers -Method GET -Uri "https://graph.microsoft.com/$version/$url" -OutputType PSObject
+    $response.value
+}
+
+Connect-MgGraph -CertificateThumbprint $appSettings.CertificateThumbprint -ClientId $appSettings.ClientID -TenantId $appSettings.TenantID
+
+$user = req -url "users"  |
+    Where-Object { $_.displayName -eq $admin}
+    Select-Object -First 1
+$user.id
+$identifiers.user._value = $user.id
+
+$team = req -url "groups" |
+    Where-Object { $_.resourceProvisioningOptions -eq "Team" -and $_.displayName -eq "U.S. Sales"} |
+    Select-Object -First 1
+$team.id
+$identifiers.team._value = $team.id
+$identifiers.group._value = $team.id
+
+$channel = req -url "teams/$($team.id)/channels" |
+    Where-Object { $_.displayName -eq "Sales West"}
+    Select-Object -First 1
+$channel.id
+$identifiers.team.channel._value = $channel.id
+
+$member = req -url "teams/$($team.id)/channels/$($channel.id)/members" |
+    Where-Object { $_.displayName -eq "MOD Administrator"}
+    Select-Object -First 1
+$member.id
+$identifiers.team.channel.conversationMember._value = $member.id
+$identifiers.team.conversationMember._value = $member.id
+
+$installedApp = req -url "teams/$($team.id)/installedApps" |
+    Select-Object -First 1
+$installedApp.id
+$identifiers.team.teamsAppInstallation._value = $installedApp.id
+
+$drive = req -url "drives" |
+    Where-Object { $_.createdBy.user.displayName -eq $admin } |
+    Select-Object -First 1
+$drive.id
+$identifiers.drive._value = $drive.id
+
+$driveItem = req -url "drives/$($drive.id)/root/children" |
+    Where-Object { $_.name -eq "Blog Post preview.docx" } |
+    Select-Object -First 1
+$driveItem.id
+$identifiers.drive.driveItem._value = $driveItem.id
+
+$thumbnailSet = req -url "drives/$($drive.id)/items/$($driveItem.id)/thumbnails" |
+    Select-Object -First 1
+$thumbnailSet.id
+$identifiers.driveItem.thumbnailSet._value = $thumbnailSet.id
+
+$permission = req -url "drives/$($drive.id)/items/$($driveItem.id)/permissions" |
+    Select-Object -First 1
+$permission.id
+$identifiers.driveItem.permission._value = $permission.id
+
+$application = req -url "applications" |
+    Where-Object { $_.displayName -eq "Salesforce" } |
+    Select-Object -First 1
+$application.id
+$identifiers.application._value = $application.id
+
+$applicationTemplate = req -url "applicationTemplates?`$filter=(displayName eq 'Microsoft Teams')" |
+    Select-Object -First 1
+$applicationTemplate.id
+$identifiers.applicationTemplate._value = $applicationTemplate.id
+
+$directoryAudit = req -url "auditLogs/directoryAudits?`$top=1" |
+    Select-Object -First 1
+$directoryAudit.id
+$identifiers.directoryAudit._value = $directoryAudit.id
+
+$signIn = req -url "auditLogs/signIns?`$top=1" |
+    Select-Object -First 1
+$signIn.id
+$identifiers.signIn._value = $signIn.id
+
+$contact = req -url "contacts" |
+    Where-Object { $_.displayName -eq "Bob Kelly (TAILSPIN)" } |
+    Select-Object -First 1
+$contact.id
+$identifiers.contact._value = $contact.id
+
+$directoryRole = req -url "directoryRoles" |
+    Where-Object { $_.displayName -eq "Global Administrator" }
+    Select-Object -First 1
+$directoryRole.id
+$identifiers.directoryRole._value = $directoryRole.id
+
+$directoryRoleTemplate = req -url "directoryRoleTemplates" |
+    Where-Object { $_.displayName -eq "Global Administrator" }
+    Select-Object -First 1
+$directoryRoleTemplate.id
+$identifiers.directoryRole._value = $directoryRoleTemplate.id
+
+$educationUser = req -url "education/users" |
+    Where-Object { $_.displayName -eq $admin }
+$educationUser.id
+$identifiers.educationUser._value = $educationUser.id
+
+$conversation = req -url "groups/$($team.id)/conversations" |
+    Where-Object { $_.topic -eq "The new U.S. Sales group is ready" }
+    Select-Object -First 1
+$conversation.id
+$identifiers.group.conversation._value = $conversation.id
+
+$conversationThread = req -url "groups/$($team.id)/conversations/$($conversation.id)/threads"
+    Select-Object -First 1
+$conversationThread.id
+$identifiers.group.conversationThread._value = $conversationThread.id
+
+$post = req -url "groups/$($team.id)/conversations/$($conversation.id)/threads/$($conversationThread.id)/posts" |
+    Where-Object { $_.from.emailAddress.name -eq "U.S. Sales" } |
+    Select-Object -First 1
+$post.id
+$identifiers.group.conversationThread.post._value = $post.id
+
+$conditionalAccessPolicy = req -url "identity/conditionalAccess/policies" |
+    Where-Object { $_.displayName -eq "Office 365 App Control" }
+    Select-Object -First 1
+$conditionalAccessPolicy.id
+$identifiers.conditionalAccessPolicy._value = $conditionalAccessPolicy.id
+
+# not in the default list of identifiers
+# $oauth2PermissionGrant = req -url "oauth2PermissionGrants" |
+#     Where-Object { $_.scope.Trim() -eq "user_impersonation" }
+#     Select-Object -First 1
+# $oauth2PermissionGrant.id
+# $identifiers.oAuth2PermissionGrant._value = $oauth2PermissionGrant.id
+
+$organization = req -url "organization" |
+    Where-Object { $_.displayName -eq "Contoso" } |
+    Select-Object -First 1
+$organization.id
+$identifiers.organization._value = $organization.id
+
+$identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
+
+# $test = req -url "informationProtection/threatAssessmentRequests"
+
+<#
+$msAppActsAsHeader = @{ "MS-APP-ACTS-AS" = $user.id }
+
+$offerShiftRequests = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/offerShiftRequests"
+$offerShiftRequests
+
+$openShiftChangeRequests = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/openShiftChangeRequests"
+$openShiftChangeRequests
+
+$openShifts = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/openShifts"
+$openShifts
+
+$schedulingGroups = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/schedulingGroups"
+$schedulingGroups
+
+$shifts = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/shifts"
+$shifts
+
+$swapShiftsChangeRequests = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/swapShiftsChangeRequests"
+$swapShiftsChangeRequests
+
+$timeOffReasons = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/timeOffReasons"
+$timeOffReasons
+
+$timeOffRequests = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/timeOffRequests"
+$timeOffRequests
+
+$timesOff = req -headers $msAppActsAsHeader -url "teams/$($team.id)/schedule/timesOff"
+$timesOff
+
+$workforceIntegrations = req -headers $msAppActsAsHeader -url "teamwork/workforceIntegrations"
+$workforceIntegrations
+
+$places = req -headers $msAppActsAsHeader -url "places"
+$places
+#>
+
+# data missing
+# $test = req -url "contracts"
+
+# permission missing
+# $test = req -url "dataPolicyOperations"
+
+# data missing - my teams login in one device caused a data entry
+# but the actual data is missing
+# $test = req -url "devices"
+
+# data missing
+# $test = req -url "directory/administrativeUnits"
+
+# can't query
+# $test = req -url "directory/deletedItems"
+
+# can't query
+# $test = req -url "directoryObjects"
+
+# $educationClasses = req -url "education/classes"
+# $educationClasses
+
+# $educationSchools = req -url "education/schools"
+# $educationSchools
+
+# access denied
+# $test = req -url "groups/$($team.id)/events"
+
+# request not supported
+# $extension = req -url "groups/$($team.id)/conversations/$($conversation.id)/threads/$($conversationThread.id)/posts/$($post.id)/extensions" |
+#     Select-Object -First 1
+# $extension.id
+# $identifiers.group.conversationThread.post.extension._value = $extension.id
+
+# resource not found for the segment
+# $groupSetting = req -url "groupSettings" |
+#     Select-Object -First 1
+
+# resource not found for the segment
+# $groupSettingTemplate = req -url "groupSettingTemplates" |
+#     Select-Object -First 1
+
+# no data
+# $namedLocation = req -url "identity/conditionalAccess/namedLocations" |
+#     Select-Object -First 1
+
+# no data
+# $appContentRequest = req -url "identityGovernance/appConsent/appConsentRequests" |
+#     Select-Object -First 1
+
+# 500
+# $agreement = req -url "identityGovernance/termsOfUse/agreements" |
+#     Select-Object -First 1
+
+# no data
+# $identityProvider = req -url "identityProviders" |
+#     Select-Object -First 1
+
+# no data
+# $threatAssessmentRequest = req -url "informationProtection/threatAssessmentRequests" |
+#     Select-Object -First 1

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -192,6 +192,89 @@ $subscribedSku = req -url "subscribedSkus" |
 $subscribedSku.id
 $identifiers.subscribedSku._value = $subscribedSku.id
 
+$site = req -url "sites?search=site" |
+    Where-Object { $_.displayName -eq 'The Landing' }
+    Select-Object -First 1
+$site.id
+$identifiers.site._value = $site.id
+
+$siteList = req -url "sites/$($site.id)/lists" |
+    Where-Object {$_.displayName -eq "Demo Docs"}
+    Select-Object -First 1
+$siteList.id
+$identifiers.site.list._value=$siteList.id
+
+$siteListItem = req -url "sites/$($site.id)/lists/$($siteList.id)/items" |
+    Select-Object -First 1
+$siteListItem.id
+$identifiers.site.list.listItem._value=$siteListItem.id
+
+$siteListItemVersion = req -url "sites/$($site.id)/lists/$($siteList.id)/items/$($siteListItem.id)/versions" |
+    Select-Object -First 1
+$siteListItemVersion.id
+$identifiers.site.list.listItem.listItemVersion._value=$siteListItem.id
+
+#Missing Permission. Need to Create Permission on Root Site
+#Azure AD Permission Issue. 
+#https://docs.microsoft.com/en-us/graph/api/site-post-permissions?view=graph-rest-1.0&tabs=http
+$sitePermission = req -url "sites/$($site.id)/permissions" |
+    Select-Object -First 1
+$sitePermission.id
+$identifiers.site.permission._value=$sitePermission.id
+
+$servicePrincipal = req -url "servicePrincipals" |
+    Where-Object {$_.displayName -eq "Microsoft Insider Risk Management"}
+    Select-Object -First 1
+$servicePrincipal.id
+$identifiers.servicePrincipal._value = $servicePrincipal.id
+
+$permissionGrantPolicy = req -url "policies/permissionGrantPolicies" |
+    Where-Object {$_.displayName -eq "All application permissions, for any client app"}
+    Select-Object -First 1
+$permissionGrantPolicy.id
+$identifiers.permissionGrantPolicy._value = $permissionGrantPolicy.id
+
+#Tenant has no messages with Attachments
+$message = req -url "users/$($identifiers.user._value)/messages?`$orderBy=createdDateTime asc" | 
+    Where-Object {$_.subject -eq "Get started with your new Enterprise Mobility + Security E5 trial"}
+    Select-Object -First 1
+$message.id
+$identifiers.message._value = $message.id
+
+#When Message with attachment is created, this should work
+#TODO: Create Message with Attachment
+$attachmentMessage = req -url "users/$($identifiers.user._value)/messages?`$filter=hasAttachments eq true" | 
+    Select-Object -First 1
+$attachment = req -url "users/$($identifiers.user._value)/messages/$($attachmentMessage.id)/attachments" |
+    Select-Object -First 1
+$identifiers.message.attachment._value = $attachment.id
+
+#OData Request is not Supported. 
+$messageExtensions = req -url "users/$($identifiers.user._value)/messages/$($identifiers.message._value)/extensions" |
+    Select-Object -First 1
+$messageExtensions.id
+$identifiers.message.extension._value = $messageExtensions.id
+
+$calendarGroup = req -url "users/$($identifiers.user._value)/calendarGroups" |
+    Where-Object {$_.name -eq "My Calendars"}
+    Select-Object -First 1
+
+$calendarGroup.id
+$identifiers.calendarGroup._value=$calendarGroup.id
+
+$orgContact = req -url "contacts" |
+    Select-Object -First 1
+
+$orgContact.id
+$identifiers.orgContact._value = $orgContact.id
+
+#Contact Folder is Missing from Tenant
+$contactFolder = req -url "users/$($identifiers.user._value)/contactFolders" | 
+    Select-Object -First 1
+
+$contactFolder.id
+$identifiers.contactFolder._value=$contactFolder.id
+
 $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
 
 # $test = req -url "planner/tasks"

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -402,32 +402,8 @@ $workforceIntegrations
 # no data
 # $test = req -url "policies/tokenLifetimePolicies"
 
-# 403
-# $test = req -url "print/connectors"
-
-# no data
-# $test = req -url "print/printers"
-
-# 403
-# $test = req -url "print/services"
-
-# 403
-# $test = req -url "print/shares"
-
-# 403
-# $test = req -url "print/taskDefinitions"
-
-# 403
-# $test = req -url "reports/dailyPrintUsageByPrinter"
-
-# 403
-# $test = req -url "reports/dailyPrintUsageByUser"
-
 # no data
 # $test = req -url "security/alerts"
-
-# 400 bad request
-# $test = req -url "shares/id"
 
 # no data
 # $test = req -url "subscriptions"
@@ -441,5 +417,3 @@ $workforceIntegrations
 # $test = req -url "users/$($user.id)/calendar/calendarPermissions"
 
 # $test = req -url "subscriptions"
-
-

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -24,9 +24,9 @@ $identifiers.domain._value = $domain
 function req
 {
     param(
+        [string]$url,
         [string]$version = "v1.0",
-        [PSCustomObject]$headers = @{},
-        [string]$url
+        [PSCustomObject]$headers = @{}
     )
 
     $response = Invoke-MgGraphRequest -Headers $headers -Method GET -Uri "https://graph.microsoft.com/$version/$url" -OutputType PSObject

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -359,18 +359,6 @@ $workforceIntegrations
 #     Select-Object -First 1
 
 # no data
-# $appContentRequest = req -url "identityGovernance/appConsent/appConsentRequests" |
-#     Select-Object -First 1
-
-# 500
-# $agreement = req -url "identityGovernance/termsOfUse/agreements" |
-#     Select-Object -First 1
-
-# no data
-# $identityProvider = req -url "identityProviders" |
-#     Select-Object -First 1
-
-# no data
 # $threatAssessmentRequest = req -url "informationProtection/threatAssessmentRequests" |
 #     Select-Object -First 1
 

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -1,3 +1,8 @@
+# - reads data from default data pack in CDX's Enterprise Data Pack.
+# - updates identifiers.json file with IDs obtained from the tenant whose
+#   credentials are given in the appsettings.json file.
+# - uses application permissions to access the data.
+
 $scriptsPath = $PWD.Path
 
 $appSettingsPath = Join-Path $scriptsPath "../msgraph-sdk-raptor-compiler-lib/appsettings.json"

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -34,6 +34,7 @@ $user = req -url "users"  |
     Select-Object -First 1
 $user.id
 $identifiers.user._value = $user.id
+$identifiers.directoryObject._value = $user.id
 
 $calendarPermission = req -url "users/$($user.id)/calendar/calendarPermissions" |
     Select-Object -First 1
@@ -329,9 +330,6 @@ $workforceIntegrations
 
 # can't query
 # $test = req -url "directory/deletedItems"
-
-# can't query
-# $test = req -url "directoryObjects"
 
 # $educationClasses = req -url "education/classes"
 # $educationClasses

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -346,14 +346,6 @@ $workforceIntegrations
 # $extension.id
 # $identifiers.group.conversationThread.post.extension._value = $extension.id
 
-# resource not found for the segment
-# $groupSetting = req -url "groupSettings" |
-#     Select-Object -First 1
-
-# resource not found for the segment
-# $groupSettingTemplate = req -url "groupSettingTemplates" |
-#     Select-Object -First 1
-
 # no data
 # $namedLocation = req -url "identity/conditionalAccess/namedLocations" |
 #     Select-Object -First 1

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -215,12 +215,12 @@ $siteListItemVersion.id
 $identifiers.site.list.listItem.listItemVersion._value=$siteListItem.id
 
 #Missing Permission. Need to Create Permission on Root Site
-#Azure AD Permission Issue. 
+#Azure AD Permission Issue.
 #https://docs.microsoft.com/en-us/graph/api/site-post-permissions?view=graph-rest-1.0&tabs=http
-$sitePermission = req -url "sites/$($site.id)/permissions" |
-    Select-Object -First 1
-$sitePermission.id
-$identifiers.site.permission._value=$sitePermission.id
+# $sitePermission = req -url "sites/$($site.id)/permissions" |
+#     Select-Object -First 1
+# $sitePermission.id
+# $identifiers.site.permission._value=$sitePermission.id
 
 $servicePrincipal = req -url "servicePrincipals" |
     Where-Object {$_.displayName -eq "Microsoft Insider Risk Management"}
@@ -235,7 +235,7 @@ $permissionGrantPolicy.id
 $identifiers.permissionGrantPolicy._value = $permissionGrantPolicy.id
 
 #Tenant has no messages with Attachments
-$message = req -url "users/$($identifiers.user._value)/messages?`$orderBy=createdDateTime asc" | 
+$message = req -url "users/$($identifiers.user._value)/messages?`$orderBy=createdDateTime asc" |
     Where-Object {$_.subject -eq "Get started with your new Enterprise Mobility + Security E5 trial"}
     Select-Object -First 1
 $message.id
@@ -243,17 +243,17 @@ $identifiers.message._value = $message.id
 
 #When Message with attachment is created, this should work
 #TODO: Create Message with Attachment
-$attachmentMessage = req -url "users/$($identifiers.user._value)/messages?`$filter=hasAttachments eq true" | 
+$attachmentMessage = req -url "users/$($identifiers.user._value)/messages?`$filter=hasAttachments eq true" |
     Select-Object -First 1
 $attachment = req -url "users/$($identifiers.user._value)/messages/$($attachmentMessage.id)/attachments" |
     Select-Object -First 1
 $identifiers.message.attachment._value = $attachment.id
 
-#OData Request is not Supported. 
-$messageExtensions = req -url "users/$($identifiers.user._value)/messages/$($identifiers.message._value)/extensions" |
-    Select-Object -First 1
-$messageExtensions.id
-$identifiers.message.extension._value = $messageExtensions.id
+#OData Request is not Supported.
+# $messageExtensions = req -url "users/$($identifiers.user._value)/messages/$($identifiers.message._value)/extensions" |
+#     Select-Object -First 1
+# $messageExtensions.id
+# $identifiers.message.extension._value = $messageExtensions.id
 
 $calendarGroup = req -url "users/$($identifiers.user._value)/calendarGroups" |
     Where-Object {$_.name -eq "My Calendars"}
@@ -269,7 +269,7 @@ $orgContact.id
 $identifiers.orgContact._value = $orgContact.id
 
 #Contact Folder is Missing from Tenant
-$contactFolder = req -url "users/$($identifiers.user._value)/contactFolders" | 
+$contactFolder = req -url "users/$($identifiers.user._value)/contactFolders" |
     Select-Object -First 1
 
 $contactFolder.id

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -275,9 +275,36 @@ $contactFolder = req -url "users/$($identifiers.user._value)/contactFolders" |
 $contactFolder.id
 $identifiers.contactFolder._value=$contactFolder.id
 
-$identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
+#Get Group with plans
+#WorkAround Since highlevel Planner doesn't work without Owner (group or user)
+$groupWithPlan = req -url "groups" |
+    Where-Object {$_.displayName -eq "Mark 8 Project Team"}
+    Select-Object -First 1
+$groupWithPlan.id
+#Get Planner via Group
+#HTTP 401
+$plannerPlan = req -url "groups/$($groupWithPlan.id)/planner/plans" |
+    Where-Object {$_.title -eq "Mark8 project tracking"}
+    Select-Object -First 1
 
-# $test = req -url "planner/tasks"
+$plannerPlan.id
+$identifiers.plannerPlan._value=$plannerPlan.Id
+
+$plannerTask = req -url "groups/$($groupWithPlan.id)/planner/plans/$($plannerPlan.id)/tasks" |
+    Where-Object {$_.title -eq "Organize Catering"}
+    Select-Object -First 1
+
+$plannerTask.id
+$identifiers.plannerTask._value=$plannerTask.Id
+
+$plannerBucket = req -url "groups/$($groupWithPlan.id)/planner/plans/$($plannerPlan.id)/buckets" |
+    Where-Object {$_.title -eq "After party"}
+    Select-Object -First 1
+
+$plannerBucket.id
+$identifiers.plannerBucket._value=$plannerBucket.Id
+
+$identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
 
 <#
 $msAppActsAsHeader = @{ "MS-APP-ACTS-AS" = $user.id }

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -276,6 +276,14 @@ $contactFolder = req -url "users/$($identifiers.user._value)/contactFolders" |
 $contactFolder.id
 $identifiers.contactFolder._value=$contactFolder.id
 
+$place = req -url "places/microsoft.graph.room" |
+    Where-Object {$_.displayName = "Conf Room Rainier"}
+    Select-Object -First 1
+$place.id
+#Places can also be obtained 
+#$place = req -url "places/$($place.id)"
+$identifiers.place._value = $place.id
+
 $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
 
 <#
@@ -311,9 +319,6 @@ $timesOff
 $workforceIntegrations = req -headers $msAppActsAsHeader -url "teamwork/workforceIntegrations"
 $workforceIntegrations
 #>
-
-# $places = req -headers $msAppActsAsHeader -url "places"
-# $places
 
 # data missing
 # $test = req -url "contracts"

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -275,35 +275,6 @@ $contactFolder = req -url "users/$($identifiers.user._value)/contactFolders" |
 $contactFolder.id
 $identifiers.contactFolder._value=$contactFolder.id
 
-#Get Group with plans
-#WorkAround Since highlevel Planner doesn't work without Owner (group or user)
-$groupWithPlan = req -url "groups" |
-    Where-Object {$_.displayName -eq "Mark 8 Project Team"}
-    Select-Object -First 1
-$groupWithPlan.id
-#Get Planner via Group
-#HTTP 401
-$plannerPlan = req -url "groups/$($groupWithPlan.id)/planner/plans" |
-    Where-Object {$_.title -eq "Mark8 project tracking"}
-    Select-Object -First 1
-
-$plannerPlan.id
-$identifiers.plannerPlan._value=$plannerPlan.Id
-
-$plannerTask = req -url "groups/$($groupWithPlan.id)/planner/plans/$($plannerPlan.id)/tasks" |
-    Where-Object {$_.title -eq "Organize Catering"}
-    Select-Object -First 1
-
-$plannerTask.id
-$identifiers.plannerTask._value=$plannerTask.Id
-
-$plannerBucket = req -url "groups/$($groupWithPlan.id)/planner/plans/$($plannerPlan.id)/buckets" |
-    Where-Object {$_.title -eq "After party"}
-    Select-Object -First 1
-
-$plannerBucket.id
-$identifiers.plannerBucket._value=$plannerBucket.Id
-
 $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
 
 <#

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -277,7 +277,7 @@ $contactFolder.id
 $identifiers.contactFolder._value=$contactFolder.id
 
 $place = req -url "places/microsoft.graph.room" |
-    Where-Object {$_.displayName = "Conf Room Rainier"}
+    Where-Object {$_.displayName -eq "Conf Room Rainier"}
     Select-Object -First 1
 $place.id
 #Places can also be obtained 

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -311,8 +311,8 @@ $workforceIntegrations = req -headers $msAppActsAsHeader -url "teamwork/workforc
 $workforceIntegrations
 #>
 
-$places = req -headers $msAppActsAsHeader -url "places"
-$places
+# $places = req -headers $msAppActsAsHeader -url "places"
+# $places
 
 # data missing
 # $test = req -url "contracts"

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -1,3 +1,4 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 # - reads data from default data pack in CDX's Enterprise Data Pack.
 # - updates identifiers.json file with IDs obtained from the tenant whose
 #   credentials are given in the appsettings.json file.

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -376,11 +376,6 @@ $workforceIntegrations
 # $threatAssessmentRequest = req -url "informationProtection/threatAssessmentRequests" |
 #     Select-Object -First 1
 
-# 401 Unauthorized
-# $test = req -url "planner/buckets"
-# $test = req -url "planner/plans"
-# $test = req -url "planner/tasks"
-
 # no data
 # $test = req -url "policies/activityBasedTimeoutPolicies"
 

--- a/scripts/readDefaultData.ps1
+++ b/scripts/readDefaultData.ps1
@@ -137,7 +137,7 @@ $directoryRoleTemplate = req -url "directoryRoleTemplates" |
     Where-Object { $_.displayName -eq "Global Administrator" }
     Select-Object -First 1
 $directoryRoleTemplate.id
-$identifiers.directoryRole._value = $directoryRoleTemplate.id
+$identifiers.directoryRoleTemplate._value = $directoryRoleTemplate.id
 
 $educationUser = req -url "education/users" |
     Where-Object { $_.displayName -eq $admin }

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -34,10 +34,16 @@ function getToken
     }
     else
     {
-        $scopes = Invoke-RestMethod -Method Get -Uri "https://graphexplorerapi.azurewebsites.net/permissions?requesturl=$path&method=$method"
-        $joinedScopeString = $scopes.value |
-            Where-Object { $_.Contains("Read") -and !$_.Contains("Write") } | # same selection as the read-only permissions for the app
-            Join-String -Separator " "
+        try {
+            $scopes = Invoke-RestMethod -Method Get -Uri "https://graphexplorerapi.azurewebsites.net/permissions?requesturl=$path&method=$method"
+            $joinedScopeString = $scopes.value |
+                Where-Object { $_.Contains("Read") -and !$_.Contains("Write") } | # same selection as the read-only permissions for the app
+                Join-String -Separator " "
+        }
+        catch {
+            # try with empty scopes if we can't get permissions from the DevX API
+            $joinedScopeString = ".default"
+        }
     }
 
     $body = "grant_type=$grantType&username=$($appSettings.Username)&password=$($appSettings.Password)&client_id=$($appSettings.ClientID)&scope=$($joinedScopeString)"
@@ -99,4 +105,55 @@ $plannerBucket = reqDelegated -url "planner/plans/$($plannerPlan.id)/buckets" |
 $plannerBucket.id
 $identifiers.plannerBucket._value=$plannerBucket.Id
 
+$driveItem = reqDelegated -url "me/drive/root/children?`$filter=name eq 'Contoso Purchasing Data - Q1.xlsx'" |
+    Select-Object -First 1
+$driveItem.id
+$identifiers.driveItem._value = $driveItem.id
+
+$driveItemPermission = reqDelegated -url "me/drive/items/$($driveItem.id)/permissions" |
+    Select-Object -First 1
+$driveItemPermission.id
+$identifiers.driveItem.permission._value = $driveItemPermission.id
+
+$driveItemThumbnail = reqDelegated -url "me/drive/items/$($driveItem.id)/thumbnails" |
+    Select-Object -First 1
+$driveItemThumbnail.id
+$identifiers.driveItem.thumbnailSet._value = $driveItemThumbnail.id
+
+$driveItemVersion = reqDelegated -url "me/drive/items/$($driveItem.id)/versions" |
+    Select-Object -First 1
+$driveItemVersion.id
+$identifiers.driveItem.driveItemVersion._value = $driveItemVersion.id
+
+$driveItemWorkbookTable = reqDelegated -url "me/drive/items/$($driveItem.id)/workbook/tables" |
+    Where-Object { $_.name -eq "Table1" } |
+    Select-Object -First 1
+$driveItemWorkbookTable.id
+$identifiers.driveItem.workbookTable._value = $driveItemWorkbookTable.id
+
+$tableColumn = reqDelegated -url "me/drive/items/$($driveItem.id)/workbook/tables/$($driveItemWorkbookTable.id)/columns" |
+    Select-Object -First 1
+$tableColumn.id
+$identifiers.driveItem.workbookTable.workbookTableColumn._value = $tableColumn.id
+
+$tableRow = reqDelegated -url "me/drive/items/$($driveItem.id)/workbook/tables/$($driveItemWorkbookTable.id)/rows" |
+    Select-Object -First 1
+$tableRow.'@odata.id'
+$identifiers.driveItem.workbookTable.workbookTableRow._value = $tableRow.'@odata.id'
+
+$worksheet = reqDelegated -url "me/drive/items/$($driveItem.id)/workbook/worksheets" |
+    Where-Object { $_.name -eq "Sheet1" } |
+    Select-Object -First 1
+$worksheet.id
+$identifiers.driveItem.workbookWorksheet._value = $worksheet.id
+
 $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
+
+# no data
+# $driveItemWorkbookNames = reqDelegated -url "me/drive/items/$($driveItem.id)/workbook/names"
+
+# bad request
+# $driveItemWorkbookOperations = reqDelegated -url "me/drive/items/$($driveItem.id)/workbook/operations"
+
+# no data
+# reqDelegated -url "me/drive/items/$($driveItem.id)/workbook/worksheets/$($worksheet.id)/charts"

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -72,9 +72,9 @@ function getToken
 function reqDelegated
 {
     param(
-        [string]$version = "v1.0",
         [string]$url,
-        [string]$scopeOverride
+        [string]$scopeOverride,
+        [string]$version = "v1.0"
     )
 
     Write-Debug "== getting token for $url"

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -55,7 +55,7 @@ function reqDelegated
     )
 
     $token = getToken -path "/$url" -scopeOverride $scopeOverride
-    Connect-MgGraph -AccessToken $token | Write-Host
+    Connect-MgGraph -AccessToken $token | Out-Null
 
     $response = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/$version/$url" -OutputType PSObject
     $response.value
@@ -71,5 +71,32 @@ $todoTaskList = reqDelegated -url "me/todo/lists" -scopeOverride "Tasks.Read" |
     Select-Object -First 1
 $todoTaskList.id
 $identifiers.todoTaskList._value = $todoTaskList.id
+
+#Get Group with plans
+$groupWithPlan = reqDelegated -url "groups" |
+    Where-Object {$_.displayName -eq "Mark 8 Project Team"}
+    Select-Object -First 1
+$groupWithPlan.id
+#Get Planner via Group
+$plannerPlan = reqDelegated -url "groups/$($groupWithPlan.id)/planner/plans" |
+    Where-Object {$_.title -eq "Mark8 project tracking"}
+    Select-Object -First 1
+
+$plannerPlan.id
+$identifiers.plannerPlan._value=$plannerPlan.Id
+
+$plannerTask = reqDelegated -url "planner/plans/$($plannerPlan.id)/tasks" |
+    Where-Object {$_.title -eq "Organize Catering"}
+    Select-Object -First 1
+
+$plannerTask.id
+$identifiers.plannerTask._value=$plannerTask.Id
+
+$plannerBucket = reqDelegated -url "planner/plans/$($plannerPlan.id)/buckets" |
+    Where-Object {$_.name -eq "After party"}
+    Select-Object -First 1
+
+$plannerBucket.id
+$identifiers.plannerBucket._value=$plannerBucket.Id
 
 $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -1,0 +1,61 @@
+$scriptsPath = $PWD.Path
+
+$appSettingsPath = Join-Path $scriptsPath "../msgraph-sdk-raptor-compiler-lib/appsettings.json"
+$appSettings = Get-Content $appSettingsPath | ConvertFrom-Json
+
+if (    !$appSettings.CertificateThumbprint `
+    -or !$appSettings.ClientID `
+    -or !$appSettings.Username `
+    -or !$appSettings.Password `
+    -or !$appSettings.TenantID)
+{
+    Write-Error -ErrorAction Stop -Message "please provide CertificateThumbprint, ClientID, Username, Password and TenantID in appsettings.json"
+}
+
+$identifiersPath = Join-Path $scriptsPath "../msgraph-sdk-raptor-compiler-lib/identifiers.json"
+$identifiers = Get-Content $identifiersPath | ConvertFrom-Json
+
+$domain = $appSettings.Username.Split("@")[1]
+
+function getToken
+{
+    param(
+        [string]$path
+    )
+
+    $tokenEndpoint = "https://login.microsoftonline.com/$domain/oauth2/v2.0/token"
+    $grantType = "password"
+    $method = "GET"
+
+    $scopes = Invoke-RestMethod -Method Get -Uri "https://graphexplorerapi.azurewebsites.net/permissions?requesturl=$path&method=$method"
+    $joinedScopeString = $scopes.value |
+        Where-Object { $_.Contains("Read") -and !$_.Contains("Write") } | # same selection as the read-only permissions for the app
+        Join-String -Separator " "
+
+    $body = "grant_type=$grantType&username=$($appSettings.Username)&password=$($appSettings.Password)&client_id=$($appSettings.ClientID)&scope=$($joinedScopeString)"
+    $token = Invoke-RestMethod -Method Post -Uri $tokenEndpoint -Body $body -ContentType 'application/x-www-form-urlencoded'
+
+    $token.access_token
+}
+
+function reqDelegated
+{
+    param(
+        [string]$version = "v1.0",
+        [string]$url
+    )
+
+    $token = getToken "/$url"
+    Connect-MgGraph -AccessToken $token | Write-Host
+
+    $response = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/$version/$url" -OutputType PSObject
+    $response.value
+}
+
+$calendarGroup = reqDelegated -url "me/calendarGroups" |
+    Where-Object { $_.name -eq "My Calendars" } |
+    Select-Object -First 1
+$calendarGroup.id
+$identifiers.calendarGroup._value = $calendarGroup.id
+
+$identifiers | ConvertTo-Json -Depth 10 > $identifiersPath

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -1,3 +1,4 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 # - reads data from default data pack in CDX's Enterprise Data Pack.
 # - updates identifiers.json file with IDs obtained from the tenant whose
 #   credentials are given in the appsettings.json file.

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -91,6 +91,25 @@ $todoTaskList = reqDelegated -url "me/todo/lists" -scopeOverride "Tasks.Read" |
 $todoTaskList.id
 $identifiers.todoTaskList._value = $todoTaskList.id
 
+# no data
+# $todoTask = reqDelegated -url "me/todo/lists/$($todoTaskList.id)/tasks" -scopeOverride "Tasks.Read"
+
+# no data
+# $linkedResource = reqDelegated -url "me/todo/lists/$($todoTaskList.id)/tasks/$($todoTask.id)/linkedResources" -scopeOverride "Tasks.Read"
+
+# no data
+# $contactFolder = reqDelegated -url "me/contactFolders" # already in readDefaultData under user/contactFolders. Remove this??
+
+# no data
+# $contact = reqDelegated -url "me/contacts?`$top=1"
+
+$mailFolder = reqDelegated -url "me/mailFolders/inbox"
+$mailFolder.id
+$identifiers.mailFolder._value = $mailFolder.id
+
+# no data
+# $messageRule = reqDelegated -url "me/mailFolders/inbox/messageRules"
+
 #Get Group with plans
 $groupWithPlan = reqDelegated -url "groups" |
     Where-Object {$_.displayName -eq "Mark 8 Project Team"}

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -197,3 +197,8 @@ $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
 
 # 500
 # reqDelegated -url "reports/dailyPrintUsageByUser"
+
+# no data
+# reqDelegated -url "identityGovernance/termsOfUse/agreements"
+# reqDelegated -url "identityGovernance/appConsent/appConsentRequests"
+# reqDelegated -url "identityProviders"

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -1,3 +1,8 @@
+# - reads data from default data pack in CDX's Enterprise Data Pack.
+# - updates identifiers.json file with IDs obtained from the tenant whose
+#   credentials are given in the appsettings.json file.
+# - uses delegated permissions to access the data.
+
 $scriptsPath = $PWD.Path
 
 $appSettingsPath = Join-Path $scriptsPath "../msgraph-sdk-raptor-compiler-lib/appsettings.json"

--- a/scripts/readDefaultDataDelegated.ps1
+++ b/scripts/readDefaultDataDelegated.ps1
@@ -172,6 +172,13 @@ $printService = reqDelegated -url "print/services" |
 $printService.id
 $identifiers.printService._value = $printService.id
 
+$groupSettingTemplate = reqDelegated -url "groupSettingTemplates" |
+    Where-Object { $_.displayName -eq "Prohibited Names Settings" } |
+    Select-Object -First 1
+
+$groupSettingTemplate.id
+$identifiers.groupSettingTemplate._value = $groupSettingTemplate.id
+
 $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
 
 # no data
@@ -202,3 +209,6 @@ $identifiers | ConvertTo-Json -Depth 10 > $identifiersPath
 # reqDelegated -url "identityGovernance/termsOfUse/agreements"
 # reqDelegated -url "identityGovernance/appConsent/appConsentRequests"
 # reqDelegated -url "identityProviders"
+
+# no data
+# reqDelegated -url "groupSettings"

--- a/scripts/transformAppSettings.ps1
+++ b/scripts/transformAppSettings.ps1
@@ -2,6 +2,7 @@ param(
     [bool]$IsLocalRun = $false,
     [bool]$GenerateLinqPadOutputInLocalRun = $false,
     [string]$DocsRepoCheckoutDirectory = "C:/github",
+    [string]$CertificateThumbprint = "",
     [Parameter(Mandatory=$true)][string]$TenantID,
     [Parameter(Mandatory=$true)][string]$ClientID,
     [Parameter(Mandatory=$true)][string]$ClientSecret,
@@ -22,6 +23,7 @@ $json = @{
     Password = $Password;
     Authority = $Authority;
     RaptorStorageConnectionString = $RaptorStorageConnectionString;
+    CertificateThumbprint = $CertificateThumbprint
 }
 
 $repoRoot = (Get-Item $MyInvocation.MyCommand.Source).Directory.Parent.FullName


### PR DESCRIPTION
Fixes #271 
Fixes #255

- Creates two Powershell scripts that query existing data in the default data pack.
- Adds the template identifier replacement JSON file
- In local run, the template identifier JSON file is used so that local testing can skip relying on the blob storage.
- Adds more APIs that require delegated permissions. (#164 still needs to be addressed separately) 
- Data that need to be explored are left out as comments intentionally to guide us for pushing those missing data in the next phase of development.