### PR TITLE
Make individual tests debuggable in VSCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "settings": {
+        "terminal.integrated.shell.linux": "/usr/bin/pwsh"
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,26 @@
 {
     "settings": {
-        "terminal.integrated.shell.linux": "/usr/bin/pwsh",
+        "terminal.integrated.profiles.linux": {
+            "bash": {
+                "path": "bash",
+                "icon": "terminal-bash"
+            },
+            "zsh": {
+                "path": "zsh"
+            },
+            "fish": {
+                "path": "fish"
+            },
+            "tmux": {
+                "path": "tmux",
+                "icon": "terminal-tmux"
+            },
+            "pwsh": {
+                "path": "pwsh",
+                "icon": "terminal-powershell"
+            }
+        },
+        "terminal.integrated.defaultProfile.linux": "pwsh",
         "workbench.colorTheme": "GitHub Dark Default"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
     "settings": {
-        "terminal.integrated.shell.linux": "/usr/bin/pwsh"
+        "terminal.integrated.shell.linux": "/usr/bin/pwsh",
+        "workbench.colorTheme": "Visual Studio Dark"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "settings": {
         "terminal.integrated.shell.linux": "/usr/bin/pwsh",
-        "workbench.colorTheme": "Visual Studio Dark"
+        "workbench.colorTheme": "GitHub Dark Default"
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ Generated\ Files/
 
 #VsCode auto generated files
 .vscode/
+!.vscode/tasks.json
+!.vscode/launch.json
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
@@ -228,7 +230,7 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk 
+# Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk
 
@@ -324,7 +326,7 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Azure Stream Analytics local run output 
+# Azure Stream Analytics local run output
 ASALocalRun/
 
 # MSBuild Binary and Structured Log
@@ -333,5 +335,5 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "request": "attach",
+            "type": "coreclr",
+            "processId": "${command:pickProcess}",
+            "name": ".NET Attach"
+        }
+    ]
+}

--- a/.vscode/tasks-json-generator.ps1
+++ b/.vscode/tasks-json-generator.ps1
@@ -52,10 +52,12 @@ foreach ($testProject in $testProjects)
 
     $obj.tasks += $task
 
-    $task.label += " filtered"
-    $task.args += "--filter `"`${input:testFilter}`""
+    # deep copy
+    $taskFiltered = $task | ConvertTo-Json -Depth 3 | ConvertFrom-Json
+    $taskFiltered.label += " filtered"
+    $taskFiltered.args += "--filter `"`${input:testFilter}`""
 
-    $obj.tasks += $task
+    $obj.tasks += $taskFiltered
 }
 
 $obj.inputs = @(

--- a/.vscode/tasks-json-generator.ps1
+++ b/.vscode/tasks-json-generator.ps1
@@ -1,0 +1,74 @@
+$obj = [ordered]@{
+    version = "2.0.0"
+    tasks = @()
+}
+
+$obj.tasks += [ordered]@{
+    label = "build"
+    command = "dotnet"
+    type = "shell"
+    args = @(
+        "build",
+        "`${workspaceFolder}/msgraph-sdk-raptor.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+    )
+    group = "build"
+    presentation = @{
+        reveal = "silent"
+    }
+    problemMatcher = "`$msCompile"
+}
+
+$obj.tasks += [ordered]@{
+    label = "checkout docs repo"
+    type = "shell"
+    command = "`${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '`${workspaceFolder}/..' -branchName '`${input:branchName}'"
+    presentation = [ordered]@{
+        echo = $true
+        reveal = "always"
+        focus = $false
+        panel = "shared"
+        showReuseMessage = $true
+        clear = $false
+    }
+}
+
+$testProjects = Get-ChildItem $PSScriptRoot/../*Tests | Select-Object -ExpandProperty Name
+
+foreach ($testProject in $testProjects)
+{
+    $task = [ordered]@{
+        label = $testProject
+        type = "process"
+        command = "dotnet"
+        args = @(
+            "test",
+            "`${workspaceFolder}/$testProject/$testProject.csproj"
+        )
+        isTestCommand = $true
+        problemMatcher = "`$msCompile"
+    }
+
+    $obj.tasks += $task
+
+    $task.label += " filtered"
+    $task.args += "--filter `"`${input:testFilter}`""
+
+    $obj.tasks += $task
+}
+
+$obj.inputs = @(
+    [ordered]@{
+        id = "branchName"
+        type = "promptString"
+        description = "documentation repo branch name"
+    },
+    [ordered]@{
+        id = "testFilter"
+        type = "promptString"
+        description = "test filter"
+    }
+)
+
+$obj | ConvertTo-Json -Depth 10 > $PSScriptRoot/tasks.json

--- a/.vscode/tasks-json-generator.ps1
+++ b/.vscode/tasks-json-generator.ps1
@@ -72,6 +72,7 @@ $obj.inputs = @(
         id = "branchName"
         type = "promptString"
         description = "documentation repo branch name"
+        default = "main"
     },
     [ordered]@{
         id = "testFilter"

--- a/.vscode/tasks-json-generator.ps1
+++ b/.vscode/tasks-json-generator.ps1
@@ -94,7 +94,7 @@ $obj.inputs = @(
     [ordered]@{
         id = "docsRepoCheckoutConfirmation"
         type = "promptString"
-        description = "This script will delete local changes in docs repo if you have any. Type YES to proceed."
+        description = "If this is your first checkout type YES. If not, this script will delete local changes in the docs repo to hard reset to the remote branch. Type YES to proceed."
         default = "NO"
     }
 )

--- a/.vscode/tasks-json-generator.ps1
+++ b/.vscode/tasks-json-generator.ps1
@@ -34,7 +34,7 @@ $obj.tasks += [ordered]@{
 $obj.tasks += [ordered]@{
     label = "checkout docs repo"
     type = "shell"
-    command = "`${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '`${workspaceFolder}/..' -branchName '`${input:branchName}'"
+    command = "`${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '`${workspaceFolder}/..' -branchName '`${input:branchName}' -confirmation '`${input:docsRepoCheckoutConfirmation}'"
     presentation = [ordered]@{
         echo = $true
         reveal = "always"
@@ -90,6 +90,12 @@ $obj.inputs = @(
         type = "promptString"
         description = "test filter"
         default = "."
+    },
+    [ordered]@{
+        id = "docsRepoCheckoutConfirmation"
+        type = "promptString"
+        description = "This script will delete local changes in docs repo if you have any. Type YES to proceed."
+        default = "NO"
     }
 )
 

--- a/.vscode/tasks-json-generator.ps1
+++ b/.vscode/tasks-json-generator.ps1
@@ -1,3 +1,14 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+<#
+.SYNOPSIS
+  This script generates a tasks.json for the repo
+.DESCRIPTION
+  - Gets all the test projects
+  - Generate 1 Run task and 1 Debug task for each test project
+  - Add VSTEST_HOST_DEBUG=1 flag for Debug runs to be able to attach
+#>
+
 $obj = [ordered]@{
     version = "2.0.0"
     tasks = @()
@@ -38,7 +49,7 @@ $testProjects = Get-ChildItem $PSScriptRoot/../*Tests | Select-Object -ExpandPro
 
 foreach ($testProject in $testProjects)
 {
-    $task = [ordered]@{
+    $taskRun = [ordered]@{
         label = "Run $testProject"
         type = "process"
         command = "dotnet"
@@ -52,10 +63,10 @@ foreach ($testProject in $testProjects)
         problemMatcher = "`$msCompile"
     }
 
-    $obj.tasks += $task
+    $obj.tasks += $taskRun
 
-    # debug tasks
-    $taskDebug = $task | ConvertTo-Json -Depth 3 | ConvertFrom-Json
+    # deep copy run task object for debug task
+    $taskDebug = $taskRun | ConvertTo-Json -Depth 3 | ConvertFrom-Json
     $taskDebug.label = $taskDebug.label.Replace("Run ", "Debug ")
     Add-Member -InputObject $taskDebug -MemberType NoteProperty -Name options -Value @{
         env = @{

--- a/.vscode/tasks-json-generator.ps1
+++ b/.vscode/tasks-json-generator.ps1
@@ -88,7 +88,7 @@ $obj.inputs = @(
     [ordered]@{
         id = "testFilter"
         type = "promptString"
-        description = "test filter"
+        description = "test filter (leave . if you want to run all the tests)"
         default = "."
     },
     [ordered]@{

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,45 +1,334 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build",
-            "command": "dotnet",
-            "type": "shell",
-            "args": [
-                "build",
-                "${workspaceFolder}/msgraph-sdk-raptor.sln",
-                // Ask dotnet build to generate full paths for file names.
-                "/property:GenerateFullPaths=true",
-                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "group": "build",
-            "presentation": {
-                "reveal": "silent"
-            },
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "checkout docs repo",
-            "type": "shell",
-            "command": "${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '${workspaceFolder}/..' -branchName '${input:branchName}'",
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
-            }
-        }
-    ],
-    "inputs": [
-        {
-            "id": "branchName",
-            "type": "promptString",
-            "description": "documentation repo branch name"
-        }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "${workspaceFolder}/msgraph-sdk-raptor.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "checkout docs repo",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '${workspaceFolder}/..' -branchName '${input:branchName}'",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      }
+    },
+    {
+      "label": "CSharpArbitraryDllTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CSharpArbitraryDllTests/CSharpArbitraryDllTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CSharpArbitraryDllTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CSharpArbitraryDllTests/CSharpArbitraryDllTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpBetaExecutionTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpBetaExecutionTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpBetaKnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpBetaKnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpBetaTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaTests/CsharpBetaTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpBetaTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaTests/CsharpBetaTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpV1ExecutionTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpV1ExecutionTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpV1KnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpV1KnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpV1Tests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1Tests/CsharpV1Tests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "CsharpV1Tests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1Tests/CsharpV1Tests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaBetaKnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaBetaKnownFailureTests/JavaBetaKnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaBetaKnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaBetaKnownFailureTests/JavaBetaKnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaBetaTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaBetaTests/JavaBetaTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaBetaTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaBetaTests/JavaBetaTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaV1KnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaV1KnownFailureTests/JavaV1KnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaV1KnownFailureTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaV1KnownFailureTests/JavaV1KnownFailureTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaV1Tests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaV1Tests/JavaV1Tests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "JavaV1Tests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/JavaV1Tests/JavaV1Tests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "UnitTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/UnitTests/UnitTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "UnitTests filtered",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/UnitTests/UnitTests.csproj",
+        "--filter \"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "branchName",
+      "type": "promptString",
+      "description": "documentation repo branch name"
+    },
+    {
+      "id": "testFilter",
+      "type": "promptString",
+      "description": "test filter"
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,13 +31,12 @@
       }
     },
     {
-      "label": "CSharpArbitraryDllTests filtered",
+      "label": "CSharpArbitraryDllTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CSharpArbitraryDllTests/CSharpArbitraryDllTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/CSharpArbitraryDllTests/CSharpArbitraryDllTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -55,13 +54,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpBetaExecutionTests filtered",
+      "label": "CsharpBetaExecutionTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -79,13 +77,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpBetaKnownFailureTests filtered",
+      "label": "CsharpBetaKnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -103,13 +100,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpBetaTests filtered",
+      "label": "CsharpBetaTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpBetaTests/CsharpBetaTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/CsharpBetaTests/CsharpBetaTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -127,13 +123,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpV1ExecutionTests filtered",
+      "label": "CsharpV1ExecutionTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -151,13 +146,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpV1KnownFailureTests filtered",
+      "label": "CsharpV1KnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -175,13 +169,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpV1Tests filtered",
+      "label": "CsharpV1Tests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpV1Tests/CsharpV1Tests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/CsharpV1Tests/CsharpV1Tests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -199,13 +192,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaBetaKnownFailureTests filtered",
+      "label": "JavaBetaKnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaBetaKnownFailureTests/JavaBetaKnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/JavaBetaKnownFailureTests/JavaBetaKnownFailureTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -223,13 +215,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaBetaTests filtered",
+      "label": "JavaBetaTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaBetaTests/JavaBetaTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/JavaBetaTests/JavaBetaTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -247,13 +238,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaV1KnownFailureTests filtered",
+      "label": "JavaV1KnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaV1KnownFailureTests/JavaV1KnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/JavaV1KnownFailureTests/JavaV1KnownFailureTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -271,13 +261,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaV1Tests filtered",
+      "label": "JavaV1Tests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaV1Tests/JavaV1Tests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/JavaV1Tests/JavaV1Tests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
@@ -295,13 +284,12 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "UnitTests filtered",
+      "label": "UnitTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/UnitTests/UnitTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "${workspaceFolder}/UnitTests/UnitTests.csproj"
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,24 +1,45 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=733558
-	// for the documentation about the tasks.json format
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"label": "build",
-			"command": "dotnet",
-			"type": "shell",
-			"args": [
-				"build",
-				// Ask dotnet build to generate full paths for file names.
-				"/property:GenerateFullPaths=true",
-				// Do not generate summary otherwise it leads to duplicate errors in Problems panel
-				"/consoleloggerparameters:NoSummary"
-			],
-			"group": "build",
-			"presentation": {
-				"reveal": "silent"
-			},
-			"problemMatcher": "$msCompile"
-		}
-	]
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "${workspaceFolder}/msgraph-sdk-raptor.sln",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "checkout docs repo",
+            "type": "shell",
+            "command": "${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '${workspaceFolder}/..' -branchName '${input:branchName}'",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            }
+        }
+    ],
+    "inputs": [
+        {
+            "id": "branchName",
+            "type": "promptString",
+            "description": "documentation repo branch name"
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,280 +31,452 @@
       }
     },
     {
-      "label": "CSharpArbitraryDllTests",
-      "type": "process",
-      "command": "dotnet",
-      "args": [
-        "test",
-        "${workspaceFolder}/CSharpArbitraryDllTests/CSharpArbitraryDllTests.csproj"
-      ],
-      "isTestCommand": true,
-      "problemMatcher": "$msCompile"
-    },
-    {
-      "label": "CSharpArbitraryDllTests filtered",
+      "label": "Run CSharpArbitraryDllTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/CSharpArbitraryDllTests/CSharpArbitraryDllTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpBetaExecutionTests",
+      "label": "Debug CSharpArbitraryDllTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj"
+        "${workspaceFolder}/CSharpArbitraryDllTests/CSharpArbitraryDllTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
+    },
+    {
+      "label": "Run CsharpBetaExecutionKnownFailureTests",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaExecutionKnownFailureTests/CsharpBetaExecutionKnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpBetaExecutionTests filtered",
+      "label": "Debug CsharpBetaExecutionKnownFailureTests",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpBetaExecutionKnownFailureTests/CsharpBetaExecutionKnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
+    },
+    {
+      "label": "Run CsharpBetaExecutionTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpBetaKnownFailureTests",
+      "label": "Debug CsharpBetaExecutionTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj"
+        "${workspaceFolder}/CsharpBetaExecutionTests/CsharpBetaExecutionTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "CsharpBetaKnownFailureTests filtered",
+      "label": "Run CsharpBetaKnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpBetaTests",
+      "label": "Debug CsharpBetaKnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpBetaTests/CsharpBetaTests.csproj"
+        "${workspaceFolder}/CsharpBetaKnownFailureTests/CsharpBetaKnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "CsharpBetaTests filtered",
+      "label": "Run CsharpBetaTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/CsharpBetaTests/CsharpBetaTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpV1ExecutionTests",
+      "label": "Debug CsharpBetaTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj"
+        "${workspaceFolder}/CsharpBetaTests/CsharpBetaTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
+    },
+    {
+      "label": "Run CsharpV1ExecutionKnownFailureTests",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1ExecutionKnownFailureTests/CsharpV1ExecutionKnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpV1ExecutionTests filtered",
+      "label": "Debug CsharpV1ExecutionKnownFailureTests",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/CsharpV1ExecutionKnownFailureTests/CsharpV1ExecutionKnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
+    },
+    {
+      "label": "Run CsharpV1ExecutionTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpV1KnownFailureTests",
+      "label": "Debug CsharpV1ExecutionTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj"
+        "${workspaceFolder}/CsharpV1ExecutionTests/CsharpV1ExecutionTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "CsharpV1KnownFailureTests filtered",
+      "label": "Run CsharpV1KnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "CsharpV1Tests",
+      "label": "Debug CsharpV1KnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/CsharpV1Tests/CsharpV1Tests.csproj"
+        "${workspaceFolder}/CsharpV1KnownFailureTests/CsharpV1KnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "CsharpV1Tests filtered",
+      "label": "Run CsharpV1Tests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/CsharpV1Tests/CsharpV1Tests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaBetaKnownFailureTests",
+      "label": "Debug CsharpV1Tests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaBetaKnownFailureTests/JavaBetaKnownFailureTests.csproj"
+        "${workspaceFolder}/CsharpV1Tests/CsharpV1Tests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "JavaBetaKnownFailureTests filtered",
+      "label": "Run JavaBetaKnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/JavaBetaKnownFailureTests/JavaBetaKnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaBetaTests",
+      "label": "Debug JavaBetaKnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaBetaTests/JavaBetaTests.csproj"
+        "${workspaceFolder}/JavaBetaKnownFailureTests/JavaBetaKnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "JavaBetaTests filtered",
+      "label": "Run JavaBetaTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/JavaBetaTests/JavaBetaTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaV1KnownFailureTests",
+      "label": "Debug JavaBetaTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaV1KnownFailureTests/JavaV1KnownFailureTests.csproj"
+        "${workspaceFolder}/JavaBetaTests/JavaBetaTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "JavaV1KnownFailureTests filtered",
+      "label": "Run JavaV1KnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/JavaV1KnownFailureTests/JavaV1KnownFailureTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "JavaV1Tests",
+      "label": "Debug JavaV1KnownFailureTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/JavaV1Tests/JavaV1Tests.csproj"
+        "${workspaceFolder}/JavaV1KnownFailureTests/JavaV1KnownFailureTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "JavaV1Tests filtered",
+      "label": "Run JavaV1Tests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/JavaV1Tests/JavaV1Tests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "UnitTests",
+      "label": "Debug JavaV1Tests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
-        "${workspaceFolder}/UnitTests/UnitTests.csproj"
+        "${workspaceFolder}/JavaV1Tests/JavaV1Tests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
-      "problemMatcher": "$msCompile"
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     },
     {
-      "label": "UnitTests filtered",
+      "label": "Run UnitTests",
       "type": "process",
       "command": "dotnet",
       "args": [
         "test",
         "${workspaceFolder}/UnitTests/UnitTests.csproj",
-        "--filter \"${input:testFilter}\""
+        "--filter",
+        "\"${input:testFilter}\""
       ],
       "isTestCommand": true,
       "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Debug UnitTests",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "test",
+        "${workspaceFolder}/UnitTests/UnitTests.csproj",
+        "--filter",
+        "\"${input:testFilter}\""
+      ],
+      "isTestCommand": true,
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "VSTEST_HOST_DEBUG": "1"
+        }
+      }
     }
   ],
   "inputs": [
@@ -316,7 +488,8 @@
     {
       "id": "testFilter",
       "type": "promptString",
-      "description": "test filter"
+      "description": "test filter",
+      "default": "."
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -495,7 +495,7 @@
     {
       "id": "docsRepoCheckoutConfirmation",
       "type": "promptString",
-      "description": "This script will delete local changes in docs repo if you have any. Type YES to proceed.",
+      "description": "If this is your first checkout type YES. If not, this script will delete local changes in the docs repo to hard reset to the remote branch. Type YES to proceed.",
       "default": "NO"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -483,7 +483,8 @@
     {
       "id": "branchName",
       "type": "promptString",
-      "description": "documentation repo branch name"
+      "description": "documentation repo branch name",
+      "default": "main"
     },
     {
       "id": "testFilter",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -489,7 +489,7 @@
     {
       "id": "testFilter",
       "type": "promptString",
-      "description": "test filter",
+      "description": "test filter (leave . if you want to run all the tests)",
       "default": "."
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,7 +20,7 @@
     {
       "label": "checkout docs repo",
       "type": "shell",
-      "command": "${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '${workspaceFolder}/..' -branchName '${input:branchName}'",
+      "command": "${workspaceFolder}/scripts/tasks/checkout-docs-repo.ps1 '${workspaceFolder}/..' -branchName '${input:branchName}' -confirmation '${input:docsRepoCheckoutConfirmation}'",
       "presentation": {
         "echo": true,
         "reveal": "always",
@@ -491,6 +491,12 @@
       "type": "promptString",
       "description": "test filter",
       "default": "."
+    },
+    {
+      "id": "docsRepoCheckoutConfirmation",
+      "type": "promptString",
+      "description": "This script will delete local changes in docs repo if you have any. Type YES to proceed.",
+      "default": "NO"
     }
   ]
 }

--- a/scripts/tasks/checkout-docs-repo.ps1
+++ b/scripts/tasks/checkout-docs-repo.ps1
@@ -1,0 +1,21 @@
+param(
+    [Parameter(Mandatory=$true)][string]$rootDirectory,
+    [string]$branchName = "main"
+)
+
+$docsRepoName = "microsoft-graph-docs"
+
+Set-Location $rootDirectory
+$docsRepoExists = Test-Path $docsRepoName
+if (!$docsRepoExists)
+{
+    git clone "https://github.com/microsoftgraph/$docsRepoName"
+}
+
+Set-Location $docsRepoName
+git fetch
+git reset --hard
+git checkout $branchName
+git pull -f
+
+Write-Host "checkout docs repo script"

--- a/scripts/tasks/checkout-docs-repo.ps1
+++ b/scripts/tasks/checkout-docs-repo.ps1
@@ -1,3 +1,10 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+<#
+.SYNOPSIS
+  This script checks out microsoft-graph-docs repo or resets to a particular branch
+#>
+
 param(
     [Parameter(Mandatory=$true)][string]$rootDirectory,
     [string]$branchName = "main"

--- a/scripts/tasks/checkout-docs-repo.ps1
+++ b/scripts/tasks/checkout-docs-repo.ps1
@@ -13,7 +13,7 @@ param(
 
 if ($confirmation -ne "YES")
 {
-    Write-Warning "will not proceed to checkout docs repo!"
+    Write-Warning "will not proceed to checkout docs repo because the operation was not confirmed!"
     exit
 }
 

--- a/scripts/tasks/checkout-docs-repo.ps1
+++ b/scripts/tasks/checkout-docs-repo.ps1
@@ -7,8 +7,15 @@
 
 param(
     [Parameter(Mandatory=$true)][string]$rootDirectory,
-    [string]$branchName = "main"
+    [string]$branchName = "main",
+    [string]$confirmation = "NO"
 )
+
+if ($confirmation -ne "YES")
+{
+    Write-Warning "will not proceed to checkout docs repo!"
+    exit
+}
 
 $docsRepoName = "microsoft-graph-docs"
 


### PR DESCRIPTION
fixes #454

- Updated `tasks.json` to debug individual tests in VSCode and Github Codespaces. VSTEST_HOST_DEBUG allows attaching debugger to a `dotnet test` process. (See more details here: https://stackoverflow.com/questions/47066356/how-does-one-debug-an-mstest-in-vscode/47241515#47241515).
- Added tasks.json generator to reuse after extending the solution with more projects.
- Added a task to checkout docs repo as it is a prerequisite to run anything on Raptor.

TODO:
- [ ] #457