### PR TITLE
App config refactoring

### DIFF
--- a/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
+++ b/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
@@ -12,14 +12,12 @@ namespace CsharpBetaExecutionKnownFailureTests
     [TestFixture]
     public class SnippetExecutionBetaKnownFailureTests
     {
-        private RaptorConfig _raptorConfig;
         private PermissionManager _permissionManagerApplication;
 
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
-            _raptorConfig = TestsSetup.GetConfig();
-            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication(_raptorConfig);
+            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication();
         }
 
         /// <summary>
@@ -44,7 +42,7 @@ namespace CsharpBetaExecutionKnownFailureTests
         [RetryTestCaseSource(typeof(SnippetExecutionBetaKnownFailureTests), nameof(TestDataBeta), MaxTries = 3)]
         public async Task Test(ExecutionTestData testData)
         {
-            await CSharpTestRunner.Execute(testData, _raptorConfig, _permissionManagerApplication);
+            await CSharpTestRunner.Execute(testData, _permissionManagerApplication);
         }
     }
 }

--- a/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
+++ b/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
@@ -12,14 +12,12 @@ namespace CsharpBetaExecutionTests
     [TestFixture]
     public class SnippetExecutionBetaTests
     {
-        private RaptorConfig _raptorConfig;
         private PermissionManager _permissionManagerApplication;
 
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
-            _raptorConfig = TestsSetup.GetConfig();
-            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication(_raptorConfig);
+            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication();
         }
 
         /// <summary>
@@ -44,7 +42,7 @@ namespace CsharpBetaExecutionTests
         [RetryTestCaseSource(typeof(SnippetExecutionBetaTests), nameof(TestDataBeta), MaxTries = 3)]
         public async Task Test(ExecutionTestData testData)
         {
-            await CSharpTestRunner.Execute(testData, _raptorConfig, _permissionManagerApplication);
+            await CSharpTestRunner.Execute(testData, _permissionManagerApplication);
         }
     }
 }

--- a/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
+++ b/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
@@ -10,14 +10,12 @@ namespace CsharpV1ExecutionKnownFailureTests
     [TestFixture]
     public class SnippetExecutionV1KnownFailureTests
     {
-        private RaptorConfig _raptorConfig;
         private PermissionManager _permissionManagerApplication;
 
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
-            _raptorConfig = TestsSetup.GetConfig();
-            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication(_raptorConfig);
+            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication();
         }
 
         /// <summary>
@@ -42,7 +40,7 @@ namespace CsharpV1ExecutionKnownFailureTests
         [RetryTestCaseSource(typeof(SnippetExecutionV1KnownFailureTests), nameof(TestDataV1), MaxTries = 3)]
         public async Task Test(ExecutionTestData testData)
         {
-            await CSharpTestRunner.Execute(testData, _raptorConfig, _permissionManagerApplication);
+            await CSharpTestRunner.Execute(testData, _permissionManagerApplication);
         }
     }
 }

--- a/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
+++ b/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
@@ -10,14 +10,12 @@ namespace CsharpV1ExecutionTests
     [TestFixture]
     public class SnippetExecutionV1Tests
     {
-        private RaptorConfig _raptorConfig;
         private PermissionManager _permissionManagerApplication;
 
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
-            _raptorConfig = TestsSetup.GetConfig();
-            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication(_raptorConfig);
+            _permissionManagerApplication = await TestsSetup.GetPermissionManagerApplication();
         }
 
         /// <summary>
@@ -40,7 +38,7 @@ namespace CsharpV1ExecutionTests
         [RetryTestCaseSource(typeof(SnippetExecutionV1Tests), nameof(TestDataV1), MaxTries = 3)]
         public async Task Test(ExecutionTestData testData)
         {
-            await CSharpTestRunner.Execute(testData, _raptorConfig, _permissionManagerApplication);
+            await CSharpTestRunner.Execute(testData, _permissionManagerApplication);
         }
     }
 }

