### PR TITLE
Separate execution known issues

### DIFF
--- a/CSharpArbitraryDllTests/Test.runsettings
+++ b/CSharpArbitraryDllTests/Test.runsettings
@@ -6,7 +6,7 @@
   <TestRunParameters>
     <Parameter name="Version" value="---VersionPlaceholder---" />
     <Parameter name="DllPath" value="---DllPathPlaceholder---" />
-    <Parameter name="KnownFailuresRequested" value="---KnownFailuresRequestedPlaceholder---" />
+    <Parameter name="TestType" value="---TestTypePlaceholder---" />
     <Parameter name="Language" value="---LanguagePlaceHolder---" />
   </TestRunParameters>
 </RunSettings>

--- a/CsharpBetaExecutionKnownFailureTests/AssemblyInfo.cs
+++ b/CsharpBetaExecutionKnownFailureTests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using NUnit.Framework;
+[assembly: Parallelizable(ParallelScope.All)]

--- a/CsharpBetaExecutionKnownFailureTests/CsharpBetaExecutionKnownFailureTests.csproj
+++ b/CsharpBetaExecutionKnownFailureTests/CsharpBetaExecutionKnownFailureTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
+++ b/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using MsGraphSDKSnippetsCompiler.Models;
+
+using NUnit.Framework;
+
+using TestsCommon;
+
+namespace CsharpBetaExecutionKnownFailureTests
+{
+    [TestFixture]
+    public class SnippetExecutionBetaKnownFailureTests
+    {
+        private IConfidentialClientApplication _confidentialClientApp;
+        private IPublicClientApplication _publicClientApp;
+        private RaptorConfig _raptorConfig;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            _raptorConfig = TestsSetup.GetConfig();
+            _publicClientApp = TestsSetup.SetupPublicClientApp(_raptorConfig);
+            _confidentialClientApp = TestsSetup.SetupConfidentialClientApp(_raptorConfig);
+        }
+
+        /// <summary>
+        /// Gets TestCaseData for Beta
+        /// TestCaseData contains snippet file name, version and test case name
+        /// </summary>
+        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetExecutionTestData(
+            new RunSettings
+            {
+                Version = Versions.Beta,
+                Language = Languages.CSharp,
+                KnownFailuresRequested = false,
+                ExecutionKnownFailuresRequested = true
+            });
+
+        /// <summary>
+        /// Represents test runs generated from test case data
+        /// </summary>
+        /// <param name="fileName">snippet file name in docs repo</param>
+        /// <param name="docsLink">documentation page where the snippet is shown</param>
+        /// <param name="version">Docs version (e.g. V1, Beta)</param>
+        [Test]
+        [RetryTestCaseSource(typeof(SnippetExecutionBetaKnownFailureTests), nameof(TestDataBeta), MaxTries = 3)]
+        public async Task Test(ExecutionTestData testData)
+        {
+            await CSharpTestRunner.Execute(testData, _raptorConfig, _publicClientApp, _confidentialClientApp);
+        }
+    }
+}

--- a/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
+++ b/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
@@ -33,8 +33,7 @@ namespace CsharpBetaExecutionKnownFailureTests
             {
                 Version = Versions.Beta,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = false,
-                ExecutionKnownFailuresRequested = true
+                TestType = TestType.ExecutionKnownIssues
             });
 
         /// <summary>

--- a/CsharpBetaExecutionKnownFailureTests/Test.runsettings
+++ b/CsharpBetaExecutionKnownFailureTests/Test.runsettings
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>

--- a/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
+++ b/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
@@ -33,7 +33,7 @@ namespace CsharpBetaExecutionTests
             {
                 Version = Versions.Beta,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = false
+                TestType = TestType.ExecutionStable
             });
 
         /// <summary>

--- a/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
+++ b/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
@@ -19,7 +19,7 @@ namespace CsharpBetaKnownFailureTests
             {
                 Version = Versions.Beta,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = true
+                TestType = TestType.CompilationKnownIssues
             });
 
         /// <summary>

