### PR TITLE
Revert "modify prerelease package updater to special case 4.0.0"

### DIFF
--- a/scripts/PrereleasePackageUpdater.ps1
+++ b/scripts/PrereleasePackageUpdater.ps1
@@ -8,30 +8,5 @@ $projectFile = "msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.
 foreach ($package in $packages)
 {
     dotnet remove $projectFile package $package
-
-    if ($package -eq "Microsoft.Graph.Beta")
-    {
-        $lowerCasePackage = $package.ToLower()
-        $nugetUrl = "https://api.nuget.org/v3/registration5-gz-semver2/$lowerCasePackage/index.json"
-        $res = Invoke-RestMethod $nugetUrl
-        $skipVersion = [version]"4.0.0"
-        $allVersionsLessThan4 = $res.items.items.catalogEntry.version | ForEach-Object {
-            if ($_.Contains("preview"))
-            {
-                $ver = [version]($_.Replace("-preview", ""))
-                if ($ver -lt $skipVersion)
-                {
-                    return $ver
-                }
-            }
-        }
-
-        $latestVersion = ($allVersionsLessThan4 | Sort-Object -Descending)[0].ToString()
-
-        dotnet add $projectFile package $package --version "$latestVersion-preview"
-    }
-    else
-    {
-        dotnet add $projectFile package $package --prerelease
-    }
+    dotnet add $projectFile package $package --prerelease
 }


### PR DESCRIPTION
.NET v4 release made the special case stale, so reverting that.

cc: @baywet @andrueastman 