### PR TITLE
Use wildcard for Microsoft.Graph.Core reference

### DIFF
--- a/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
+++ b/msgraph-sdk-raptor-compiler-lib/msgraph-sdk-raptor-compiler-lib.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Graph" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.7" />
     <PackageReference Include="Microsoft.Graph.Beta" Version="4.8.0-preview" />
-    <PackageReference Include="Microsoft.Graph.Core" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="2.*" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.35.1" />
     <PackageReference Include="System.CodeDom" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #386 