### PR TITLE
Create missing apps with delegated permissions periodically in test tenant

### DIFF
--- a/DelegatedAppCreator/DelegatedAppCreator.cs
+++ b/DelegatedAppCreator/DelegatedAppCreator.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MsGraphSDKSnippetsCompiler;
+using MsGraphSDKSnippetsCompiler.Models;
+
+namespace DelegatedAppCreator
+{
+    /// <summary>
+    /// 1. Fetches all delegated scopes listed in permission descriptions in the devx-content repo.
+    /// 2. Fetches all the applications with delegated permissions that were previously created in the tenant.
+    /// 3. Creates missing applications with desired oauth permission grant (admin consent in the Azure Portal)
+    /// </summary>
+    class DelegatedAppCreator
+    {
+        static async Task Main(string[] args)
+        {
+            const string Prefix = "DelegatedApp ";
+            var config = AppSettings.Config();
+            var raptorConfig = RaptorConfig.Create(config);
+            var permissionManagerApplication = new PermissionManager(raptorConfig);
+
+            // get existing applications
+            var existingApplicationSet = await permissionManagerApplication.GetExistingApplicationsWithPrefix(Prefix);
+            PrintApplicationNames("Existing Applications", existingApplicationSet);
+
+            // get expected applications
+            var permissionDescriptions = await PermissionManager.GetPermissionDescriptions();
+            var delegatedScopes = permissionDescriptions.delegatedScopesList;
+            var expectedApplications = delegatedScopes
+                .Select(x => x.DelegatedAppName(Prefix));
+            PrintApplicationNames("Expected Applications", expectedApplications);
+
+            // find missing application scopes
+            var missingScopes = delegatedScopes
+                .Where(x => !existingApplicationSet.Contains(x.DelegatedAppName(Prefix)));
+
+            if (!missingScopes.Any())
+            {
+                Console.WriteLine("All the applications exist in the tenant! Exiting...");
+                return;
+            }
+
+            var missingApplications = missingScopes
+                .Select(x => x.DelegatedAppName(Prefix));
+            PrintApplicationNames("Missing Applications", missingApplications);
+
+            // create missing applications
+            var resourceId = await permissionManagerApplication.GetMicrosoftGraphServicePrincipalId();
+            var failedApplications = new List<string>();
+            var succeededApplications = new List<string>();
+            foreach (var scope in missingScopes)
+            {
+                var appDisplayName = scope.DelegatedAppName(Prefix);
+                try
+                {
+                    Console.WriteLine($"Creating Application with name '{appDisplayName}'");
+                    var application = await permissionManagerApplication.CreateApplication(appDisplayName, scope.id);
+                    var servicePrincipal = await permissionManagerApplication.CreateServicePrincipal(application.AppId);
+                    _ = await permissionManagerApplication.CreateOAuthPermission(servicePrincipal.Id, resourceId, scope.value);
+
+                    Console.WriteLine($"Created Application with name '{appDisplayName}' and id '{application.Id}'");
+                    succeededApplications.Add(appDisplayName);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Couldn't create application named '{appDisplayName}'. See exception details below:");
+                    Console.WriteLine("-------------------------");
+                    Console.WriteLine(e.Message);
+                    Console.WriteLine("-------------------------");
+                    failedApplications.Add(appDisplayName);
+                }
+            }
+
+            Console.WriteLine("=========================");
+            Console.WriteLine("Summary:");
+            Console.WriteLine("-------------------------");
+            Console.WriteLine($"number of existing applications: {existingApplicationSet.Count}");
+            Console.WriteLine($"number of expected applications: {expectedApplications.Count()}");
+            Console.WriteLine($"number of missing applications: {missingApplications.Count()}");
+            Console.WriteLine($"number of successfully created applications in this run: {succeededApplications.Count}");
+            Console.WriteLine($"number of failed application creation attempts: {failedApplications.Count}");
+            Console.WriteLine("=========================");
+
+            PrintApplicationNames("Successfully Created Applications", succeededApplications);
+            PrintApplicationNames("Failed Attempts", failedApplications);
+        }
+
+        private static void PrintApplicationNames(string title, IEnumerable<string> names)
+        {
+            if ((names?.Count() ?? 0) < 1)
+            {
+                return;
+            }
+
+            var namesList = names.ToList();
+            namesList.Sort();
+            Console.WriteLine("=========================");
+            Console.WriteLine(title);
+            Console.WriteLine("-------------------------");
+            namesList.ForEach(x => { Console.WriteLine(x); });
+            Console.WriteLine("=========================");
+        }
+    }
+}