--- a/CsharpBetaTests/SnippetCompileBetaTests.cs
+++ b/CsharpBetaTests/SnippetCompileBetaTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
@@ -19,7 +19,7 @@ namespace CsharpBetaTests
             {
                 Version = Versions.Beta,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = false
+                TestType = TestType.CompilationStable
             });
 
         /// <summary>

--- a/CsharpV1ExecutionKnownFailureTests/AssemblyInfo.cs
+++ b/CsharpV1ExecutionKnownFailureTests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using NUnit.Framework;
+[assembly: Parallelizable(ParallelScope.All)]

--- a/CsharpV1ExecutionKnownFailureTests/CsharpV1ExecutionKnownFailureTests.csproj
+++ b/CsharpV1ExecutionKnownFailureTests/CsharpV1ExecutionKnownFailureTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+    <ProjectReference Include="..\TestsCommon\TestsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
+++ b/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
@@ -31,8 +31,7 @@ namespace CsharpV1ExecutionKnownFailureTests
             {
                 Version = Versions.V1,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = false,
-                ExecutionKnownFailuresRequested = true
+                TestType = TestType.ExecutionKnownIssues
             });
 
         /// <summary>

--- a/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
+++ b/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.Identity.Client;
+using MsGraphSDKSnippetsCompiler.Models;
+using NUnit.Framework;
+using TestsCommon;
+
+namespace CsharpV1ExecutionKnownFailureTests
+{
+    [TestFixture]
+    public class SnippetExecutionV1KnownFailureTests
+    {
+        private RaptorConfig _raptorConfig;
+        private IPublicClientApplication _publicClientApp;
+        private IConfidentialClientApplication _confidentialClientApp;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            _raptorConfig = TestsSetup.GetConfig();
+            _publicClientApp = TestsSetup.SetupPublicClientApp(_raptorConfig);
+            _confidentialClientApp = TestsSetup.SetupConfidentialClientApp(_raptorConfig);
+        }
+        /// <summary>
+        /// Gets TestCaseData for V1
+        /// TestCaseData contains snippet file name, version and test case name
+        /// </summary>
+        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetExecutionTestData(
+            new RunSettings
+            {
+                Version = Versions.V1,
+                Language = Languages.CSharp,
+                KnownFailuresRequested = false,
+                ExecutionKnownFailuresRequested = true
+            });
+
+        /// <summary>
+        /// Represents test runs generated from test case data
+        /// </summary>
+        /// <param name="fileName">snippet file name in docs repo</param>
+        /// <param name="docsLink">documentation page where the snippet is shown</param>
+        /// <param name="version">Docs version (e.g. V1, Beta)</param>
+        [Test]
+        [RetryTestCaseSource(typeof(SnippetExecutionV1KnownFailureTests), nameof(TestDataV1), MaxTries = 3)]
+        public async Task Test(ExecutionTestData testData)
+        {
+            await CSharpTestRunner.Execute(testData, _raptorConfig, _publicClientApp, _confidentialClientApp);
+        }
+    }
+}

--- a/CsharpV1ExecutionKnownFailureTests/Test.runsettings
+++ b/CsharpV1ExecutionKnownFailureTests/Test.runsettings
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>

--- a/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
+++ b/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
@@ -31,7 +31,7 @@ namespace CsharpV1ExecutionTests
             {
                 Version = Versions.V1,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = false
+                TestType = TestType.ExecutionStable
             });
 
         /// <summary>

--- a/CsharpV1KnownFailureTests/KnownFailuresV1.cs
+++ b/CsharpV1KnownFailureTests/KnownFailuresV1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
@@ -19,7 +19,7 @@ namespace CsharpV1KnownFailureTests
             {
                 Version = Versions.V1,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = true
+                TestType = TestType.CompilationKnownIssues
             });
 
         /// <summary>

--- a/CsharpV1Tests/SnippetCompileV1Tests.cs
+++ b/CsharpV1Tests/SnippetCompileV1Tests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
@@ -19,7 +19,7 @@ namespace CsharpV1Tests
             {
                 Version = Versions.V1,
                 Language = Languages.CSharp,
-                KnownFailuresRequested = false
+                TestType = TestType.CompilationStable
             });
 
         /// <summary>

