### PR TITLE
Trigger Java builds in PRs only if the changes are related to Java

### DIFF
--- a/azure-pipelines/java-beta-compile-tests-known-issues.yml
+++ b/azure-pipelines/java-beta-compile-tests-known-issues.yml
@@ -6,6 +6,19 @@ pr:
     include:
       - dev
       - main
+  paths:
+    include:
+      - azure-pipelines/java*
+      - Java*
+      - msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+      - TestsCommon/JavaTestRunner.cs
+schedules:
+  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montreal)
+    displayName: 'Daily Beta Java Snippet Compilation Tests - Known Issues'
+    branches:
+      include:
+      - dev
+    always: true
 
 name: 'Beta Java Snippet Compilation Tests - Known Issues'
 

--- a/azure-pipelines/java-beta-compile-tests.yml
+++ b/azure-pipelines/java-beta-compile-tests.yml
@@ -6,6 +6,19 @@ pr:
     include:
       - dev
       - main
+  paths:
+    include:
+      - azure-pipelines/java*
+      - Java*
+      - msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+      - TestsCommon/JavaTestRunner.cs
+schedules:
+  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montreal)
+    displayName: 'Daily Beta Java Snippet Compilation Tests'
+    branches:
+      include:
+      - dev
+    always: true
 
 name: 'Beta Java Snippet Compilation Tests'
 

--- a/azure-pipelines/java-preview-compile-tests-known-issues.yml
+++ b/azure-pipelines/java-preview-compile-tests-known-issues.yml
@@ -6,6 +6,19 @@ pr:
     include:
       - dev
       - main
+  paths:
+    include:
+      - azure-pipelines/java*
+      - Java*
+      - msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+      - TestsCommon/JavaTestRunner.cs
+schedules:
+  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montreal)
+    displayName: 'Daily Preview Java Snippet Compilation Tests - Known Issues'
+    branches:
+      include:
+      - dev
+    always: true
 
 name: 'Preview Java Snippet Compilation Tests - Known Issues'
 

--- a/azure-pipelines/java-preview-compile-tests.yml
+++ b/azure-pipelines/java-preview-compile-tests.yml
@@ -6,6 +6,19 @@ pr:
     include:
       - dev
       - main
+  paths:
+    include:
+      - azure-pipelines/java*
+      - Java*
+      - msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+      - TestsCommon/JavaTestRunner.cs
+schedules:
+  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montreal)
+    displayName: 'Daily Preview Java Snippet Compilation Tests'
+    branches:
+      include:
+      - dev
+    always: true
 
 name: 'Preview Java Snippet Compilation Tests'
 

--- a/azure-pipelines/java-v1-compile-tests-known-issues.yml
+++ b/azure-pipelines/java-v1-compile-tests-known-issues.yml
@@ -6,6 +6,19 @@ pr:
     include:
       - dev
       - main
+  paths:
+    include:
+      - azure-pipelines/java*
+      - Java*
+      - msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+      - TestsCommon/JavaTestRunner.cs
+schedules:
+  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montreal)
+    displayName: 'Daily V1 Java Snippet Compilation Tests - Known Issues'
+    branches:
+      include:
+      - dev
+    always: true
 
 name: 'V1 Java Snippet Compilation Tests - Known Issues'
 

--- a/azure-pipelines/java-v1-compile-tests.yml
+++ b/azure-pipelines/java-v1-compile-tests.yml
@@ -6,6 +6,19 @@ pr:
     include:
       - dev
       - main
+  paths:
+    include:
+      - azure-pipelines/java*
+      - Java*
+      - msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+      - TestsCommon/JavaTestRunner.cs
+schedules:
+  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montreal)
+    displayName: 'Daily V1 Java Snippet Compilation Tests'
+    branches:
+      include:
+      - dev
+    always: true
 
 name: 'V1 Java Snippet Compilation Tests'
 


### PR DESCRIPTION
- Added path filters for Java pipelines to run them in PRs if the changes are related
- Added a daily schedule on `dev` to catch any seemingly-unrelated regression.

Fixes #373 