--- a/DelegatedAppCreator/DelegatedAppCreator.csproj
+++ b/DelegatedAppCreator/DelegatedAppCreator.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/azure-pipelines/common-templates/transform-app-settings-single-repo.yml
+++ b/azure-pipelines/common-templates/transform-app-settings-single-repo.yml
@@ -1,0 +1,7 @@
+steps:
+  - pwsh: '$(Build.SourcesDirectory)/scripts/transformAppSettings.ps1 -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret) -Authority $(Authority) -Username $(Username) -Password $(Password) -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"'
+    displayName: 'Transform app settings with the secrets'
+
+  - pwsh: |
+      Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor-compiler-lib/appsettings.json
+    displayName: 'Show app settings'

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -8,7 +8,7 @@ steps:
       {
         $scriptPath = $(Build.SourcesDirectory)/scripts/transformAppSettings.ps1
       }
-      . $scriptPath -TenantID $env:TenantID -ClientID $env:ClientID -ClientSecret $env:ClientSecret -Authority $env:Authority-Username $env:Username -Password $env:Password -RaptorStorageConnectionString $env:RaptorStorageConnectionString -EducationClientId $env:EducationClientId -EducationTenantId $env:EducationTenantId
+      . $scriptPath -TenantID $env:TenantID -ClientID $env:ClientID -ClientSecret $env:ClientSecret -Authority $env:Authority -Username $env:Username -Password $env:Password -RaptorStorageConnectionString $env:RaptorStorageConnectionString -EducationClientId $env:EducationClientId -EducationTenantId $env:EducationTenantId
     displayName: 'Transform app settings with the secrets'
     env:
       TenantID: $(TenantID)

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -1,14 +1,5 @@
 steps:
-  - pwsh: |
-      if (Test-Path $(Build.SourcesDirectory)/msgraph-sdk-raptor) # multi repo checkout
-      {
-        $scriptPath = $(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1
-      }
-      else # single repo checkout
-      {
-        $scriptPath = $(Build.SourcesDirectory)/scripts/transformAppSettings.ps1
-      }
-      . $scriptPath -TenantID $env:TenantID -ClientID $env:ClientID -ClientSecret $env:ClientSecret -Authority $env:Authority -Username $env:Username -Password $env:Password -RaptorStorageConnectionString $env:RaptorStorageConnectionString -EducationClientId $env:EducationClientId -EducationTenantId $env:EducationTenantId
+  - pwsh: $(Build.SourcesDirectory)/scripts/transformAppSettings.ps1 -TenantID $env:TenantID -ClientID $env:ClientID -ClientSecret $env:ClientSecret -Authority $env:Authority -Username $env:Username -Password $env:Password -RaptorStorageConnectionString $env:RaptorStorageConnectionString -EducationClientId $env:EducationClientId -EducationTenantId $env:EducationTenantId
     displayName: 'Transform app settings with the secrets'
     env:
       TenantID: $(TenantID)

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -12,5 +12,12 @@ steps:
     displayName: 'Transform app settings with the secrets'
 
   - pwsh: |
-      Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json
+      if (Test-Path $(Build.SourcesDirectory)/msgraph-sdk-raptor) # multi repo checkout
+      {
+        Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json
+      }
+      else # single repo checkout
+      {
+        Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor-compiler-lib/appsettings.json
+      }
     displayName: 'Show app settings'

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -8,7 +8,7 @@ steps:
       {
         $scriptPath = $(Build.SourcesDirectory)/scripts/transformAppSettings.ps1
       }
-      . $scriptPath -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret) -Authority $(Authority) -Username $(Username) -Password $(Password) -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"
+      . $scriptPath -TenantID "$(TenantID)" -ClientID "$(ClientID)" -ClientSecret "$(ClientSecret)" -Authority "$(Authority)" -Username "$(Username)" -Password "$(Password)" -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"
     displayName: 'Transform app settings with the secrets'
 
   - pwsh: |

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -8,8 +8,18 @@ steps:
       {
         $scriptPath = $(Build.SourcesDirectory)/scripts/transformAppSettings.ps1
       }
