### PR TITLE
Handle Verbatim Identifiers such as @event

### DIFF
--- a/TestsCommon/AssemblyInfo.cs
+++ b/TestsCommon/AssemblyInfo.cs
@@ -1,2 +1,6 @@
-using System;
+﻿using System;
+using System.Runtime.CompilerServices;
+
 [assembly:CLSCompliant(false)]
+[assembly:InternalsVisibleTo("UnitTests")]
+

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -156,15 +156,7 @@ public class GraphSDKTest
             string resultVariable = null;
             try
             {
-                var resultVariableMatch = ResultVariableRegex.Match(codeToCompile);
-                if (resultVariableMatch.Success)
-                {
-                    resultVariable = resultVariableMatch.Groups[1].Value;
-                }
-                else
-                {
-                    Assert.Fail("Regex {0}, against code {1} Failed", ResultVariablePattern, codeToCompile);
-                }
+                resultVariable = GetResultVariable(codeToCompile);
             }
             catch (Exception e)
             {
@@ -200,15 +192,7 @@ public class GraphSDKTest
             string resultVariable = null;
             try
             {
-                var resultVariableMatch = ResultVariableRegex.Match(codeSnippet);
-                if (resultVariableMatch.Success)
-                {
-                    resultVariable = resultVariableMatch.Groups[1].Value;
-                }
-                else
-                {
-                    Assert.Fail("Regex {0}, against code {1} Failed", ResultVariablePattern, codeSnippet);
-                }
+                resultVariable = GetResultVariable(codeSnippet);
             }
             catch (Exception e)
             {
@@ -221,6 +205,21 @@ public class GraphSDKTest
         return {resultVariable};");
 
             return codeSnippet;
+        }
+        private static string GetResultVariable(string codeToCompile)
+        {
+            string resultVariable = null;
+            var resultVariableMatch = ResultVariableRegex.Match(codeToCompile);
+            if (resultVariableMatch.Success)
+            {
+                resultVariable = resultVariableMatch.Groups[1].Value;
+            }
+            else
+            {
+                Assert.Fail("Regex {0}, against code {1} Failed", ResultVariablePattern, codeToCompile);
+            }
+
+            return resultVariable;
         }
 
         /// <summary>

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -59,12 +59,12 @@ public class GraphSDKTest
         /// <summary>
         /// matches result variable name from code snippets
         /// </summary>
-        private const string ResultVariablePattern = "var ([a-zA-Z0-9]+) = await graphClient";
+        private const string ResultVariablePattern = "var ([@_a-zA-Z][_a-zA-Z0-9]+) = await graphClient";
 
         /// <summary>
         /// compiled version of the regex matching result variable name from code snippets
         /// </summary>
-        private static readonly Regex ResultVariableRegex = new Regex(ResultVariablePattern, RegexOptions.Singleline | RegexOptions.Compiled);
+        internal static readonly Regex ResultVariableRegex = new Regex(ResultVariablePattern, RegexOptions.Singleline | RegexOptions.Compiled);
 
         /// <summary>
         /// 1. Fetches snippet from docs repo
@@ -151,12 +151,20 @@ public class GraphSDKTest
             }
         }
 