--- a/DelegatedAppCreator/DelegatedAppCreator.cs
+++ b/DelegatedAppCreator/DelegatedAppCreator.cs
@@ -17,8 +17,7 @@ namespace DelegatedAppCreator
         static async Task Main(string[] args)
         {
             const string Prefix = "DelegatedApp ";
-            var config = AppSettings.Config();
-            var raptorConfig = RaptorConfig.Create(config);
+            var raptorConfig = TestsSetup.GetConfig();
             var permissionManagerApplication = new PermissionManager(raptorConfig);
 
             // get existing applications

--- a/DelegatedAppCreator/DelegatedAppCreator.cs
+++ b/DelegatedAppCreator/DelegatedAppCreator.cs
@@ -17,8 +17,7 @@ namespace DelegatedAppCreator
         static async Task Main(string[] args)
         {
             const string Prefix = "DelegatedApp ";
-            var raptorConfig = TestsSetup.GetConfig();
-            var permissionManagerApplication = new PermissionManager(raptorConfig);
+            var permissionManagerApplication = new PermissionManager();
 
             // get existing applications
             var existingApplicationSet = await permissionManagerApplication.GetExistingApplicationsWithPrefix(Prefix);

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -113,18 +113,12 @@ public class GraphSDKTest
         /// 5. It uses the compiled binary to make a request to the demo tenant and reports error if there's a service exception i.e 4XX or 5xx response
         /// </summary>
         /// <param name="executionTestData">Test data containing information such as snippet file name</param>
-        /// <param name="config">Raptor configuration</param>
         /// <param name="permissionManagerApplication">Permission manager application to provide auth providers and tokens</param>
-        public static async Task Execute(ExecutionTestData executionTestData, RaptorConfig config, PermissionManager permissionManagerApplication)
+        public static async Task Execute(ExecutionTestData executionTestData, PermissionManager permissionManagerApplication)
         {
             if (executionTestData == null)
             {
                 throw new ArgumentNullException(nameof(executionTestData));
-            }
-
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
             }
 
             if (permissionManagerApplication == null)
@@ -137,7 +131,7 @@ public class GraphSDKTest
             var (codeToCompile, codeSnippetFormatted) = GetCodeToExecute(executionTestData.FileContent);
 
             // Compile Code
-            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData.FileName, testData.DllPath, config, permissionManagerApplication);
+            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData.FileName, testData.DllPath, permissionManagerApplication);
             var executionResultsModel = await microsoftGraphCSharpCompiler
                 .ExecuteSnippet(codeToCompile, testData.Version)
                 .ConfigureAwait(false);