-      . $scriptPath -TenantID "$(TenantID)" -ClientID "$(ClientID)" -ClientSecret "$(ClientSecret)" -Authority "$(Authority)" -Username "$(Username)" -Password "$(Password)" -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"
+      . $scriptPath -TenantID $env:TenantID -ClientID $env:ClientID -ClientSecret $env:ClientSecret -Authority $env:Authority-Username $env:Username -Password $env:Password -RaptorStorageConnectionString $env:RaptorStorageConnectionString -EducationClientId $env:EducationClientId -EducationTenantId $env:EducationTenantId
     displayName: 'Transform app settings with the secrets'
+    env:
+      TenantID: $(TenantID)
+      ClientID: $(ClientID)
+      ClientSecret: $(ClientSecret)
+      Authority: $(Authority)
+      Username: $(Username)
+      Password: $(Password)
+      RaptorStorageConnectionString: $(RaptorStorageConnectionString)
+      EducationClientId: $(EducationClientId)
+      EducationTenantId: $(EducationTenantId)
 
   - pwsh: |
       if (Test-Path $(Build.SourcesDirectory)/msgraph-sdk-raptor) # multi repo checkout

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -1,6 +1,5 @@
 steps:
   - pwsh: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1 -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret) -Authority $(Authority) -Username $(Username) -Password $(Password) -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"'
-    workingDirectory: 'msgraph-sdk-raptor'
     displayName: 'Transform app settings with the secrets'
 
   - pwsh: |

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -1,5 +1,14 @@
 steps:
-  - pwsh: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1 -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret) -Authority $(Authority) -Username $(Username) -Password $(Password) -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"'
+  - pwsh: |
+      if (Test-Path $(Build.SourcesDirectory)/msgraph-sdk-raptor) # multi repo checkout
+      {
+        $scriptPath = $(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1
+      }
+      else # single repo checkout
+      {
+        $scriptPath = $(Build.SourcesDirectory)/scripts/transformAppSettings.ps1
+      }
+      . $scriptPath -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret) -Authority $(Authority) -Username $(Username) -Password $(Password) -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"
     displayName: 'Transform app settings with the secrets'
 
   - pwsh: |

--- a/azure-pipelines/common-templates/transform-app-settings.yml
+++ b/azure-pipelines/common-templates/transform-app-settings.yml
@@ -1,24 +1,8 @@
 steps:
-  - pwsh: $(Build.SourcesDirectory)/scripts/transformAppSettings.ps1 -TenantID $env:TenantID -ClientID $env:ClientID -ClientSecret $env:ClientSecret -Authority $env:Authority -Username $env:Username -Password $env:Password -RaptorStorageConnectionString $env:RaptorStorageConnectionString -EducationClientId $env:EducationClientId -EducationTenantId $env:EducationTenantId
+  - pwsh: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/scripts/transformAppSettings.ps1 -TenantID $(TenantID) -ClientID $(ClientID) -ClientSecret $(ClientSecret) -Authority $(Authority) -Username $(Username) -Password $(Password) -RaptorStorageConnectionString "$(RaptorStorageConnectionString)" -EducationClientId "$(EducationClientId)" -EducationTenantId "$(EducationTenantId)"'
+    workingDirectory: 'msgraph-sdk-raptor'
     displayName: 'Transform app settings with the secrets'
-    env:
-      TenantID: $(TenantID)
-      ClientID: $(ClientID)
-      ClientSecret: $(ClientSecret)
-      Authority: $(Authority)
-      Username: $(Username)
-      Password: $(Password)
-      RaptorStorageConnectionString: $(RaptorStorageConnectionString)
-      EducationClientId: $(EducationClientId)
-      EducationTenantId: $(EducationTenantId)
 
   - pwsh: |
