### PR TITLE
Print unexpected test results in plain text

### DIFF
--- a/azure-pipelines/compile-run-tests-template.yml
+++ b/azure-pipelines/compile-run-tests-template.yml
@@ -16,16 +16,38 @@ steps:
   inputs:
     command: 'test'
     projects: '**/${{ parameters.projectFileName }}.csproj'
-    arguments: '--configuration $(buildConfiguration) --logger "trx;logfilename=${{ parameters.runName }}.trx" --results-directory $(Agent.TempDirectory) --settings $(Build.SourcesDirectory)/msgraph-sdk-raptor/${{ parameters.projectFileName}}/Test.runsettings'
+    arguments: '--configuration $(buildConfiguration) --logger "trx;logfilename=${{ parameters.runName }}.trx" --results-directory $(Build.ArtifactStagingDirectory)/TestResults --settings $(Build.SourcesDirectory)/msgraph-sdk-raptor/${{ parameters.projectFileName}}/Test.runsettings'
     publishTestResults: false
   displayName: '${{ parameters.projectFileName }} ${{ parameters.testType }} Tests'
   continueOnError: true
 
+- pwsh: |
+    $trxFilePathRegex = "$(Build.ArtifactStagingDirectory)/TestResults/*.trx"
+    $trxFilePath = (Resolve-Path $trxFilePathRegex).Path
+    $txtFilePath = "$(Build.ArtifactStagingDirectory)/TestResults/UnexpectedTestResults.txt"
+
+    # Known issue tests are expected to fail
+    $unexpectedTestOutcome = ($env:PROJECT_FILE_NAME -contains "Known") ? "Passed" : "Failed"
+
+    Write-Host "--- $unexpectedTestOutcome Tests ---"
+    ./msgraph-sdk-raptor/scripts/filterTests.ps1  -trxFilePath $trxFilePath -outcome $unexpectedTestOutcome -txtOutputFilePath $txtFilePath
+    Write-Host "--------------------"
+  displayName: 'Print unexpected test results'
+  workingDirectory: '$(Build.SourcesDirectory)'
+  env:
+    PROJECT_FILE_NAME: ${{ parameters.projectFileName }}
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish test results as artifact'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/TestResults'
+    ArtifactName: 'TestResults'
+    publishLocation: 'Container'
+
 - task: PublishTestResults@2
-  condition: succeededOrFailed()
   inputs:
     testResultsFormat: 'VSTest'
-    searchFolder: '$(Agent.TempDirectory)'
-    testResultsFiles: '**/${{ parameters.runName }}.trx'
+    searchFolder: '$(Build.ArtifactStagingDirectory)/TestResults'
+    testResultsFiles: '**/*.trx'
     testRunTitle: '${{ parameters.runName }}'
-  displayName: 'Publish Test Results'
+  displayName: 'Publish Test Results for Regular Tests'

--- a/azure-pipelines/compile-run-tests-template.yml
+++ b/azure-pipelines/compile-run-tests-template.yml
@@ -50,4 +50,4 @@ steps:
     searchFolder: '$(Build.ArtifactStagingDirectory)/TestResults'
     testResultsFiles: '**/*.trx'
     testRunTitle: '${{ parameters.runName }}'
-  displayName: 'Publish Test Results for Regular Tests'
+  displayName: 'Publish Test Results'

--- a/azure-pipelines/e2e-templates/known-failure-tests.yml
+++ b/azure-pipelines/e2e-templates/known-failure-tests.yml
@@ -31,10 +31,21 @@ steps:
     publishTestResults: false
   continueOnError: true
 