@@ -163,7 +157,7 @@ public class GraphSDKTest
             if (!compilationResult.IsSuccess)
             {
                 // environment variable for sources directory is defined only for cloud runs
-                var config = TestsSetup.GetConfig();
+                var config = TestsSetup.Config.Value;
                 if (config.IsLocalRun)
                 {
                     var linqPadQueriesDefaultFolder = Path.Join(

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -163,8 +163,8 @@ public class GraphSDKTest
             if (!compilationResult.IsSuccess)
             {
                 // environment variable for sources directory is defined only for cloud runs
-                var config = AppSettings.Config();
-                if (bool.Parse(config.GetSection("IsLocalRun").Value))
+                var config = TestsSetup.GetConfig();
+                if (config.IsLocalRun)
                 {
                     var linqPadQueriesDefaultFolder = Path.Join(
                         Environment.GetEnvironmentVariable("USERPROFILE"),

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -164,10 +164,18 @@ public class GraphSDKTest
             {
                 // environment variable for sources directory is defined only for cloud runs
                 var config = AppSettings.Config();
-                if (bool.Parse(config.GetSection("IsLocalRun").Value)
-                    && bool.Parse(config.GetSection("GenerateLinqPadOutputInLocalRun").Value))
+                if (bool.Parse(config.GetSection("IsLocalRun").Value))
                 {
-                    WriteLinqFile(testData, codeSnippetFormatted);
+                    var linqPadQueriesDefaultFolder = Path.Join(
+                        Environment.GetEnvironmentVariable("USERPROFILE"),
+                        "/OneDrive - Microsoft", // remove this if you are not syncing your Documents to OneDrive
+                        "/Documents",
+                        "/LINQPad Queries");
+
+                    if (Directory.Exists(linqPadQueriesDefaultFolder))
+                    {
+                        WriteLinqFile(testData, linqPadQueriesDefaultFolder, codeSnippetFormatted);
+                    }
                 }
 
                 Assert.Fail($"{compilationOutputMessage}");
@@ -265,15 +273,10 @@ public class GraphSDKTest
         /// Generates .linq file in default My Queries folder so that the results are visible in LinqPad right away
         /// </summary>
         /// <param name="testData">test data</param>
+        /// <param name="linqPadQueriesDefaultFolder">path to linqpad queries folder</param>
         /// <param name="codeSnippetFormatted">code snippet</param>
-        private static void WriteLinqFile(LanguageTestData testData, string codeSnippetFormatted)
+        private static void WriteLinqFile(LanguageTestData testData, string linqPadQueriesDefaultFolder, string codeSnippetFormatted)
         {
-            var linqPadQueriesDefaultFolder = Path.Join(
-                    Environment.GetEnvironmentVariable("USERPROFILE"),
-                    "/OneDrive - Microsoft", // remove this if you are not syncing your Documents to OneDrive
-                    "/Documents",
-                    "/LINQPad Queries");
-
             var linqDirectory = Path.Join(
                     linqPadQueriesDefaultFolder,
                     "/RaptorResults",

--- a/TestsCommon/GraphDocsDirectory.cs
+++ b/TestsCommon/GraphDocsDirectory.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-
-using MsGraphSDKSnippetsCompiler;
 using MsGraphSDKSnippetsCompiler.Models;
-using System;
 using System.IO;
 
 namespace TestsCommon
@@ -33,7 +30,7 @@ namespace TestsCommon
                 return SnippetsDirectory;
             }
 
-            var msGraphDocsRepoLocation = GetSourcesDirectory();
+            var msGraphDocsRepoLocation = TestsSetup.GetConfig().DocsRepoCheckoutDirectory;
             SnippetsDirectory = Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}includes{Path.DirectorySeparatorChar}snippets{Path.DirectorySeparatorChar}{language.AsString()}");
 
             return SnippetsDirectory;
@@ -48,32 +45,8 @@ namespace TestsCommon
         /// </returns>
         public static string GetDocumentationDirectory(Versions version)
         {
-            var msGraphDocsRepoLocation = GetSourcesDirectory();
+            var msGraphDocsRepoLocation = TestsSetup.GetConfig().DocsRepoCheckoutDirectory;
             return Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}api");
-        }
-
-        /// <summary>
-        /// Gets git source directory
-        /// </summary>
-        /// <returns>
-        /// 1. For local runs, the directory specified in AppSettings file with DocsRepoCheckoutDirectory
-        /// 2. For cloud runs, BUILD_SOURCESDIRECTORY
-        /// </returns>
-        private static string GetSourcesDirectory()
-        {
-            var config = AppSettings.Config();
-            var isLocalRun = bool.Parse(config.GetSection("IsLocalRun").Value);
-
-            var msGraphDocsRepoLocation = isLocalRun
-                ? config.GetSection("DocsRepoCheckoutDirectory").Value
-                : Environment.GetEnvironmentVariable("BUILD_SOURCESDIRECTORY");
-
-            if (!Directory.Exists(msGraphDocsRepoLocation))
-            {
-                throw new FileNotFoundException("If you are running this locally, please set IsLocalRun=true with a valid DocsRepoCheckoutDirectory");
-            }
-
-            return msGraphDocsRepoLocation;
         }
     }
 }

--- a/TestsCommon/GraphDocsDirectory.cs
+++ b/TestsCommon/GraphDocsDirectory.cs
@@ -30,7 +30,7 @@ namespace TestsCommon
                 return SnippetsDirectory;
             }
 
-            var msGraphDocsRepoLocation = TestsSetup.GetConfig().DocsRepoCheckoutDirectory;
+            var msGraphDocsRepoLocation = TestsSetup.Config.Value.DocsRepoCheckoutDirectory;
             SnippetsDirectory = Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}includes{Path.DirectorySeparatorChar}snippets{Path.DirectorySeparatorChar}{language.AsString()}");
 
             return SnippetsDirectory;
@@ -45,7 +45,7 @@ namespace TestsCommon
         /// </returns>
         public static string GetDocumentationDirectory(Versions version)
         {
-            var msGraphDocsRepoLocation = TestsSetup.GetConfig().DocsRepoCheckoutDirectory;
+            var msGraphDocsRepoLocation = TestsSetup.Config.Value.DocsRepoCheckoutDirectory;
             return Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}api");
         }
     }

