### PR TITLE
Set SignInAudience to allow all permissions from devx-content

### DIFF
--- a/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
+++ b/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
@@ -148,6 +148,7 @@ namespace MsGraphSDKSnippetsCompiler
                     RedirectUris = new string[] { "http://localhost" }
                 },
                 RequiredResourceAccess = new List<RequiredResourceAccess> { requiredResourceAccess },
+                SignInAudience = "AzureADMyOrg",
                 IsFallbackPublicClient = true // allowPublicClient: true in application manifest
             };
 


### PR DESCRIPTION
Some permissions are not assignable to MSA audience because the default value for `SignInAudience` is `AzureADAndPersonalMicrosoftAccount`. ([description here](https://docs.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0#properties))

Here is the summary of local DelegatedAppCreator run after deleting all existing applications:
```
=========================
Summary:
-------------------------
number of existing applications: 0
number of expected applications: 296
number of missing applications: 296
number of successfully created applications in this run: 296
number of failed application creation attempts: 0
```

fixes #466 