--- a/JavaBetaKnownFailureTests/KnownFailuresBeta.cs
+++ b/JavaBetaKnownFailureTests/KnownFailuresBeta.cs
@@ -1,4 +1,4 @@
-using MsGraphSDKSnippetsCompiler.Models;
+﻿using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
@@ -17,7 +17,7 @@ namespace JavaBetaKnownFailureTests
             {
                 Version = Versions.Beta,
                 Language = Languages.Java,
-                KnownFailuresRequested = true
+                TestType = TestType.CompilationKnownIssues
             });
 
         /// <summary>

--- a/JavaBetaKnownFailureTests/Test.runsettings
+++ b/JavaBetaKnownFailureTests/Test.runsettings
@@ -6,7 +6,7 @@
   <TestRunParameters>
     <Parameter name="Version" value="---VersionPlaceholder---" />
     <Parameter name="DllPath" value="C:/sources/github" />
-    <Parameter name="KnownFailuresRequested" value="---KnownFailuresRequestedPlaceholder---" />
+    <Parameter name="TestType" value="---TestTypePlaceholder---" />
     <Parameter name="Language" value="---LanguagePlaceHolder---" />
     <Parameter name="JavaCoreVersion" value="---JavaCoreVersionPlaceHolder---" />
     <Parameter name="JavaLibVersion" value="---JavaLibVersionPlaceHolder---" />

--- a/JavaBetaTests/SnippetCompileBetaTests.cs
+++ b/JavaBetaTests/SnippetCompileBetaTests.cs
@@ -1,4 +1,4 @@
-using MsGraphSDKSnippetsCompiler.Models;
+﻿using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
@@ -17,7 +17,7 @@ namespace JavaBetaTests
             {
                 Version = Versions.Beta,
                 Language = Languages.Java,
-                KnownFailuresRequested = false
+                TestType = TestType.CompilationStable
             });
 
         /// <summary>

--- a/JavaBetaTests/Test.runsettings
+++ b/JavaBetaTests/Test.runsettings
@@ -6,7 +6,7 @@
   <TestRunParameters>
     <Parameter name="Version" value="---VersionPlaceholder---" />
     <Parameter name="DllPath" value="C:/sources/github" />
-    <Parameter name="KnownFailuresRequested" value="---KnownFailuresRequestedPlaceholder---" />
+    <Parameter name="TestType" value="---TestTypePlaceholder---" />
     <Parameter name="Language" value="---LanguagePlaceHolder---" />
     <Parameter name="JavaCoreVersion" value="---JavaCoreVersionPlaceHolder---" />
     <Parameter name="JavaLibVersion" value="---JavaLibVersionPlaceHolder---" />

--- a/JavaV1KnownFailureTests/KnownFailuresV1.cs
+++ b/JavaV1KnownFailureTests/KnownFailuresV1.cs
@@ -1,4 +1,4 @@
-using MsGraphSDKSnippetsCompiler.Models;
+﻿using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
@@ -17,7 +17,7 @@ namespace JavaV1KnownFailureTests
             {
                 Version = Versions.V1,
                 Language = Languages.Java,
-                KnownFailuresRequested = true
+                TestType = TestType.CompilationKnownIssues
             });
 
         /// <summary>

--- a/JavaV1KnownFailureTests/Test.runsettings
+++ b/JavaV1KnownFailureTests/Test.runsettings
@@ -6,7 +6,7 @@
   <TestRunParameters>
     <Parameter name="Version" value="---VersionPlaceholder---" />
     <Parameter name="DllPath" value="C:/sources/github" />
-    <Parameter name="KnownFailuresRequested" value="---KnownFailuresRequestedPlaceholder---" />
+    <Parameter name="TestType" value="---TestTypePlaceholder---" />
     <Parameter name="Language" value="---LanguagePlaceHolder---" />
     <Parameter name="JavaCoreVersion" value="---JavaCoreVersionPlaceHolder---" />
     <Parameter name="JavaLibVersion" value="---JavaLibVersionPlaceHolder---" />