--- a/UnitTests/AppSettingsTests.cs
+++ b/UnitTests/AppSettingsTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using MsGraphSDKSnippetsCompiler;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    class AppSettingsTests
+    {
+        private const string CustomLabel = "Development.Codespaces";
+        private const string RaptorConfigLabel = "RAPTOR_CONFIGLABEL";
+
+        public static IConfigurationRoot EmptyConfig => new ConfigurationBuilder().Build();
+
+        public static IConfigurationRoot ConfigWithCustomLabel => new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    { RaptorConfigLabel, CustomLabel }
+                }).Build();
+
+        [Test]
+        public void CustomLabelExistsInLocalRun()
+        {
+            var label = AppSettings.GetAppConfigLabel(ConfigWithCustomLabel, isLocalRun: true);
+            Assert.AreEqual(CustomLabel, label);
+        }
+
+        [Test]
+        public void CustomLabelExistsInCI()
+        {
+            var label = AppSettings.GetAppConfigLabel(ConfigWithCustomLabel, isLocalRun: false);
+            Assert.AreEqual(CustomLabel, label);
+        }
+
+        [Test]
+        public void CustomLabelDoesNotExistInLocalRun()
+        {
+            var label = AppSettings.GetAppConfigLabel(EmptyConfig, isLocalRun: true);
+            Assert.AreEqual("Development", label);
+        }
+
+        [Test]
+        public void CustomLabelDoesNotExistInCI()
+        {
+            var label = AppSettings.GetAppConfigLabel(EmptyConfig, isLocalRun: false);
+            Assert.AreEqual("CI", label);
+        }
+
+        [Test]
+        public void ExpectExceptionIfConfigIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => AppSettings.GetAppConfigLabel(null, false));
+        }
+    }
+}

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -31,7 +31,6 @@ namespace MsGraphSDKSnippetsCompiler
         const string SourceCodePath = "generated.cs";
         private readonly string _markdownFileName;
         private readonly string _dllPath;
-        private readonly RaptorConfig _config;
         private readonly PermissionManager _permissionManagerApplication;
 
         /// for hiding bearer token
