### PR TITLE
IdentifierReplacer throwing `KeyNotFoundException`

### DIFF
--- a/UnitTests/IdentiferReplacerTests.cs
+++ b/UnitTests/IdentiferReplacerTests.cs
@@ -27,10 +27,13 @@ namespace UnitTests
                   "https://graph.microsoft.com/v1.0/chats/<chat>/members/<chat_conversationMember>")]
         [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/members/{conversationMember-id}",
                   "https://graph.microsoft.com/v1.0/teams/<team>/members/<team_conversationMember>")]
+        [TestCase("https://graph.microsoft.com/v1.0/education/schools/{educationSchool-id}/users",
+                  "https://graph.microsoft.com/v1.0/education/schools/<educationSchool>/users")]
         public void TestIds(string snippetUrl, string expectedUrl)
         {
             var newUrl = idReplacer.ReplaceIds(snippetUrl);
             Assert.AreEqual(expectedUrl, newUrl);
         }
+
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+
 using Azure.Storage.Blobs;
 
 namespace MsGraphSDKSnippetsCompiler.Models
@@ -14,7 +15,7 @@ namespace MsGraphSDKSnippetsCompiler.Models
         /// </summary>
         public static IdentifierReplacer Instance => lazy.Value;
 
-        private static readonly Lazy<IdentifierReplacer> lazy = new (() => new IdentifierReplacer());
+        private static readonly Lazy<IdentifierReplacer> lazy = new(() => new IdentifierReplacer());
 
         /// <summary>
         /// tree of IDs that appear in sample Graph URLs
@@ -82,8 +83,12 @@ namespace MsGraphSDKSnippetsCompiler.Models
                 var id = match.Groups[0].Value;     // e.g. {site-id}
                 var idType = match.Groups[1].Value; // e.g. extract site from {site-id}
 
-                currentIdNode = currentIdNode[idType];
-                input = input.Replace(id, currentIdNode.Value);
+                var exists = currentIdNode.TryGetValue(idType, out IDTree localTree);
+                if (exists && localTree != null)
+                {
+                    currentIdNode = localTree;
+                    input = input.Replace(id, currentIdNode.Value);
+                }
             }
 
             return input;

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -84,7 +84,7 @@ namespace MsGraphSDKSnippetsCompiler.Models
                 var idType = match.Groups[1].Value; // e.g. extract site from {site-id}
 
                 var exists = currentIdNode.TryGetValue(idType, out IDTree localTree);
-                if (exists && localTree != null)
+                if (exists)
                 {
                     currentIdNode = localTree;
                     input = input.Replace(id, currentIdNode.Value);

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -83,8 +83,8 @@ namespace MsGraphSDKSnippetsCompiler.Models
                 var id = match.Groups[0].Value;     // e.g. {site-id}
                 var idType = match.Groups[1].Value; // e.g. extract site from {site-id}
 
-                var exists = currentIdNode.TryGetValue(idType, out IDTree localTree);
-                if (exists)
+                currentIdNode.TryGetValue(idType, out IDTree localTree);
+                if (localTree != null)
                 {
                     currentIdNode = localTree;
                     input = input.Replace(id, currentIdNode.Value);

--- a/msgraph-sdk-raptor-compiler-lib/identifiers.json
+++ b/msgraph-sdk-raptor-compiler-lib/identifiers.json
@@ -108,7 +108,16 @@
     "_value": "<subscription>"
   },
   "educationClass": {
-    "_value": "<educationClass>"
+    "_value": "<educationClass>",
+    "educationAssignment": {
+      "_value": "<educationAssignment>",
+      "educationSubmission": {
+        "_value": "<educationSubmission>",
+        "educationSubmissionResource": {
+          "_value": "<educationSubmissionResource>"
+        } 
+      } 
+    } 
   },
   "educationSchool": {
     "_value": "<educationSchool>"


### PR DESCRIPTION
IdentifierReplacer throwing `KeyNotFoundException` for tests whose entity key is not in IDTree(Identifiers.json).
Handle case when Key is not found. 
Add test to verify scenario.

![image](https://user-images.githubusercontent.com/1641829/123004206-f86ae700-d3bc-11eb-8c5b-405523ce0820.png)


Add missing entities to identifiers tree to resolve `KeyNotFoundException`
- EducationClass
- EducationAssignment
- EducationSubmission
- educationSubmissionResource