--- a/JavaV1Tests/SnippetCompileV1Tests.cs
+++ b/JavaV1Tests/SnippetCompileV1Tests.cs
@@ -1,4 +1,4 @@
-using MsGraphSDKSnippetsCompiler.Models;
+﻿using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
@@ -17,7 +17,7 @@ namespace JavaV1Tests
             {
                 Version = Versions.V1,
                 Language = Languages.Java,
-                KnownFailuresRequested = false
+                TestType = TestType.CompilationStable
             });
 
         /// <summary>

--- a/JavaV1Tests/Test.runsettings
+++ b/JavaV1Tests/Test.runsettings
@@ -6,7 +6,7 @@
   <TestRunParameters>
     <Parameter name="Version" value="---VersionPlaceholder---" />
     <Parameter name="DllPath" value="---DllPathPlaceholder---" />
-    <Parameter name="KnownFailuresRequested" value="---KnownFailuresRequestedPlaceholder---" />
+    <Parameter name="TestType" value="---TestTypePlaceholder---" />
     <Parameter name="Language" value="---LanguagePlaceHolder---" />
     <Parameter name="JavaCoreVersion" value="---JavaCoreVersionPlaceHolder---" />
     <Parameter name="JavaLibVersion" value="---JavaLibVersionPlaceHolder---" />

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -100,7 +100,7 @@ public class GraphSDKTest
             var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData.FileName, testData.DllPath);
             var compilationResultsModel = microsoftGraphCSharpCompiler.CompileSnippet(codeToCompile, testData.Version);
 
-            var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsKnownIssue);
+            var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsCompilationKnownIssue);
             EvaluateCompilationResult(compilationResultsModel, testData, codeSnippetFormatted, compilationOutputMessage);
 
             Assert.Pass();
@@ -138,7 +138,7 @@ public class GraphSDKTest
                 codeToCompile,
                 testData.DocsLink,
                 testData.KnownIssueMessage,
-                testData.IsKnownIssue);
+                testData.IsCompilationKnownIssue);
 
             EvaluateCompilationResult(executionResultsModel.CompilationResult, testData, codeSnippetFormatted, compilationOutputMessage);
 
@@ -269,7 +269,7 @@ public class GraphSDKTest
             var linqDirectory = Path.Join(
                     linqPadQueriesDefaultFolder,
                     "/RaptorResults",
-                    (testData.Version, testData.IsKnownIssue) switch
+                    (testData.Version, testData.IsCompilationKnownIssue) switch
                     {
                         (Versions.Beta, false) => "/Beta",
                         (Versions.Beta, true) => "/BetaKnown",
@@ -291,7 +291,7 @@ public class GraphSDKTest
   <Namespace>System.Threading.Tasks</Namespace>
   <Namespace>TimeOfDay = Microsoft.Graph.TimeOfDay</Namespace>
 </Query>
-// {testData.DocsLink}{(testData.IsKnownIssue ? (Environment.NewLine + "/* " + testData.KnownIssueMessage + " */") : string.Empty)}
+// {testData.DocsLink}{(testData.IsCompilationKnownIssue ? (Environment.NewLine + "/* " + testData.KnownIssueMessage + " */") : string.Empty)}
 IAuthenticationProvider authProvider  = null;";
 
             File.WriteAllText(linqFilePath,

--- a/TestsCommon/JavaTestRunner.cs
+++ b/TestsCommon/JavaTestRunner.cs
@@ -113,7 +113,7 @@ public class App
                     continue;
                 }
 
-                var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsKnownIssue);
+                var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsCompilationKnownIssue);
 
                 Assert.Fail($"{compilationOutputMessage}");
                 break;

--- a/TestsCommon/LanguageTestData.cs
+++ b/TestsCommon/LanguageTestData.cs
@@ -6,7 +6,8 @@ namespace TestsCommon
     /// Test Data
     /// </summary>
     /// <param name="Version">Docs version e.g. V1 or Beta</param>
-    /// <param name="IsKnownIssue">Whether the test case is failing due to a known issue</param>
+    /// <param name="IsCompilationKnownIssue">Whether the test case is failing due to a known issue in compilation</param>
+    /// <param name="IsExecutionKnownIssue">Whether the test case is failing due to a known issue in execution</param>
     /// <param name="KnownIssueMessage">Message to represent known issue</param>
     /// <param name="DocsLink">Documentation link where snippet is shown</param>
     /// <param name="FileName">Snippet file name</param>
