### PR TITLE
Newly Added APIs for Bitlocker lack an API to create bitlocker Keys.

### DIFF
--- a/TestsCommon/CSharpKnownIssues.cs
+++ b/TestsCommon/CSharpKnownIssues.cs
@@ -895,6 +895,10 @@ namespace TestsCommon
                 { "subjectrightsrequest-getfinalattachment-csharp-V1-executes", NeedsAnalysisKnownIssue },
                 { "get-subjectrightsrequest-csharp-V1-executes", NeedsAnalysisKnownIssue },
                 { "subjectrightsrequest-getfinalreport-csharp-V1-executes", NeedsAnalysisKnownIssue },
+                { "list-bitlockerrecoverykey-csharp-V1-executes",MissingDataKnownIssue },
+                { "list-bitlockerrecoverykey-filter-deviceid-csharp-V1-executes", MissingDataKnownIssue },
+                { "get-bitlockerrecoverykey-key-csharp-V1-executes", MissingDataKnownIssue },
+                { "get-bitlockerrecoverykey-csharp-V1-executes", MissingDataKnownIssue }
             };
         }
     }


### PR DESCRIPTION
Newly Added APIs for Bitlocker lack an API to create BitrLocker Keys.
This PR marks these tests as known Issues. 