### PR TITLE
When no scopes are returned default to default scope.

### DIFF
--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -213,12 +213,12 @@ namespace MsGraphSDKSnippetsCompiler
                     .Select(x => $"https://graph.microsoft.com/{ x.value }")
                     .ToArray();
 
-                return fullReadScopes.Length == 0 ? null : fullReadScopes;
+                return fullReadScopes.Length == 0 ? new[] { DefaultAuthScope } : fullReadScopes;
             }
             catch (Exception)
             {
                 // some URLs don't return scopes from the permissions endpoint of DevX API
-                return null;
+                return new[] { DefaultAuthScope };
             }
         }
 
@@ -233,7 +233,7 @@ namespace MsGraphSDKSnippetsCompiler
         /// <returns>token for the given context</returns>
         static string GetATokenForGraph(string clientId, string authority, string username, string password, string[] scopes)
         {
-            lock(tokenLock)
+            lock (tokenLock)
             {
                 var scopesSorted = scopes.ToList();
                 scopesSorted.Sort();
@@ -326,7 +326,8 @@ namespace MsGraphSDKSnippetsCompiler
                 new Regex(@"^IdentityGovernance",regexOptions),
                 new Regex(@"^GroupSetting",regexOptions),
                 new Regex(@"^Teams\[[^\]]*\]\.Schedule",regexOptions),
-                new Regex(@"^Teamwork.WorkforceIntegrations",regexOptions)
+                new Regex(@"^Teamwork.WorkforceIntegrations",regexOptions),
+                new Regex(@"^Communications.Presences\[[^\]]*\]",regexOptions)
             };
 
             var matchResult = apisWithDelegatedPermissions.Any(x => x.IsMatch(apiPath));


### PR DESCRIPTION
Due to missing permissions, DevX sometimes does not return requested permissions. 
As such default to the default scope ("https://graph.microsoft.com/.default") whenever:-
- DevX is unreachable 
- DevX returns HTTP 500

This change unblocks a significant number of tests such as:-
- get-user-presences-csharp-V1-compiles

Yields a significant jump from **~47pc to ~54pc.**
***Previous Run***
![image](https://user-images.githubusercontent.com/1641829/124199168-fef31000-dada-11eb-8efc-9ea351547fb9.png)
***This Run***
![image](https://user-images.githubusercontent.com/1641829/124199105-dc60f700-dada-11eb-9603-a779f60efad2.png)