@@ -16,7 +17,8 @@ namespace TestsCommon
     /// <param name="JavaPreviewLibPath">Optional. Folder container the java core and java service library repositories so the unit testing uses that local version instead.</param>
     public record LanguageTestData(
         Versions Version,
-        bool IsKnownIssue,
+        bool IsCompilationKnownIssue,
+        bool IsExecutionKnownIssue,
         string KnownIssueMessage,
         string DocsLink,
         string FileName,

--- a/TestsCommon/RunSettings.cs
+++ b/TestsCommon/RunSettings.cs
@@ -14,7 +14,7 @@ namespace TestsCommon
     {
         public Versions Version { get; init; }
         public string DllPath { get; init; }
-        public bool KnownFailuresRequested { get; init; }
+        public TestType TestType { get; init; }
         public bool ExecutionKnownFailuresRequested { get; init; }
         public Languages Language { get; init; }
         public string JavaCoreVersion { get; init; } = "2.0.0";
@@ -47,8 +47,7 @@ namespace TestsCommon
 
             var versionString = parameters.Get("Version");
             var dllPath = parameters.Get("DllPath");
-            var knownFailuresRequested = parameters.Get("KnownFailuresRequested");
-            var executionKnownFailuresRequested = parameters.Get("ExecutionKnownFailuresRequested");
+            var testType = parameters.Get("TestType");
 
             var lng = parameters.Get("Language");
             if (!string.IsNullOrEmpty(lng) && !lng.Contains(DashDash))
@@ -80,14 +79,16 @@ namespace TestsCommon
                 Version = VersionString.GetVersion(versionString);
             }
 
-            if (!string.IsNullOrEmpty(knownFailuresRequested) && !knownFailuresRequested.Contains(DashDash))
+            if (!string.IsNullOrEmpty(testType))
             {
-                KnownFailuresRequested = bool.Parse(knownFailuresRequested);
-            }
-
-            if (!string.IsNullOrEmpty(executionKnownFailuresRequested) && !executionKnownFailuresRequested.Contains(DashDash))
-            {
-                ExecutionKnownFailuresRequested = bool.Parse(executionKnownFailuresRequested);
+                if (Enum.TryParse(testType, out TestType testTypeEnum))
+                {
+                    TestType = testTypeEnum;
+                }
+                else
+                {
+                    throw new ArgumentException($"Unexpected test type specified: {testType}");
+                }
             }
 
             JavaCoreVersion = InitializeParameter(parameters, nameof(JavaCoreVersion)) ?? JavaCoreVersion;

--- a/TestsCommon/RunSettings.cs
+++ b/TestsCommon/RunSettings.cs
@@ -15,7 +15,6 @@ namespace TestsCommon
         public Versions Version { get; init; }
         public string DllPath { get; init; }
         public TestType TestType { get; init; }
-        public bool ExecutionKnownFailuresRequested { get; init; }
         public Languages Language { get; init; }
         public string JavaCoreVersion { get; init; } = "2.0.0";
         private string _javaLibVersion;

--- a/TestsCommon/RunSettings.cs
+++ b/TestsCommon/RunSettings.cs
@@ -15,6 +15,7 @@ namespace TestsCommon
         public Versions Version { get; init; }
         public string DllPath { get; init; }
         public bool KnownFailuresRequested { get; init; }
+        public bool ExecutionKnownFailuresRequested { get; init; }
         public Languages Language { get; init; }
         public string JavaCoreVersion { get; init; } = "2.0.0";
         private string _javaLibVersion;
@@ -47,6 +48,7 @@ namespace TestsCommon
             var versionString = parameters.Get("Version");
             var dllPath = parameters.Get("DllPath");
             var knownFailuresRequested = parameters.Get("KnownFailuresRequested");
+            var executionKnownFailuresRequested = parameters.Get("ExecutionKnownFailuresRequested");
 
             var lng = parameters.Get("Language");
             if (!string.IsNullOrEmpty(lng) && !lng.Contains(DashDash))
@@ -81,6 +83,11 @@ namespace TestsCommon
             if (!string.IsNullOrEmpty(knownFailuresRequested) && !knownFailuresRequested.Contains(DashDash))
             {
                 KnownFailuresRequested = bool.Parse(knownFailuresRequested);
+            }
+
+            if (!string.IsNullOrEmpty(executionKnownFailuresRequested) && !executionKnownFailuresRequested.Contains(DashDash))
+            {
+                ExecutionKnownFailuresRequested = bool.Parse(executionKnownFailuresRequested);
             }
 
             JavaCoreVersion = InitializeParameter(parameters, nameof(JavaCoreVersion)) ?? JavaCoreVersion;

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -592,7 +592,7 @@ namespace TestsCommon
                    let fileContent = File.ReadAllText(fullPath)
                    let executionTestData = new ExecutionTestData(testData with
                    {
-                       TestName = testData.TestName.Replace("-compiles", "executes")
+                       TestName = testData.TestName.Replace("-compiles", "-executes")
                    }, fileContent)
                    where !testData.IsCompilationKnownIssue // select compiling tests
                    && !(testData.IsExecutionKnownIssue ^ runSettings.TestType == TestType.ExecutionKnownIssues) // select known execution issues iff requested

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -573,7 +573,7 @@ namespace TestsCommon
         public static IEnumerable<TestCaseData> GetTestCaseData(RunSettings runSettings)
         {
             return from testData in GetLanguageTestData(runSettings)
-                   where !(testData.IsCompilationKnownIssue ^ runSettings.KnownFailuresRequested) // select known compilation issues iff requested
+                   where !(testData.IsCompilationKnownIssue ^ runSettings.TestType == TestType.CompilationKnownIssues) // select known compilation issues iff requested
                    select new TestCaseData(testData).SetName(testData.TestName).SetProperty("Owner", testData.Owner);
         }
 
@@ -595,7 +595,7 @@ namespace TestsCommon
                        TestName = testData.TestName.Replace("-compiles", "executes")
                    }, fileContent)
                    where !testData.IsCompilationKnownIssue // select compiling tests
