### PR TITLE
Make test output parsable for DevX API 404 responses for permissions

### DIFF
--- a/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
+++ b/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
+using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;

--- a/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
+++ b/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using MsGraphSDKSnippetsCompiler;
 using MsGraphSDKSnippetsCompiler.Models;
 
 using NUnit.Framework;
@@ -32,7 +31,7 @@ namespace CsharpBetaExecutionKnownFailureTests
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
         [RetryTestCaseSource(typeof(SnippetExecutionBetaKnownFailureTests), nameof(TestDataBeta), MaxTries = 3)]
-        public async Task Test(ExecutionTestData testData)
+        public async Task Test(LanguageTestData testData)
         {
             await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
         }

--- a/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
+++ b/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using MsGraphSDKSnippetsCompiler;
 using MsGraphSDKSnippetsCompiler.Models;
 
 using NUnit.Framework;
@@ -32,7 +31,7 @@ namespace CsharpBetaExecutionTests
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
         [RetryTestCaseSource(typeof(SnippetExecutionBetaTests), nameof(TestDataBeta), MaxTries = 3)]
-        public async Task Test(ExecutionTestData testData)
+        public async Task Test(LanguageTestData testData)
         {
             await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
         }

--- a/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
+++ b/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using MsGraphSDKSnippetsCompiler;
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using TestsCommon;
@@ -30,7 +29,7 @@ namespace CsharpV1ExecutionKnownFailureTests
         /// <param name="version">Docs version (e.g. V1, Beta)</param>
         [Test]
         [RetryTestCaseSource(typeof(SnippetExecutionV1KnownFailureTests), nameof(TestDataV1), MaxTries = 3)]
-        public async Task Test(ExecutionTestData testData)
+        public async Task Test(LanguageTestData testData)
         {
             await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
         }

--- a/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
+++ b/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using MsGraphSDKSnippetsCompiler;
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using TestsCommon;
@@ -28,7 +27,7 @@ namespace CsharpV1ExecutionTests
         /// <param name="testData"></param>
         [Test]
         [RetryTestCaseSource(typeof(SnippetExecutionV1Tests), nameof(TestDataV1), MaxTries = 3)]
-        public async Task Test(ExecutionTestData testData)
+        public async Task Test(LanguageTestData testData)
         {
             await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
         }

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -89,14 +89,10 @@ public class GraphSDKTest
                 throw new ArgumentNullException(nameof(testData));
             }
 
-            var fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(testData.Version, Languages.CSharp), testData.FileName);
-            Assert.IsTrue(File.Exists(fullPath), "Snippet file referenced in documentation is not found!");
-
-            var fileContent = File.ReadAllText(fullPath);
-            var (codeToCompile, codeSnippetFormatted) = GetCodeToCompile(fileContent);
+            var (codeToCompile, codeSnippetFormatted) = GetCodeToCompile(testData.FileContent);
 
             // Compile Code
-            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData.FileName, testData.DllPath);
+            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData);
             var compilationResultsModel = microsoftGraphCSharpCompiler.CompileSnippet(codeToCompile, testData.Version);
 
             var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsCompilationKnownIssue);
@@ -112,20 +108,14 @@ public class GraphSDKTest
         /// 4. Attempts to compile and reports errors if there is any
         /// 5. It uses the compiled binary to make a request to the demo tenant and reports error if there's a service exception i.e 4XX or 5xx response
         /// </summary>
-        /// <param name="executionTestData">Test data containing information such as snippet file name</param>
-        public static async Task Execute(ExecutionTestData executionTestData)
+        /// <param name="testData">Test data containing information such as snippet file name</param>
+        public static async Task Execute(LanguageTestData testData)
         {
-            if (executionTestData == null)
-            {
-                throw new ArgumentNullException(nameof(executionTestData));
-            }
 
-            var testData = executionTestData.LanguageTestData;
-
-            var (codeToCompile, codeSnippetFormatted) = GetCodeToExecute(executionTestData.FileContent);
+            var (codeToCompile, codeSnippetFormatted) = GetCodeToExecute(testData.FileContent);
 
             // Compile Code
-            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData.FileName, testData.DllPath);
+            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData);
             var executionResultsModel = await microsoftGraphCSharpCompiler
                 .ExecuteSnippet(codeToCompile, testData.Version)
                 .ConfigureAwait(false);

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -111,6 +111,10 @@ public class GraphSDKTest
         /// <param name="testData">Test data containing information such as snippet file name</param>
         public static async Task Execute(LanguageTestData testData)
         {
+            if (testData == null)
+            {
+                throw new ArgumentNullException(nameof(testData));
+            }
 
             var (codeToCompile, codeSnippetFormatted) = GetCodeToExecute(testData.FileContent);
 

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -75,16 +75,14 @@ namespace TestsCommon
         public static IEnumerable<TestCaseData> GetExecutionTestData(RunSettings runSettings)
         {
             return from testData in GetLanguageTestData(runSettings)
-                   let fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(testData.Version, runSettings.Language), testData.FileName)
-                   let fileContent = File.ReadAllText(fullPath)
-                   let executionTestData = new ExecutionTestData(testData with
+                   let LanguageTestData = testData with
                    {
-                       TestName = testData.TestName.Replace("-compiles", "-executes")
-                   }, fileContent)
+                       TestName = testData.TestName.Replace("-compiles", "-executes"),
+                   }
                    where !testData.IsCompilationKnownIssue // select compiling tests
                    && !(testData.IsExecutionKnownIssue ^ runSettings.TestType == TestType.ExecutionKnownIssues) // select known execution issues iff requested