@@ -41,12 +40,10 @@ namespace MsGraphSDKSnippetsCompiler
 
         public MicrosoftGraphCSharpCompiler(string markdownFileName,
             string dllPath,
-            RaptorConfig config,
             PermissionManager permissionManagerApplication)
         {
             _markdownFileName = markdownFileName;
             _dllPath = dllPath;
-            _config = config;
             _permissionManagerApplication = permissionManagerApplication;
         }
         public MicrosoftGraphCSharpCompiler(string markdownFileName,
@@ -169,7 +166,7 @@ namespace MsGraphSDKSnippetsCompiler
                 {
                     var innerExceptionMessage = e.InnerException?.Message ?? string.Empty;
                     exceptionMessage = e.Message + Environment.NewLine + innerExceptionMessage;
-                    if (!_config.IsLocalRun)
+                    if (!TestsSetup.Config.Value.IsLocalRun)
                     {
                         exceptionMessage = AuthHeaderRegex.Replace(exceptionMessage, AuthHeaderReplacement);
                     }

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -38,9 +38,10 @@ namespace MsGraphSDKSnippetsCompiler.Models
         /// </summary>
         private IdentifierReplacer()
         {
-            var config = AppSettings.Config();
+            var config = TestsSetup.GetConfig();
+
             string json;
-            if (bool.Parse(config.GetSection("IsLocalRun").Value))
+            if (config.IsLocalRun)
             {
                 json = File.ReadAllText(@"identifiers.json");
             }
@@ -49,7 +50,7 @@ namespace MsGraphSDKSnippetsCompiler.Models
                 const string blobContainerName = "raptoridentifiers";
                 const string blobName = "identifiers.json";
 
-                var raptorStorageConnectionString = config.GetNonEmptyValue("RaptorStorageConnectionString");
+                var raptorStorageConnectionString = config.RaptorStorageConnectionString;
                 var blobClient = new BlobClient(raptorStorageConnectionString, blobContainerName, blobName);
 
                 using var stream = new MemoryStream();

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -38,7 +38,7 @@ namespace MsGraphSDKSnippetsCompiler.Models
         /// </summary>
         private IdentifierReplacer()
         {
-            var config = TestsSetup.GetConfig();
+            var config = TestsSetup.Config.Value;
 
             string json;
             if (config.IsLocalRun)

--- a/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System.IO;
+using Microsoft.Extensions.Configuration;
 
 namespace MsGraphSDKSnippetsCompiler.Models
 {
@@ -14,10 +15,17 @@ namespace MsGraphSDKSnippetsCompiler.Models
                 TenantID = config.GetNonEmptyValue(nameof(TenantID)),
                 ClientID = config.GetNonEmptyValue(nameof(ClientID)),
                 ClientSecret = config.GetNonEmptyValue(nameof(ClientSecret)),
-                DocsRepoCheckoutDirectory = config.GetNonEmptyValue(nameof(DocsRepoCheckoutDirectory)),
+                DocsRepoCheckoutDirectory = config.GetNonEmptyValue("BUILD_SOURCESDIRECTORY"),
                 RaptorStorageConnectionString = config.GetNonEmptyValue(nameof(RaptorStorageConnectionString)),
                 IsLocalRun = bool.Parse(config.GetNonEmptyValue(nameof(IsLocalRun)))
             };
+
+            if (!Directory.Exists(Path.Join(raptorConfig.DocsRepoCheckoutDirectory, "microsoft-graph-docs")))
+            {
+                throw new FileNotFoundException("If you are running this locally, please set environment" +
+                    " variable BUILD_SOURCESDIRECTORY to the docs repo checkout location.");
+            }
+
             return raptorConfig;
         }
 

--- a/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
@@ -4,11 +4,21 @@ namespace MsGraphSDKSnippetsCompiler.Models
 {
     public static class TestsSetup
     {
+        private static RaptorConfig _raptorConfig;
+        private static readonly object _configLock = new { };
+
         public static RaptorConfig GetConfig()
         {
-            var config = AppSettings.Config();
-            var raptorConfig = RaptorConfig.Create(config);
-            return raptorConfig;
+            lock (_configLock)
+            {
+                if (_raptorConfig == null)
+                {
+                    var config = AppSettings.Config();
+                    _raptorConfig = RaptorConfig.Create(config);
+                }
+
+                return _raptorConfig;
+            }
         }
 
         /// <summary>

--- a/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
@@ -1,35 +1,20 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace MsGraphSDKSnippetsCompiler.Models
 {
     public static class TestsSetup
     {
-        private static RaptorConfig _raptorConfig;
-        private static readonly object _configLock = new { };
-
-        public static RaptorConfig GetConfig()
-        {
-            lock (_configLock)
-            {
-                if (_raptorConfig == null)
-                {
-                    var config = AppSettings.Config();
-                    _raptorConfig = RaptorConfig.Create(config);
-                }
-
-                return _raptorConfig;
-            }
-        }
+        public static readonly Lazy<RaptorConfig> Config = new Lazy<RaptorConfig>(() => RaptorConfig.Create(AppSettings.Config()));
 
         /// <summary>
         /// Initilizes permission manager application with the tenant and application specified in the config
         /// Fetches delegated tokens and caches them
         /// </summary>
-        /// <param name="raptorConfig">Raptor configuration</param>
         /// <returns>Permission manager application to access auth providers and tokens</returns>
-        public static async Task<PermissionManager> GetPermissionManagerApplication(RaptorConfig raptorConfig)
+        public static async Task<PermissionManager> GetPermissionManagerApplication()
         {
-            var permissionManagerApplication = new PermissionManager(raptorConfig);
+            var permissionManagerApplication = new PermissionManager();
             await permissionManagerApplication.CreateDelegatedAuthProviders();
             return permissionManagerApplication;
         }

--- a/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
+++ b/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
@@ -39,9 +39,9 @@ namespace MsGraphSDKSnippetsCompiler
             get; init;
         }
 
-        public PermissionManager(RaptorConfig raptorConfig)
+        public PermissionManager()
         {
-            _config = raptorConfig;
+            _config = TestsSetup.Config.Value;
 
             const string DefaultAuthScope = "https://graph.microsoft.com/.default";
             AuthProvider = new TokenCredentialAuthProvider(


### PR DESCRIPTION
- read docs directory from environment variable shared with Azure DevOps, fixes #441 
- singleton access to raptor config per execution
- deduce IsLocalRun from env variables (BUILD_REASON and BUILD_BUILDID are expected to be set only in Azure DevOps runs).
- allow custom app config labels for testing different settings locally, fixes #442 
- remove indexed access to raw config, reuse raptor config