-                   && !(testData.IsExecutionKnownIssue ^ runSettings.ExecutionKnownFailuresRequested) // select known execution issues iff requested
+                   && !(testData.IsExecutionKnownIssue ^ runSettings.TestType == TestType.ExecutionKnownIssues) // select known execution issues iff requested
                    && fileContent.Contains("GetAsync()") // select only the get tests
                    select new TestCaseData(executionTestData).SetName(testData.TestName).SetProperty("Owner", testData.Owner);
         }

--- a/TestsCommon/TestType.cs
+++ b/TestsCommon/TestType.cs
@@ -1,0 +1,10 @@
+﻿namespace TestsCommon
+{
+    public enum TestType
+    {
+        CompilationStable,
+        CompilationKnownIssues,
+        ExecutionStable,
+        ExecutionKnownIssues
+    }
+}

--- a/azure-pipelines/compile-run-tests-template.yml
+++ b/azure-pipelines/compile-run-tests-template.yml
@@ -16,7 +16,7 @@ steps:
   inputs:
     command: 'test'
     projects: '**/${{ parameters.projectFileName }}.csproj'
-    arguments: '--configuration $(buildConfiguration) --logger trx --results-directory $(Agent.TempDirectory) --settings $(Build.SourcesDirectory)/msgraph-sdk-raptor/${{ parameters.projectFileName}}/Test.runsettings'
+    arguments: '--configuration $(buildConfiguration) --logger "trx;logfilename=${{ parameters.runName }}.trx" --results-directory $(Agent.TempDirectory) --settings $(Build.SourcesDirectory)/msgraph-sdk-raptor/${{ parameters.projectFileName}}/Test.runsettings'
     publishTestResults: false
   displayName: '${{ parameters.projectFileName }} ${{ parameters.testType }} Tests'
   continueOnError: true
@@ -26,6 +26,6 @@ steps:
   inputs:
     testResultsFormat: 'VSTest'
     searchFolder: '$(Agent.TempDirectory)'
-    testResultsFiles: '**/*.trx'
+    testResultsFiles: '**/${{ parameters.runName }}.trx'
     testRunTitle: '${{ parameters.runName }}'
   displayName: 'Publish Test Results'

