### PR TITLE
Handle Delegated Permissions Requirement for various Entities.

### DIFF
--- a/UnitTests/DelegatedPermissionsTests.cs
+++ b/UnitTests/DelegatedPermissionsTests.cs
@@ -1,0 +1,71 @@
+﻿using MsGraphSDKSnippetsCompiler;
+
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    public class DelegatedPermissionsTests
+    {
+        /// <summary>
+        ///     Schedule Requires Delegated Permission otherwise
+        ///     MS-APP-ACT-AS Header is required
+        /// </summary>
+        private const string Schedule = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var schedule = graphClient.Teams[\""8730b5a6-eca3-400d-9011-1f4202418218\""].Schedule
+                          .Request()
+                          .GetHttpRequestMessage();
+";
+        /// <summary>
+        ///     Children of `Me` should be treated as Delegated
+        /// </summary>
+        private const string People = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var schedule = graphClient.Me.People
+                          .Request()
+                          .GetHttpRequestMessage();
+";
+        /// <summary>
+        ///     Children of `Me` should be treated as Delegated
+        /// </summary>
+        private const string Me = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var schedule = graphClient.Me
+                          .Request()
+                          .GetHttpRequestMessage();
+";
+        /// <summary>
+        ///     Group should not be treated as Delegated
+        /// </summary>
+        private const string Groups = @"
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+var schedule = graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""].Drive
+                          .Request()
+                          .GetHttpRequestMessage();
+";
+
+        /// <summary>
+        ///     All Snippets in Test Cases should be marked as requiring Delegated permission
+        /// </summary>
+        /// <param name="testSnippet"></param>
+        [TestCase(Me)]
+        [TestCase(People)]
+        [TestCase(Schedule)]
+        public void ShouldBeMarkedAsDelegated(string testSnippet)
+        {
+            var requiredDelegatedPermissions = MicrosoftGraphCSharpCompiler.RequiresDelegatedPermissions(testSnippet);
+            Assert.True(requiredDelegatedPermissions);
+        }
+
+        /// <summary>
+        ///     Groups Snippet Should not be marked as Delegated
+        /// </summary>
+        /// <param name="testSnippet"></param>
+        [TestCase(Groups)]
+        public void ShouldNotBeMarkedDelegated(string testSnippet)
+        {
+            var requiredDelegatedPermissions = MicrosoftGraphCSharpCompiler.RequiresDelegatedPermissions(testSnippet);
+            Assert.False(requiredDelegatedPermissions);
+        }
+    }
+}