-                   && fileContent.Contains("GetAsync()") // select only the get tests
-                   select new TestCaseData(executionTestData).SetName(executionTestData.LanguageTestData.KnownIssueTestNamePrefix + executionTestData.LanguageTestData.TestName).SetProperty("Owner", executionTestData.LanguageTestData.Owner);
+                   && testData.FileContent.Contains("GetAsync()") // select only the get tests
+                   select new TestCaseData(LanguageTestData).SetName(testData.KnownIssueTestNamePrefix + testData.TestName).SetProperty("Owner", LanguageTestData.Owner);
         }
 
         private static IEnumerable<LanguageTestData> GetLanguageTestData(RunSettings runSettings)
@@ -114,6 +112,8 @@ namespace TestsCommon
                    let knownIssueMessage = compilationKnownIssue?.Message ?? executionKnownIssue?.Message ?? string.Empty
                    let knownIssueTestNamePrefix = compilationKnownIssue?.TestNamePrefix ?? executionKnownIssue?.TestNamePrefix ?? string.Empty
                    let owner = compilationKnownIssue?.Owner ?? executionKnownIssue?.Message ?? string.Empty
+                   let fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(version, runSettings.Language), fileName)
+                   let fileContent = File.ReadAllText(fullPath)
                    select new LanguageTestData(
                            version,
                            isCompilationKnownIssue,
@@ -127,7 +127,8 @@ namespace TestsCommon
                            runSettings.JavaLibVersion,
                            runSettings.JavaPreviewLibPath,
                            testName,
-                           owner);
+                           owner,
+                           fileContent);
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -29,8 +29,7 @@ namespace MsGraphSDKSnippetsCompiler
     public class MicrosoftGraphCSharpCompiler : IMicrosoftGraphSnippetsCompiler
     {
         const string SourceCodePath = "generated.cs";
-        private readonly string _markdownFileName;
-        private readonly string _dllPath;
+        private readonly LanguageTestData TestData;
         private bool _isEducation;
 
         private async Task<PermissionManager> GetPermissionManager()
@@ -45,11 +44,9 @@ namespace MsGraphSDKSnippetsCompiler
         private const string AuthHeaderReplacement = "Authorization: Bearer <token>";
         private static readonly Regex AuthHeaderRegex = new Regex(AuthHeaderPattern, RegexOptions.Compiled);
 
-        public MicrosoftGraphCSharpCompiler(string markdownFileName,
-            string dllPath)
+        public MicrosoftGraphCSharpCompiler(LanguageTestData testData)
         {
-            _markdownFileName = markdownFileName;
-            _dllPath = dllPath;
+            TestData = testData;
         }
 
         /// <summary>
@@ -91,14 +88,14 @@ namespace MsGraphSDKSnippetsCompiler
             };
 
             //Use the right Microsoft Graph Version
-            if (!string.IsNullOrEmpty(_dllPath))
+            if (!string.IsNullOrEmpty(TestData.DllPath))
             {
-                if (!System.IO.File.Exists(_dllPath))
+                if (!System.IO.File.Exists(TestData.DllPath))
                 {
-                    throw new ArgumentException($"Provided dll path {_dllPath} doesn't exist!");
+                    throw new ArgumentException($"Provided dll path {TestData.DllPath} doesn't exist!");
                 }
 
-                metadataReferences.Add(MetadataReference.CreateFromFile(_dllPath));
+                metadataReferences.Add(MetadataReference.CreateFromFile(TestData.DllPath));
             }
             else if (version == Versions.V1)
             {
@@ -317,7 +314,7 @@ namespace MsGraphSDKSnippetsCompiler
                 ? null
                 : emitResult.Diagnostics.Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error);
 
-            return new CompilationResultsModel(emitResult.Success, failures, _markdownFileName);
+            return new CompilationResultsModel(emitResult.Success, failures, TestData.FileName);
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -237,7 +237,7 @@ namespace MsGraphSDKSnippetsCompiler
         /// If DevX API fails to return scopes for both application and delegation permissions,
         /// throws an AggregateException containing the last exception from the service
         /// </exception>