-      if (Test-Path $(Build.SourcesDirectory)/msgraph-sdk-raptor) # multi repo checkout
-      {
-        Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json
-      }
-      else # single repo checkout
-      {
-        Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor-compiler-lib/appsettings.json
-      }
+      Get-Content $env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/msgraph-sdk-raptor-compiler-lib/appsettings.json
     displayName: 'Show app settings'

--- a/azure-pipelines/delegated-app-creator.yml
+++ b/azure-pipelines/delegated-app-creator.yml
@@ -37,3 +37,4 @@ steps:
     chmod +x ./DelegatedAppCreator
     ./DelegatedAppCreator
   workingDirectory: '$(Build.SourcesDirectory)/DelegatedAppCreator/bin/Release/net5.0'
+  displayName: 'Create delegated apps'

--- a/azure-pipelines/delegated-app-creator.yml
+++ b/azure-pipelines/delegated-app-creator.yml
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+pr: none # disable this as a PR check
+name: 'Weekly Delegated App Creator'
+
+schedules:
+  - cron: "0 3 * * SAT" # every Saturday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
+    displayName: 'Weekly Delegated App Creator'
+    branches:
+      include:
+      - dev
+    always: true
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- checkout: self
+  clean: true
+  fetchDepth: 1
+- template: common-templates/transform-app-settings.yml
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'build'
+    projects: '**/DelegatedAppCreator.csproj'
+    arguments: '--configuration $(buildConfiguration)'
+  displayName: 'Build DelegatedAppCreator'
+
+# not using dotnet run due to the following issue preventing us from picking up appsettings.json file
+# consistently between VS and dotnet command line: https://github.com/dotnet/project-system/issues/3619
+- pwsh: |
+    chmod +x ./DelegatedAppCreator.exe
+    ./DelegatedAppCreator.exe
+  workingDirectory: 'DelegatedAppCreator/bin/Release/net5.0'

--- a/azure-pipelines/delegated-app-creator.yml
+++ b/azure-pipelines/delegated-app-creator.yml
@@ -22,7 +22,7 @@ steps:
 - checkout: self
   clean: true
   fetchDepth: 1
-- template: common-templates/transform-app-settings.yml
+- template: common-templates/transform-app-settings-single-repo.yml
 - template: common-templates/use-dotnet-sdk.yml
 - task: DotNetCoreCLI@2
   inputs:

--- a/azure-pipelines/delegated-app-creator.yml
+++ b/azure-pipelines/delegated-app-creator.yml
@@ -34,9 +34,6 @@ steps:
 # not using dotnet run due to the following issue preventing us from picking up appsettings.json file
 # consistently between VS and dotnet command line: https://github.com/dotnet/project-system/issues/3619
 - pwsh: |
-    Push-Location $env:binDir
-    chmod +x ./DelegatedAppCreator.exe
-    ./DelegatedAppCreator.exe
-    Pop-Location
-  env:
-    binDir: '$(Build.SourcesDirectory)/DelegatedAppCreator/bin/Release/net5.0'
+    chmod +x ./DelegatedAppCreator
+    ./DelegatedAppCreator
+  workingDirectory: '$(Build.SourcesDirectory)/DelegatedAppCreator/bin/Release/net5.0'

--- a/azure-pipelines/delegated-app-creator.yml
+++ b/azure-pipelines/delegated-app-creator.yml
@@ -36,4 +36,4 @@ steps:
 - pwsh: |
     chmod +x ./DelegatedAppCreator.exe
     ./DelegatedAppCreator.exe
-  workingDirectory: 'DelegatedAppCreator/bin/Release/net5.0'
+  workingDirectory: '$(Build.SourcesDirectory)/DelegatedAppCreator/bin/Release/net5.0'

--- a/azure-pipelines/delegated-app-creator.yml
+++ b/azure-pipelines/delegated-app-creator.yml
@@ -34,6 +34,9 @@ steps:
 # not using dotnet run due to the following issue preventing us from picking up appsettings.json file
 # consistently between VS and dotnet command line: https://github.com/dotnet/project-system/issues/3619
 - pwsh: |