+- pwsh: |
+    $trxFilePathRegex = "$(Build.ArtifactStagingDirectory)/KnownFailures/*.trx"
+    $trxFilePath = (Resolve-Path $trxFilePathRegex).Path
+    $txtFilePath = "$(Build.ArtifactStagingDirectory)/KnownFailures/PassedTests.txt"
+
+    Write-Host "--- Passed Tests ---"
+    ./msgraph-sdk-raptor/scripts/filterTests.ps1  -trxFilePath $trxFilePath -outcome Passed -txtOutputFilePath $txtFilePath
+    Write-Host "--------------------"
+  displayName: 'Print unexpected test results'
+  workingDirectory: '$(Build.SourcesDirectory)'
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish known failure test results as artifact'
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/KnownFailures'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/KnownFailures/*.trx;$(Build.ArtifactStagingDirectory)/KnownFailures/PassedTests.txt'
     ArtifactName: 'KnownFailures'
     publishLocation: 'Container'
 

--- a/azure-pipelines/e2e-templates/known-failure-tests.yml
+++ b/azure-pipelines/e2e-templates/known-failure-tests.yml
@@ -45,7 +45,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: 'Publish known failure test results as artifact'
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/KnownFailures/*.trx;$(Build.ArtifactStagingDirectory)/KnownFailures/PassedTests.txt'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/KnownFailures'
     ArtifactName: 'KnownFailures'
     publishLocation: 'Container'
 

--- a/azure-pipelines/e2e-templates/regular-tests.yml
+++ b/azure-pipelines/e2e-templates/regular-tests.yml
@@ -29,10 +29,21 @@ steps:
     publishTestResults: false
   continueOnError: true
 
+- pwsh: |
+    $trxFilePathRegex = "$(Build.ArtifactStagingDirectory)/RegularTests/*.trx"
+    $trxFilePath = (Resolve-Path $trxFilePathRegex).Path
+    $txtFilePath = "$(Build.ArtifactStagingDirectory)/RegularTests/FailedTests.txt"
+
+    Write-Host "--- Failed Tests ---"
+    ./msgraph-sdk-raptor/scripts/filterTests.ps1  -trxFilePath $trxFilePath -outcome Failed -txtOutputFilePath $txtFilePath
+    Write-Host "--------------------"
+  displayName: 'Print unexpected test results'
+  workingDirectory: '$(Build.SourcesDirectory)'
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish test results as artifact'
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/RegularTests'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/RegularTests/*.trx;$(Build.ArtifactStagingDirectory)/RegularTests/FailedTests.txt'
     ArtifactName: 'RegularTests'
     publishLocation: 'Container'
 

--- a/azure-pipelines/e2e-templates/regular-tests.yml
+++ b/azure-pipelines/e2e-templates/regular-tests.yml
@@ -43,7 +43,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: 'Publish test results as artifact'
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/RegularTests/*.trx;$(Build.ArtifactStagingDirectory)/RegularTests/FailedTests.txt'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/RegularTests'
     ArtifactName: 'RegularTests'
     publishLocation: 'Container'
 

--- a/scripts/filterTests.ps1
+++ b/scripts/filterTests.ps1
@@ -1,0 +1,23 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$trxFilePath,
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("Failed", "Passed")]
+    [string]$outcome,
+    [string]$txtOutputFilePath
+)
+
+if (!(Test-Path $trxFilePath))
+{
+    Write-Error "File not found at $trxFilePath";
+    exit
+}
+
+[xml]$xmlContent = Get-Content $trxFilePath
+$result = $xmlContent.TestRun.Results.UnitTestResult |
+  Where-Object { $_.outcome -eq $outcome } |
+  Select-Object -ExpandProperty testName |
+  Sort-Object
+
+Set-Content -Path $txtOutputFilePath -Value $result
+$result


### PR DESCRIPTION
Fixes #398 

- Prints test names into the pipeline logs
- Outputs flat list as pipeline artifact

![image](https://user-images.githubusercontent.com/803311/130508530-60cbeb1c-860c-4fea-97fd-363c59af0b45.png)

![image](https://user-images.githubusercontent.com/803311/130508605-46627fd6-40c3-4be4-97fe-5d75e3e83a91.png)