-        private static async Task<Scope[]> GetScopes(HttpRequestMessage httpRequestMessage)
+        private async Task<Scope[]> GetScopes(HttpRequestMessage httpRequestMessage)
         {
             var path = httpRequestMessage.RequestUri.LocalPath;
             var versionSegmentLength = "/v1.0".Length;
@@ -276,7 +276,9 @@ namespace MsGraphSDKSnippetsCompiler
             }
             catch (Exception e)
             {
-                TestContext.Out.WriteLine($"Can't get scopes for both delegated and application scopes, url={httpRequestMessage.RequestUri}");
+                TestContext.Out.WriteLine($"Can't get scopes for both delegated and application scopes");
+                TestContext.Out.WriteLine($"url={httpRequestMessage.RequestUri}");
+                TestContext.Out.WriteLine($"docslink={TestData.DocsLink}");
                 throw new AggregateException("Can't get scopes for both delegated and application scopes", e);
             }
         }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -46,6 +46,11 @@ namespace MsGraphSDKSnippetsCompiler
 
         public MicrosoftGraphCSharpCompiler(LanguageTestData testData)
         {
+            if (testData is null)
+            {
+                throw new ArgumentNullException(nameof(testData));
+            }
+
             TestData = testData;
         }
 

--- a/msgraph-sdk-raptor-compiler-lib/Models/LanguageTestData.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/LanguageTestData.cs
@@ -1,6 +1,4 @@
-﻿using MsGraphSDKSnippetsCompiler.Models;
-
-namespace TestsCommon
+﻿namespace MsGraphSDKSnippetsCompiler.Models
 {
     /// <summary>
     /// Test Data
@@ -16,6 +14,9 @@ namespace TestsCommon
     /// <param name="JavaCoreVersion">Optional. Version to use for the java core library. Ignored when using JavaPreviewLibPath</param>
     /// <param name="JavaLibVersion">Optional. Version to use for the java service library. Ignored when using JavaPreviewLibPath</param>
     /// <param name="JavaPreviewLibPath">Optional. Folder container the java core and java service library repositories so the unit testing uses that local version instead.</param>
+    /// <param name="TestName">name of the test case</param>
+    /// <param name="Owner">test case owner</param>
+    /// <param name="FileContent">contents of the snippet file</param>
     public record LanguageTestData(
         Versions Version,
         bool IsCompilationKnownIssue,
@@ -29,9 +30,6 @@ namespace TestsCommon
         string JavaLibVersion,
         string JavaPreviewLibPath,
         string TestName,
-        string Owner);
-
-    public record ExecutionTestData(
-        LanguageTestData LanguageTestData,
+        string Owner,
         string FileContent);
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Microsoft.Extensions.Configuration;
 
 namespace MsGraphSDKSnippetsCompiler.Models

--- a/scripts/extract-permission-missing-issues.ps1
+++ b/scripts/extract-permission-missing-issues.ps1
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+Param(
+    [string]$trxPath = "$env:BUILD_SOURCESDIRECTORY/msgraph-sdk-raptor/TestResults/RaptorTestResults.trx"
+)
+
+if (!(Test-Path $trxPath))
+{
+    Write-Error "please provide a path to a trx file"
+    exit
+}
+
+[xml]$results = Get-Content $trxPath
+return $results.TestRun.Results.UnitTestResult |
+    Where-Object { $_.Output?.StdOut?.Contains("Can't get scopes for both") } |
+    Select-Object -ExpandProperty Output |
+    Select-Object -ExpandProperty StdOut |
+    ForEach-Object {
+        # last two lines of the StdOut are of the form:
+        # url=<url>
+        # docslink=<docslink>
+        $lines = $_.Split([System.Environment]::NewLine)
+        return @{
+            url = $lines[-2].Split("url=")[-1];
+            docslink = $lines[-1].Split("docslink=")[-1]
+        }
+    } |
+    # convert array of objects into a flattened table with url and docs link columns
+    ForEach-Object { [PSCustomObject]$_ }


### PR DESCRIPTION
- Refactored the code to access link to documentation page (`DocsLink`) at exception time (first commit: https://github.com/microsoftgraph/msgraph-sdk-raptor/commit/d500543a721d0437a0c324d9e117b7afa514bad5).
  - Flattened `ExecutionTestData` and `LanguageTestData` types into a single `LanguageTestData` type because `LanguageTestData` already had execution related properties and `ExecutionTestData` was not adding too much value.
  - Made `MicrosoftGraphCSharpCompiler` type to refer to `LanguageTestData` directly so that we don't have to plumb properties one by one. We needed `DocsLink` in this particular occasion, but `FileName` and `DllPath` were already being plumbed.
- Tweaked the output to be parsable and added a quick PowerShell parser to create a table output for DevX API permission issues (second commit: https://github.com/microsoftgraph/msgraph-sdk-raptor/commit/845314622e91b0b274b7535248b2dee0e69d57c1)

fixes #480 