+    Push-Location $env:binDir
     chmod +x ./DelegatedAppCreator.exe
     ./DelegatedAppCreator.exe
-  workingDirectory: '$(Build.SourcesDirectory)/DelegatedAppCreator/bin/Release/net5.0'
+    Pop-Location
+  env:
+    binDir: '$(Build.SourcesDirectory)/DelegatedAppCreator/bin/Release/net5.0'

--- a/azure-pipelines/delegated-app-creator.yml
+++ b/azure-pipelines/delegated-app-creator.yml
@@ -23,6 +23,7 @@ steps:
   clean: true
   fetchDepth: 1
 - template: common-templates/transform-app-settings.yml
+- template: common-templates/use-dotnet-sdk.yml
 - task: DotNetCoreCLI@2
   inputs:
     command: 'build'

--- a/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
@@ -3,5 +3,17 @@
     /// <summary>
     /// Model from https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/dev/GraphExplorerPermissionsService/Models/ScopeInformation.cs
     /// </summary>
-    public record Scope (string value, bool isAdmin, string id);
+    public record Scope(string value, bool isAdmin, string id)
+    {
+        /// <summary>
+        /// Creates a delegated app name from scope
+        /// </summary>
+        /// <param name="prefix">app display name prefix</param>
+        /// <returns>e.g. 'DelegatedApp User.Read' for prefix: 'DelegatedApp ' and Scope: 'User.Read'</returns>
+        public string DelegatedAppName(string prefix)
+        {
+            return prefix + value;
+        }
+    };
+
 }

--- a/msgraph-sdk-raptor.sln
+++ b/msgraph-sdk-raptor.sln
@@ -36,9 +36,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsharpBetaExecutionTests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTests", "UnitTests\UnitTests.csproj", "{28AA9EBB-3F91-4E63-B0F8-2BB165927B3D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpBetaExecutionKnownFailureTests", "CsharpBetaExecutionKnownFailureTests\CsharpBetaExecutionKnownFailureTests.csproj", "{21F552A3-5287-4776-A491-DE5A914AE83D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsharpBetaExecutionKnownFailureTests", "CsharpBetaExecutionKnownFailureTests\CsharpBetaExecutionKnownFailureTests.csproj", "{21F552A3-5287-4776-A491-DE5A914AE83D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsharpV1ExecutionKnownFailureTests", "CsharpV1ExecutionKnownFailureTests\CsharpV1ExecutionKnownFailureTests.csproj", "{E20BE04F-3DB7-457F-9172-7E874055969C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsharpV1ExecutionKnownFailureTests", "CsharpV1ExecutionKnownFailureTests\CsharpV1ExecutionKnownFailureTests.csproj", "{E20BE04F-3DB7-457F-9172-7E874055969C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DelegatedAppCreator", "DelegatedAppCreator\DelegatedAppCreator.csproj", "{6E786AF0-52D3-48A8-AF8C-C85E98614572}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -110,6 +112,10 @@ Global
 		{E20BE04F-3DB7-457F-9172-7E874055969C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E20BE04F-3DB7-457F-9172-7E874055969C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E20BE04F-3DB7-457F-9172-7E874055969C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E786AF0-52D3-48A8-AF8C-C85E98614572}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E786AF0-52D3-48A8-AF8C-C85E98614572}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E786AF0-52D3-48A8-AF8C-C85E98614572}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E786AF0-52D3-48A8-AF8C-C85E98614572}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        <clear />
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
fixes #418

- Adds a console application to:
  - fetch all delegated scopes listed in permission descriptions in the devx-content repo.
  - fetch all the applications with delegated permissions that were previously created in the tenant.
  - create missing applications with desired oauth permission grant (admin consent in the Azure Portal)
- Adds a pipeline to run the console application weekly on Saturdays
- Adds `<clear />` to `nuget.config` based on an automated security analysis: https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=55583&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=a774f190-bf61-5b2d-fa2a-f1e70e64a0e4

Example output of the application run can be found here: https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=55596&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=d01ed771-bc1f-5e98-e7ad-71f8c6eef93d&l=12