--- a/azure-pipelines/csharp-beta-execution-tests-known-issues.yml
+++ b/azure-pipelines/csharp-beta-execution-tests-known-issues.yml
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+name: 'Beta C# Snippet Execution Tests - Known Issues'
+
+resources:
+ repositories:
+   - repository: microsoft-graph-docs
+     type: github
+     endpoint: microsoftgraph
+     name: microsoftgraph/microsoft-graph-docs
+     ref: main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- template: common-templates/checkout.yml
+- template: common-templates/transform-app-settings.yml
+- template: compile-run-tests-template.yml
+  parameters:
+    projectFileName: CsharpBetaExecutionKnownFailureTests
+    runName: 'Beta C# Snippet Execution Tests $(testRunTitle) - Known Issues'
+    testType: 'Execution'

--- a/azure-pipelines/csharp-v1-execution-tests-known-issues.yml
+++ b/azure-pipelines/csharp-v1-execution-tests-known-issues.yml
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+name: 'V1 C# Snippet Execution Tests - Known Issues'
+
+resources:
+ repositories:
+   - repository: microsoft-graph-docs
+     type: github
+     endpoint: microsoftgraph
+     name: microsoftgraph/microsoft-graph-docs
+     ref: main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- template: common-templates/checkout.yml
+- template: common-templates/transform-app-settings.yml
+- template: compile-run-tests-template.yml
+  parameters:
+    projectFileName: CsharpV1ExecutionKnownFailureTests
+    runName: 'V1 C# Snippet Execution Tests $(testRunTitle) - Known Issues'
+    testType: 'Execution'

--- a/azure-pipelines/e2e-templates/known-failure-tests.yml
+++ b/azure-pipelines/e2e-templates/known-failure-tests.yml
@@ -13,14 +13,14 @@ steps:
     $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netcoreapp") }).FullName
     Write-Host "Path to Microsoft.Graph.dll: $dllPath"
 
-    ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -KnownFailuresRequested "true" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"
+    ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -TestType "CompilationKnownIssues" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"
 
     Write-Host "--- Test.runsettings file ---"
     Get-Content "$(runSettingsFile)"
     Write-Host "-----------------------------"
   displayName: 'Transform .runsettings file for known failures'
   workingDirectory: '$(Build.SourcesDirectory)'
-      
+
 
 - task: DotNetCoreCLI@2
   displayName: 'Csharp Compilation Tests for Known Failures'

--- a/azure-pipelines/e2e-templates/regular-tests.yml
+++ b/azure-pipelines/e2e-templates/regular-tests.yml
@@ -12,7 +12,7 @@ steps:
     $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netcoreapp") }).FullName
     Write-Host "Path to Microsoft.Graph.dll: $dllPath"
 
-    ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -KnownFailuresRequested "false" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"
+    ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -TestType "CompilationStable" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"
 
     Write-Host "--- Test.runsettings file ---"
     Get-Content "$(runSettingsFile)"

--- a/azure-pipelines/e2e-templates/transformSettings.ps1
+++ b/azure-pipelines/e2e-templates/transformSettings.ps1
@@ -9,12 +9,12 @@
     assigns runsettings values for Raptor tests
 
 .Example
-    .\CSharpArbitraryDllTests\transformSettings.ps1 -Version v1.0 -KnownFailuresRequested true -DllPath C:\github\msgraph-sdk-dotnet\tests\Microsoft.Graph.DotnetCore.Test\bin\Debug\netcoreapp3.1\Microsoft.Graph.dll -Language CSharp -RunSettingsPath .\CSharpArbitraryDllTests\Test.runsettings
+    .\CSharpArbitraryDllTests\transformSettings.ps1 -Version v1.0 -TestType CompilationStable -DllPath C:\github\msgraph-sdk-dotnet\tests\Microsoft.Graph.DotnetCore.Test\bin\Debug\netcoreapp3.1\Microsoft.Graph.dll -Language CSharp -RunSettingsPath .\CSharpArbitraryDllTests\Test.runsettings
 
 .Parameter Version
     Required. Either v1.0 or beta
 
