### PR TITLE
Use VsTest with Re-runs, Test Isolation and Parallelization. 

### DIFF
--- a/azure-pipelines/common-templates/use-dotnet-sdk.yml
+++ b/azure-pipelines/common-templates/use-dotnet-sdk.yml
@@ -2,6 +2,4 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk'
   inputs:
-    packageType: sdk
-    version: 5.0.100
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+    version: 5.x

--- a/azure-pipelines/compile-run-tests-template.yml
+++ b/azure-pipelines/compile-run-tests-template.yml
@@ -5,27 +5,57 @@ parameters:
 steps:
 - template: common-templates/use-dotnet-sdk.yml
 
-- task: DotNetCoreCLI@2
+- task: NuGetToolInstaller@1
+  displayName: 'Install Nuget 5.9.x'
   inputs:
-    command: 'build'
-    projects: msgraph-sdk-raptor/**/${{ parameters.projectFileName }}.csproj
-    arguments: '--configuration $(buildConfiguration)'
-  displayName: 'Build Projects'
+     versionSpec: 5.9.1
+     checkLatest: true # Optional
 
-- task: DotNetCoreCLI@2
+- task: NuGetCommand@2
+  displayName: 'Restore Nuget Packages'
   inputs:
-    command: 'test'
-    projects: '**/${{ parameters.projectFileName }}.csproj'
-    arguments: '--configuration $(buildConfiguration) --logger trx --results-directory $(Agent.TempDirectory) --settings $(Build.SourcesDirectory)/msgraph-sdk-raptor/${{ parameters.projectFileName}}/Test.runsettings'
-    publishTestResults: false
-  displayName: '${{ parameters.projectFileName }} ${{ parameters.testType }} Tests'
+    command: 'restore'
+    restoreSolution: '**/*.sln'
+    feedsToUse: 'select'
+
+# Visual Studio build
+# Build with MSBuild and set the Visual Studio version property
+- task: VSBuild@1
+  inputs:
+    solution: '**\*.sln' 
+    vsVersion: 'latest'
+    configuration: $(BuildConfiguration)
+    clean: true
+    restoreNugetPackages: true
+    msbuildArchitecture: x64
+    logProjectEvents: true # Optional
+    logFileVerbosity: 'normal' # Optional. Options: quiet, minimal, normal, detailed, diagnostic
+
+- task: VisualStudioTestPlatformInstaller@1
+  inputs:
+    packageFeedSelector: 'nugetOrg' 
+    versionSelector: 'latestStable' 
+
+- task: VSTest@2
   continueOnError: true
+  inputs:
+    runInParallel: true
+    rerunFailedTests: True
+    rerunFailedThreshold: 40
+    rerunType: basedOnTestFailurePercentage
+    runTestsInIsolation: true
+    diagnosticsEnabled: true
+    rerunMaxAttempts: 10
+    testAssemblyVer2: | # Required when testSelector == TestAssemblies
+      **\*CsharpV1ExecutionTests*.dll
+      !**\*TestAdapter.dll
+      !**\obj\**
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   inputs:
     testResultsFormat: 'VSTest'
     searchFolder: '$(Agent.TempDirectory)'
-    testResultsFiles: '**/*.trx'
+    testResultsFiles: '**/*.trx;**/*-TestResults.xml'
     testRunTitle: '${{ parameters.runName }}'
   displayName: 'Publish Test Results'

--- a/azure-pipelines/csharp-v1-execution-tests.yml
+++ b/azure-pipelines/csharp-v1-execution-tests.yml
@@ -11,8 +11,7 @@ resources:
      name: microsoftgraph/microsoft-graph-docs
      ref: main
 
-pool:
-  vmImage: 'ubuntu-latest'
+pool: MsGraphBuildAgentsWindows
 
 variables:
   buildConfiguration: 'Release'

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -96,13 +96,13 @@ namespace MsGraphSDKSnippetsCompiler
             {
                 metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(graphAssemblyPathBeta, "Microsoft.Graph.Beta.dll")));
             }
-
+            //Compile with Debug for better error feedback.
             var compilation = CSharpCompilation.Create(
                assemblyName,
                syntaxTrees: new[] { syntaxTree },
                references: metadataReferences,
                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                                .WithOptimizationLevel(OptimizationLevel.Release));
+                                .WithOptimizationLevel(OptimizationLevel.Debug));
 
             var (emitResult, assembly) = GetEmitResult(compilation);
             CompilationResultsModel results = GetCompilationResults(emitResult);


### PR DESCRIPTION
VsTest has Retry capabilities, ability to re-run tests based on a failure percentage as well as isolation of tests. 
[VsTest@2](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/vstest?view=azure-devops#arguments)

Change to larger build agent for faster execution. 

Use VsBuild to build solution.
simplify selection of dotnet to latest version.
Compile snippets in Debug mode for better error reporting. 