--- a/msgraph-sdk-raptor-compiler-lib/AssemblyInfo.cs
+++ b/msgraph-sdk-raptor-compiler-lib/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnitTests")]

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -316,8 +316,7 @@ namespace MsGraphSDKSnippetsCompiler
             const RegexOptions regexOptions = RegexOptions.Compiled | RegexOptions.Singleline;
             var apisWithDelegatedPermissions = new[]
             {
-               
-                
+                new Regex(@"^Me", regexOptions),
                 new Regex(@"^Education.Me", regexOptions),
                 new Regex(@"^Users\[",regexOptions),
                 new Regex(@"^Planner",regexOptions),

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -306,27 +306,31 @@ namespace MsGraphSDKSnippetsCompiler
         /// </summary>
         /// <param name="codeSnippet">code snippet</param>
         /// <returns>true if the snippet requires delegated permissions</returns>
-        private static bool RequiresDelegatedPermissions(string codeSnippet)
+        internal static bool RequiresDelegatedPermissions(string codeSnippet)
         {
             // TODO: https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/164
             const string graphClient = "graphClient.";
             var apiPathStart = codeSnippet.IndexOf(graphClient) + graphClient.Length;
             var apiPath = codeSnippet[apiPathStart..];
 
-            var apisWithDelegatedPermissions = new []
+            const RegexOptions regexOptions = RegexOptions.Compiled | RegexOptions.Singleline;
+            var apisWithDelegatedPermissions = new[]
             {
-                "Me",
-                "Education.Me",
-                "Users[",
-                "Planner",
-                "Print",
-                "IdentityProviders",
-                "Reports",
-                "IdentityGovernance",
-                "GroupSetting"
+               
+                
+                new Regex(@"^Education.Me", regexOptions),
+                new Regex(@"^Users\[",regexOptions),
+                new Regex(@"^Planner",regexOptions),
+                new Regex(@"^Print",regexOptions),
+                new Regex(@"^IdentityProviders",regexOptions),
+                new Regex(@"^Reports",regexOptions),
+                new Regex(@"^IdentityGovernance",regexOptions),
+                new Regex(@"^GroupSetting",regexOptions),
+                new Regex(@"^Teams\[[^\]]*\]\.Schedule",regexOptions)
             };
 
-            return apisWithDelegatedPermissions.Any(x => apiPath.StartsWith(x));
+            var matchResult = apisWithDelegatedPermissions.Any(x => x.IsMatch(apiPath));
+            return matchResult;
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -325,7 +325,8 @@ namespace MsGraphSDKSnippetsCompiler
                 new Regex(@"^Reports",regexOptions),
                 new Regex(@"^IdentityGovernance",regexOptions),
                 new Regex(@"^GroupSetting",regexOptions),
-                new Regex(@"^Teams\[[^\]]*\]\.Schedule",regexOptions)
+                new Regex(@"^Teams\[[^\]]*\]\.Schedule",regexOptions),
+                new Regex(@"^Teamwork.WorkforceIntegrations",regexOptions)
             };
 
             var matchResult = apisWithDelegatedPermissions.Any(x => x.IsMatch(apiPath));


### PR DESCRIPTION
Scheduling APIs under Teams require Delegated permissions or specification of `MS-APP-ACT-AS`. 
Previously raptor used a checklist of strings to check whether the snippet required Delegated Permissions, the string is limited for cases such as:-
```
GraphServiceClient graphClient = new GraphServiceClient( authProvider );
var schedule = graphClient.Teams[\""8730b5a6-eca3-400d-9011-1f4202418218\""].Schedule
                          .Request()
                          .GetHttpRequestMessage();
```

Where Its the navigation property `Schedule` that requires delegated permissions. Thus a regex serves this scenario better to be able to specify the navigation property instead. 

This change enables the following tests to pass:-
- schedule-get-csharp-V1-compiles Success: [Docs Link](https://docs.microsoft.com/en-us/graph/api/schedule-get?view=graph-rest-1.0&tabs=csharp)
- schedule-get-schedulinggroups-csharp-V1-compiles Success: [Docs Link](https://docs.microsoft.com/en-us/graph/api/schedulinggroup-get?view=graph-rest-1.0&tabs=csharp)
- schedule-list-schedulinggroups-csharp-V1-compiles Success: [Docs Link](https://docs.microsoft.com/en-us/graph/api/schedule-list-schedulinggroups?view=graph-rest-1.0&tabs=csharp)
- schedule-list-shifts-csharp-V1-compiles Success: [Docs Link](https://docs.microsoft.com/en-us/graph/api/schedule-list-shifts?view=graph-rest-1.0&tabs=csharp)
- schedule-list-timeoffreasons-csharp-V1-compiles Success: [Docs Link](https://docs.microsoft.com/en-us/graph/api/schedule-list-timeoffreasons?view=graph-rest-1.0&tabs=csharp)
- schedule-list-timesoff-csharp-V1-compiles Success: [Docs Link](https://docs.microsoft.com/en-us/graph/api/schedule-list-timesoff?view=graph-rest-1.0&tabs=csharp)
-  get-workforceintegrations-csharp-V1-compiles Success: [Docs Link](https://docs.microsoft.com/en-us/graph/api/workforceintegration-list?view=graph-rest-1.0&tabs=csharp)