-.Parameter KnownFailuresRequested
+.Parameter TestType
     Required. Determines whether known issue tests should be run
 
 .Parameter DllPath
@@ -42,7 +42,7 @@ Param(
     [string]$Version,
     [Parameter(Mandatory = $true, ParameterSetName="CSharp")]
     [Parameter(Mandatory = $false, ParameterSetName="Java")]
-    [string]$KnownFailuresRequested,
+    [string]$TestType,
     [Parameter(Mandatory = $true, ParameterSetName="CSharp")][string]$DllPath,
     [Parameter(Mandatory = $true, ParameterSetName="CSharp")]
     [Parameter(Mandatory = $false, ParameterSetName="Java")]
@@ -58,7 +58,7 @@ Param(
 $mapping = @{}
 
 $mapping.Add("Version", $Version)
-$mapping.Add("KnownFailuresRequested", $KnownFailuresRequested)
+$mapping.Add("TestType", $TestType)
 $mapping.Add("DllPath", $DllPath)
 $mapping.Add("Language", $Language)
 $mapping.Add("JavaCoreVersion", $JavaCoreVersion)

--- a/azure-pipelines/prod-beta-execution-tests.yml
+++ b/azure-pipelines/prod-beta-execution-tests.yml
@@ -34,3 +34,9 @@ steps:
     projectFileName: CsharpBetaExecutionTests
     runName: 'Weekly Beta C# Snippet Execution Tests'
     testType: 'Execution'
+
+- template: compile-run-tests-template.yml
+  parameters:
+    projectFileName: CsharpBetaExecutionKnownFailureTests
+    runName: 'Weekly Beta C# Snippet Execution Tests - Known Issues'
+    testType: 'Execution'

--- a/azure-pipelines/prod-v1-execution-tests.yml
+++ b/azure-pipelines/prod-v1-execution-tests.yml
@@ -34,3 +34,9 @@ steps:
     projectFileName: CsharpV1ExecutionTests
     runName: 'Weekly V1 C# Snippet Execution Tests'
     testType: 'Execution'
+
+- template: compile-run-tests-template.yml
+  parameters:
+    projectFileName: CsharpV1ExecutionKnownFailureTests
+    runName: 'Weekly V1 C# Snippet Execution Tests - Known Issues'
+    testType: 'Execution'

--- a/msgraph-sdk-raptor.sln
+++ b/msgraph-sdk-raptor.sln
@@ -36,6 +36,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsharpBetaExecutionTests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTests", "UnitTests\UnitTests.csproj", "{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpBetaExecutionKnownFailureTests", "CsharpBetaExecutionKnownFailureTests\CsharpBetaExecutionKnownFailureTests.csproj", "{21F552A3-5287-4776-A491-DE5A914AE83D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpV1ExecutionKnownFailureTests", "CsharpV1ExecutionKnownFailureTests\CsharpV1ExecutionKnownFailureTests.csproj", "{E20BE04F-3DB7-457F-9172-7E874055969C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,6 +102,14 @@ Global
 		{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21F552A3-5287-4776-A491-DE5A914AE83D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21F552A3-5287-4776-A491-DE5A914AE83D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21F552A3-5287-4776-A491-DE5A914AE83D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21F552A3-5287-4776-A491-DE5A914AE83D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E20BE04F-3DB7-457F-9172-7E874055969C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E20BE04F-3DB7-457F-9172-7E874055969C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E20BE04F-3DB7-457F-9172-7E874055969C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E20BE04F-3DB7-457F-9172-7E874055969C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- `KnownFailuresRequested` was not a representative naming, especially after introducing new known issue type for execution tests. Instead I defined a new `TestType` enum separating stable and known issue tests for both compilation and execution:

```csharp
    public enum TestType
    {
        CompilationStable,
        CompilationKnownIssues,
        ExecutionStable,
        ExecutionKnownIssues
    }
```

This allows us a two layered approach to known issues. We can now add execution known issues into the code for further categorization.

- Fixed pipeline for weekly execution tests to include both stable tests and known issues to continue having the full suite in the dashboard.
- Created "execution known issues" pipelines for V1 and Beta to run them as part of PRs.
- Fixes #370