-        private static string CaptureUriAndHeadersInException(string codeToCompile)
+        internal static string CaptureUriAndHeadersInException(string codeToCompile)
         {
             string resultVariable = null;
             try
             {
-                resultVariable = ResultVariableRegex.Match(codeToCompile).Groups[1].Value;
+                var resultVariableMatch = ResultVariableRegex.Match(codeToCompile);
+                if (resultVariableMatch.Success)
+                {
+                    resultVariable = resultVariableMatch.Groups[1].Value;
+                }
+                else
+                {
+                    Assert.Fail("Regex {0}, against code {1} Failed", ResultVariablePattern, codeToCompile);
+                }
             }
             catch (Exception e)
             {
@@ -187,12 +195,20 @@ public class GraphSDKTest
         /// <param name="codeSnippet">code snippet</param>
         /// <returns>Code snippet that returns an HttpRequestMessage</returns>
 
-        private static string ReturnHttpRequestMessage(string codeSnippet)
+        internal static string ReturnHttpRequestMessage(string codeSnippet)
         {
             string resultVariable = null;
             try
             {
-                resultVariable = ResultVariableRegex.Match(codeSnippet).Groups[1].Value;
+                var resultVariableMatch = ResultVariableRegex.Match(codeSnippet);
+                if (resultVariableMatch.Success)
+                {
+                    resultVariable = resultVariableMatch.Groups[1].Value;
+                }
+                else
+                {
+                    Assert.Fail("Regex {0}, against code {1} Failed", ResultVariablePattern, codeSnippet);
+                }
             }
             catch (Exception e)
             {
@@ -294,11 +310,11 @@ IAuthenticationProvider authProvider  = null;";
                 LinqTemplateStart
                 + Environment.NewLine
                 + (testData.Version) switch
-                    {
-                        Versions.Beta => "  <NuGetReference Prerelease=\"true\">Microsoft.Graph.Beta</NuGetReference>",
-                        Versions.V1 => "  <NuGetReference>Microsoft.Graph</NuGetReference>",
-                        _ => throw new ArgumentException("unsupported version", nameof(testData))
-                    }
+                {
+                    Versions.Beta => "  <NuGetReference Prerelease=\"true\">Microsoft.Graph.Beta</NuGetReference>",
+                    Versions.V1 => "  <NuGetReference>Microsoft.Graph</NuGetReference>",
+                    _ => throw new ArgumentException("unsupported version", nameof(testData))
+                }
                 + LinqTemplateEnd
                 + codeSnippetFormatted.Replace("\n        ", "\n"));
         }

--- a/UnitTests/CSharpTestRunnerTests.cs
+++ b/UnitTests/CSharpTestRunnerTests.cs
@@ -65,7 +65,7 @@ var ev@ent = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""
         [TestCase("_event", UnderScoreIdentifier, TestName = "_event")]
         public void ShouldCaptureUriAndHeadersInException(string variableName, string testSnippet)
         {
-            CSharpTestRunner.CaptureUriAndHeadersInException(testSnippet);
+            Assert.DoesNotThrow(() => CSharpTestRunner.CaptureUriAndHeadersInException(testSnippet));
         }
 
         [TestCase("@event", VerbatimIdentifer, TestName = "@event")]
@@ -73,7 +73,7 @@ var ev@ent = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""
         [TestCase("_event", UnderScoreIdentifier, TestName = "_event")]
         public void ShouldReturnHttpRequestMessage(string variableName, string testSnippet)
         {
-            CSharpTestRunner.ReturnHttpRequestMessage(testSnippet);
+            Assert.DoesNotThrow(() => CSharpTestRunner.ReturnHttpRequestMessage(testSnippet));
         }
 
         [TestCase("ev@ent", IncorrectVerbatimIdentifier, TestName = "ev@ent", Description = "Incorrect Verbatim Identifier")]

--- a/UnitTests/CSharpTestRunnerTests.cs
+++ b/UnitTests/CSharpTestRunnerTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+
+using NUnit.Framework;
+
+using TestsCommon;
+
+namespace UnitTests
+{
+    /// <summary>
+    ///     Checks that the CSharpTestRunner Regex is able to
+    ///     get identifiers for all identifiers as would be valid C#
+    ///     https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names
+    /// </summary>
+    public class CSharpTestRunnerTests
+    {
+        /// <summary>
+        ///     Verbatim Identifier such as @event
+        ///     https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim
+        /// </summary>
+        private const string VerbatimIdentifer = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var @event = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
+                                .Events[\""<group_event>\""]
+                                .Request()
+                                .GetAsync();
+";
+        private const string UnderScoreIdentifier = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var _event = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
+                                .Events[\""<group_event>\""]
+                                .Request()
+                                .GetAsync();
+";
+        /// <summary>
+        ///     @_event is an allowed identifier
+        /// </summary>
+        private const string VerbatimIdentifierWithUnderScore = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var @_event = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
+                                .Events[\""<group_event>\""]
+                                .Request()
+                                .GetAsync();
+";
+        private const string IncorrectVerbatimIdentifier = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var ev@ent = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
+                                .Events[\""<group_event>\""]
+                                .Request()
+                                .GetAsync();
+";
+
+        [TestCase("@event", VerbatimIdentifer, TestName = "@event")]
+        [TestCase("@_event", VerbatimIdentifierWithUnderScore, TestName = "@_event")]
+        [TestCase("_event", UnderScoreIdentifier, TestName = "_event")]
+        public void ShouldHandleVerbatimVariableIdentifier(string variableName, string testSnippet)
+        {
+            var match = CSharpTestRunner.ResultVariableRegex.Match(testSnippet);
+            Assert.True(match.Success);
+            Assert.AreEqual(match.Groups.Count, 2);
+            Assert.AreEqual(match.Groups[1].Value, variableName);
+        }
+
+        [TestCase("@event", VerbatimIdentifer, TestName = "@event")]
+        [TestCase("@_event", VerbatimIdentifierWithUnderScore, TestName = "@_event")]
+        [TestCase("_event", UnderScoreIdentifier, TestName = "_event")]
+        public void ShouldCaptureUriAndHeadersInException(string variableName, string testSnippet)
+        {
+            CSharpTestRunner.CaptureUriAndHeadersInException(testSnippet);
+        }
+
+        [TestCase("@event", VerbatimIdentifer, TestName = "@event")]
+        [TestCase("@_event", VerbatimIdentifierWithUnderScore, TestName = "@_event")]
+        [TestCase("_event", UnderScoreIdentifier, TestName = "_event")]
+        public void ShouldReturnHttpRequestMessage(string variableName, string testSnippet)
+        {
+            CSharpTestRunner.ReturnHttpRequestMessage(testSnippet);
+        }
+
+        [TestCase("ev@ent", IncorrectVerbatimIdentifier, TestName = "ev@ent", Description = "Incorrect Verbatim Identifier")]
+        public void ShouldFailWhenReturningHttpRequestMessageWithIncorrectSnippet(string variableName, string testSnippet)
+        {
+            Assert.Throws<AssertionException>(() => CSharpTestRunner.ReturnHttpRequestMessage(testSnippet));
+        }
+
+        [TestCase("ev@ent", IncorrectVerbatimIdentifier, TestName = "ev@ent", Description = "Incorrect Verbatim Identifier")]
+        public void ShouldFailWhenCapturingUriWithIncorrectSnippet(string variableName, string testSnippet)
+        {
+            Assert.Throws<AssertionException>(() => CSharpTestRunner.CaptureUriAndHeadersInException(testSnippet));
+        }
+
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -16,20 +16,4 @@
     <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
     <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <None Update="identifiers.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="Snippets\underScoreIdentifier.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="Snippets\nonVerbatimIdentifier.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="Snippets\verbatimIdentifier.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -14,10 +14,20 @@
 
   <ItemGroup>
     <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="identifiers.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Snippets\underScoreIdentifier.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Snippets\nonVerbatimIdentifier.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Snippets\verbatimIdentifier.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Currently Raptor incorrectly handles verbatim identifiers due to the Regex used to handle variable replacement. 

![image](https://user-images.githubusercontent.com/1641829/122104668-97716b00-ce20-11eb-9c39-219bc1358df1.png)

**The correct structure should be:-**

![image](https://user-images.githubusercontent.com/1641829/122104796-ba9c1a80-ce20-11eb-8bfe-2185225e7c51.png)

This PR changes the regex to correctly handle `@event`, `_event` and `@_event`.

**Other Changes**
- Check if Regex passes when replacing variables in C# test runner, throws and reports the error.
- Add tests to verify various cases for verbatim identifiers.