### PR TITLE
C# 10 features

### DIFF
--- a/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
+++ b/CSharpArbitraryDllTests/SnippetCompileArbitraryDllTests.cs
@@ -5,28 +5,27 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace CSharpArbitraryDllTests
-{
-    [TestFixture]
-    public class SnippetCompileArbitraryDllTests
-    {
-        /// <summary>
-        /// Gets TestCaseData for version specified in Test.runsettings
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> ArbitraryDllTestData => TestDataGenerator.GetTestCaseData(new RunSettings(TestContext.Parameters));
+namespace CSharpArbitraryDllTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(SnippetCompileArbitraryDllTests), nameof(ArbitraryDllTestData))]
-        public void Test(LanguageTestData testData)
-        {
-            CSharpTestRunner.Compile(testData);
-        }
+[TestFixture]
+public class SnippetCompileArbitraryDllTests
+{
+    /// <summary>
+    /// Gets TestCaseData for version specified in Test.runsettings
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> ArbitraryDllTestData => TestDataGenerator.GetTestCaseData(new RunSettings(TestContext.Parameters));
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(SnippetCompileArbitraryDllTests), nameof(ArbitraryDllTestData))]
+    public void Test(LanguageTestData testData)
+    {
+        CSharpTestRunner.Compile(testData);
     }
 }

--- a/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
+++ b/CsharpBetaExecutionKnownFailureTests/SnippetExecutionBetaKnownFailureTests.cs
@@ -6,34 +6,33 @@ using NUnit.Framework;
 
 using TestsCommon;
 
-namespace CsharpBetaExecutionKnownFailureTests
-{
-    [TestFixture]
-    public class SnippetExecutionBetaKnownFailureTests
-    {
-        /// <summary>
-        /// Gets TestCaseData for Beta
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetExecutionTestData(
-            new RunSettings
-            {
-                Version = Versions.Beta,
-                Language = Languages.CSharp,
-                TestType = TestType.ExecutionKnownIssues
-            });
+namespace CsharpBetaExecutionKnownFailureTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [RetryTestCaseSource(typeof(SnippetExecutionBetaKnownFailureTests), nameof(TestDataBeta), MaxTries = 3)]
-        public async Task Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetExecutionBetaKnownFailureTests
+{
+    /// <summary>
+    /// Gets TestCaseData for Beta
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetExecutionTestData(
+        new RunSettings
         {
-            await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
-        }
+            Version = Versions.Beta,
+            Language = Languages.CSharp,
+            TestType = TestType.ExecutionKnownIssues
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [RetryTestCaseSource(typeof(SnippetExecutionBetaKnownFailureTests), nameof(TestDataBeta), MaxTries = 3)]
+    public async Task Test(LanguageTestData testData)
+    {
+        await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
     }
 }

--- a/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
+++ b/CsharpBetaExecutionTests/SnippetExecutionBetaTests.cs
@@ -6,34 +6,33 @@ using NUnit.Framework;
 
 using TestsCommon;
 
-namespace CsharpBetaExecutionTests
-{
-    [TestFixture]
-    public class SnippetExecutionBetaTests
-    {
-        /// <summary>
-        /// Gets TestCaseData for Beta
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetExecutionTestData(
-            new RunSettings
-            {
-                Version = Versions.Beta,
-                Language = Languages.CSharp,
-                TestType = TestType.ExecutionStable
-            });
+namespace CsharpBetaExecutionTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [RetryTestCaseSource(typeof(SnippetExecutionBetaTests), nameof(TestDataBeta), MaxTries = 3)]
-        public async Task Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetExecutionBetaTests
+{
+    /// <summary>
+    /// Gets TestCaseData for Beta
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetExecutionTestData(
+        new RunSettings
         {
-            await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
-        }
+            Version = Versions.Beta,
+            Language = Languages.CSharp,
+            TestType = TestType.ExecutionStable
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [RetryTestCaseSource(typeof(SnippetExecutionBetaTests), nameof(TestDataBeta), MaxTries = 3)]
+    public async Task Test(LanguageTestData testData)
+    {
+        await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
     }
 }

--- a/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
+++ b/CsharpBetaKnownFailureTests/KnownFailuresBeta.cs
@@ -5,34 +5,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace CsharpBetaKnownFailureTests
-{
-    [TestFixture]
-    public class KnownFailuresBeta
-    {
-        /// <summary>
-        /// Gets TestCaseData for Beta known failures
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
-            new RunSettings
-            {
-                Version = Versions.Beta,
-                Language = Languages.CSharp,
-                TestType = TestType.CompilationKnownIssues
-            });
+namespace CsharpBetaKnownFailureTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(KnownFailuresBeta), nameof(TestDataBeta))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class KnownFailuresBeta
+{
+    /// <summary>
+    /// Gets TestCaseData for Beta known failures
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
+        new RunSettings
         {
-            CSharpTestRunner.Compile(testData);
-        }
+            Version = Versions.Beta,
+            Language = Languages.CSharp,
+            TestType = TestType.CompilationKnownIssues
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(KnownFailuresBeta), nameof(TestDataBeta))]
+    public void Test(LanguageTestData testData)
+    {
+        CSharpTestRunner.Compile(testData);
     }
 }

--- a/CsharpBetaTests/SnippetCompileBetaTests.cs
+++ b/CsharpBetaTests/SnippetCompileBetaTests.cs
@@ -5,34 +5,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace CsharpBetaTests
-{
-    [TestFixture]
-    public class SnippetCompileBetaTests
-    {
-        /// <summary>
-        /// Gets TestCaseData for Beta
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
-            new RunSettings
-            {
-                Version = Versions.Beta,
-                Language = Languages.CSharp,
-                TestType = TestType.CompilationStable
-            });
+namespace CsharpBetaTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(SnippetCompileBetaTests), nameof(TestDataBeta))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetCompileBetaTests
+{
+    /// <summary>
+    /// Gets TestCaseData for Beta
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
+        new RunSettings
         {
-            CSharpTestRunner.Compile(testData);
-        }
+            Version = Versions.Beta,
+            Language = Languages.CSharp,
+            TestType = TestType.CompilationStable
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(SnippetCompileBetaTests), nameof(TestDataBeta))]
+    public void Test(LanguageTestData testData)
+    {
+        CSharpTestRunner.Compile(testData);
     }
 }

--- a/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
+++ b/CsharpV1ExecutionKnownFailureTests/SnippetExecutionV1KnownFailureTests.cs
@@ -4,34 +4,33 @@ using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using TestsCommon;
 
-namespace CsharpV1ExecutionKnownFailureTests
-{
-    [TestFixture]
-    public class SnippetExecutionV1KnownFailureTests
-    {
-        /// <summary>
-        /// Gets TestCaseData for V1
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetExecutionTestData(
-            new RunSettings
-            {
-                Version = Versions.V1,
-                Language = Languages.CSharp,
-                TestType = TestType.ExecutionKnownIssues
-            });
+namespace CsharpV1ExecutionKnownFailureTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [RetryTestCaseSource(typeof(SnippetExecutionV1KnownFailureTests), nameof(TestDataV1), MaxTries = 3)]
-        public async Task Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetExecutionV1KnownFailureTests
+{
+    /// <summary>
+    /// Gets TestCaseData for V1
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetExecutionTestData(
+        new RunSettings
         {
-            await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
-        }
+            Version = Versions.V1,
+            Language = Languages.CSharp,
+            TestType = TestType.ExecutionKnownIssues
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [RetryTestCaseSource(typeof(SnippetExecutionV1KnownFailureTests), nameof(TestDataV1), MaxTries = 3)]
+    public async Task Test(LanguageTestData testData)
+    {
+        await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
     }
 }

--- a/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
+++ b/CsharpV1ExecutionTests/SnippetExecutionV1Tests.cs
@@ -4,32 +4,31 @@ using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 using TestsCommon;
 
-namespace CsharpV1ExecutionTests
-{
-    [TestFixture]
-    public class SnippetExecutionV1Tests
-    {
-        /// <summary>
-        /// Gets TestCaseData for V1
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetExecutionTestData(
-            new RunSettings
-            {
-                Version = Versions.V1,
-                Language = Languages.CSharp,
-                TestType = TestType.ExecutionStable
-            });
+namespace CsharpV1ExecutionTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="testData"></param>
-        [Test]
-        [RetryTestCaseSource(typeof(SnippetExecutionV1Tests), nameof(TestDataV1), MaxTries = 3)]
-        public async Task Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetExecutionV1Tests
+{
+    /// <summary>
+    /// Gets TestCaseData for V1
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetExecutionTestData(
+        new RunSettings
         {
-            await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
-        }
+            Version = Versions.V1,
+            Language = Languages.CSharp,
+            TestType = TestType.ExecutionStable
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="testData"></param>
+    [Test]
+    [RetryTestCaseSource(typeof(SnippetExecutionV1Tests), nameof(TestDataV1), MaxTries = 3)]
+    public async Task Test(LanguageTestData testData)
+    {
+        await CSharpTestRunner.Execute(testData).ConfigureAwait(false);
     }
 }

--- a/CsharpV1KnownFailureTests/KnownFailuresV1.cs
+++ b/CsharpV1KnownFailureTests/KnownFailuresV1.cs
@@ -5,34 +5,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace CsharpV1KnownFailureTests
-{
-    [TestFixture]
-    public class KnownFailuresV1
-    {
-        /// <summary>
-        /// Gets TestCaseData for V1 known failures
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
-            new RunSettings
-            {
-                Version = Versions.V1,
-                Language = Languages.CSharp,
-                TestType = TestType.CompilationKnownIssues
-            });
+namespace CsharpV1KnownFailureTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(KnownFailuresV1), nameof(TestDataV1))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class KnownFailuresV1
+{
+    /// <summary>
+    /// Gets TestCaseData for V1 known failures
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
+        new RunSettings
         {
-            CSharpTestRunner.Compile(testData);
-        }
+            Version = Versions.V1,
+            Language = Languages.CSharp,
+            TestType = TestType.CompilationKnownIssues
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(KnownFailuresV1), nameof(TestDataV1))]
+    public void Test(LanguageTestData testData)
+    {
+        CSharpTestRunner.Compile(testData);
     }
 }

--- a/CsharpV1Tests/SnippetCompileV1Tests.cs
+++ b/CsharpV1Tests/SnippetCompileV1Tests.cs
@@ -5,34 +5,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace CsharpV1Tests
-{
-    [TestFixture]
-    public class SnippetCompileV1Tests
-    {
-        /// <summary>
-        /// Gets TestCaseData for V1
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
-            new RunSettings
-            {
-                Version = Versions.V1,
-                Language = Languages.CSharp,
-                TestType = TestType.CompilationStable
-            });
+namespace CsharpV1Tests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(SnippetCompileV1Tests), nameof(TestDataV1))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetCompileV1Tests
+{
+    /// <summary>
+    /// Gets TestCaseData for V1
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
+        new RunSettings
         {
-            CSharpTestRunner.Compile(testData);
-        }
+            Version = Versions.V1,
+            Language = Languages.CSharp,
+            TestType = TestType.CompilationStable
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(SnippetCompileV1Tests), nameof(TestDataV1))]
+    public void Test(LanguageTestData testData)
+    {
+        CSharpTestRunner.Compile(testData);
     }
 }

--- a/DelegatedAppCreator/DelegatedAppCreator.cs
+++ b/DelegatedAppCreator/DelegatedAppCreator.cs
@@ -4,113 +4,112 @@ using System.Linq;
 using System.Threading.Tasks;
 using MsGraphSDKSnippetsCompiler;
 
-namespace DelegatedAppCreator
+namespace DelegatedAppCreator;
+
+/// <summary>
+/// For both the regular and the education tenants:
+/// 1. Fetches all delegated scopes listed in permission descriptions in the devx-content repo.
+/// 2. Fetches all the applications with delegated permissions that were previously created in the tenant.
+/// 3. Creates missing applications with desired oauth permission grant (admin consent in the Azure Portal)
+/// </summary>
+class DelegatedAppCreator
 {
-    /// <summary>
-    /// For both the regular and the education tenants:
-    /// 1. Fetches all delegated scopes listed in permission descriptions in the devx-content repo.
-    /// 2. Fetches all the applications with delegated permissions that were previously created in the tenant.
-    /// 3. Creates missing applications with desired oauth permission grant (admin consent in the Azure Portal)
-    /// </summary>
-    class DelegatedAppCreator
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            Console.WriteLine("*************************");
-            Console.WriteLine("Creating applications for regular tenant...");
-            Console.WriteLine("*************************");
-            await CreateDelegatedApps(new PermissionManager()).ConfigureAwait(false);
+        Console.WriteLine("*************************");
+        Console.WriteLine("Creating applications for regular tenant...");
+        Console.WriteLine("*************************");
+        await CreateDelegatedApps(new PermissionManager()).ConfigureAwait(false);
 
-            Console.WriteLine();
-            Console.WriteLine("*************************");
-            Console.WriteLine("Creating applications for education tenant...");
-            Console.WriteLine("*************************");
-            await CreateDelegatedApps(new PermissionManager(isEducation:true)).ConfigureAwait(false);
+        Console.WriteLine();
+        Console.WriteLine("*************************");
+        Console.WriteLine("Creating applications for education tenant...");
+        Console.WriteLine("*************************");
+        await CreateDelegatedApps(new PermissionManager(isEducation: true)).ConfigureAwait(false);
+    }
+
+    private static async Task CreateDelegatedApps(PermissionManager permissionManagerApplication)
+    {
+        const string Prefix = "DelegatedApp ";
+        // get existing applications
+        var existingApplicationSet = await permissionManagerApplication.GetExistingApplicationsWithPrefix(Prefix).ConfigureAwait(false);
+        PrintApplicationNames("Existing Applications", existingApplicationSet);
+
+        // get expected applications
+        var permissionDescriptions = await PermissionManager.GetPermissionDescriptions().ConfigureAwait(false);
+        var delegatedScopes = permissionDescriptions.delegatedScopesList;
+        var expectedApplications = delegatedScopes
+            .Select(x => x.DelegatedAppName(Prefix));
+        PrintApplicationNames("Expected Applications", expectedApplications);
+
+        // find missing application scopes
+        var missingScopes = delegatedScopes
+            .Where(x => !existingApplicationSet.Contains(x.DelegatedAppName(Prefix)));
+
+        if (!missingScopes.Any())
+        {
+            Console.WriteLine("All the applications exist in the tenant! Exiting...");
+            return;
         }
 
-        private static async Task CreateDelegatedApps(PermissionManager permissionManagerApplication)
+        var missingApplications = missingScopes
+            .Select(x => x.DelegatedAppName(Prefix));
+        PrintApplicationNames("Missing Applications", missingApplications);
+
+        // create missing applications
+        var resourceId = await permissionManagerApplication.GetMicrosoftGraphServicePrincipalId().ConfigureAwait(false);
+        var failedApplications = new List<string>();
+        var succeededApplications = new List<string>();
+        foreach (var scope in missingScopes)
         {
-            const string Prefix = "DelegatedApp ";
-            // get existing applications
-            var existingApplicationSet = await permissionManagerApplication.GetExistingApplicationsWithPrefix(Prefix).ConfigureAwait(false);
-            PrintApplicationNames("Existing Applications", existingApplicationSet);
-
-            // get expected applications
-            var permissionDescriptions = await PermissionManager.GetPermissionDescriptions().ConfigureAwait(false);
-            var delegatedScopes = permissionDescriptions.delegatedScopesList;
-            var expectedApplications = delegatedScopes
-                .Select(x => x.DelegatedAppName(Prefix));
-            PrintApplicationNames("Expected Applications", expectedApplications);
-
-            // find missing application scopes
-            var missingScopes = delegatedScopes
-                .Where(x => !existingApplicationSet.Contains(x.DelegatedAppName(Prefix)));
-
-            if (!missingScopes.Any())
+            var appDisplayName = scope.DelegatedAppName(Prefix);
+            try
             {
-                Console.WriteLine("All the applications exist in the tenant! Exiting...");
-                return;
+                Console.WriteLine($"Creating Application with name '{appDisplayName}'");
+                var application = await permissionManagerApplication.CreateApplication(appDisplayName, scope.id).ConfigureAwait(false);
+                var servicePrincipal = await permissionManagerApplication.CreateServicePrincipal(application.AppId).ConfigureAwait(false);
+                _ = await permissionManagerApplication.CreateOAuthPermission(servicePrincipal.Id, resourceId, scope.value).ConfigureAwait(false);
+
+                Console.WriteLine($"Created Application with name '{appDisplayName}' and id '{application.Id}'");
+                succeededApplications.Add(appDisplayName);
             }
-
-            var missingApplications = missingScopes
-                .Select(x => x.DelegatedAppName(Prefix));
-            PrintApplicationNames("Missing Applications", missingApplications);
-
-            // create missing applications
-            var resourceId = await permissionManagerApplication.GetMicrosoftGraphServicePrincipalId().ConfigureAwait(false);
-            var failedApplications = new List<string>();
-            var succeededApplications = new List<string>();
-            foreach (var scope in missingScopes)
+            catch (Exception e)
             {
-                var appDisplayName = scope.DelegatedAppName(Prefix);
-                try
-                {
-                    Console.WriteLine($"Creating Application with name '{appDisplayName}'");
-                    var application = await permissionManagerApplication.CreateApplication(appDisplayName, scope.id).ConfigureAwait(false);
-                    var servicePrincipal = await permissionManagerApplication.CreateServicePrincipal(application.AppId).ConfigureAwait(false);
-                    _ = await permissionManagerApplication.CreateOAuthPermission(servicePrincipal.Id, resourceId, scope.value).ConfigureAwait(false);
-
-                    Console.WriteLine($"Created Application with name '{appDisplayName}' and id '{application.Id}'");
-                    succeededApplications.Add(appDisplayName);
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine($"Couldn't create application named '{appDisplayName}'. See exception details below:");
-                    Console.WriteLine("-------------------------");
-                    Console.WriteLine(e.Message);
-                    Console.WriteLine("-------------------------");
-                    failedApplications.Add(appDisplayName);
-                }
+                Console.WriteLine($"Couldn't create application named '{appDisplayName}'. See exception details below:");
+                Console.WriteLine("-------------------------");
+                Console.WriteLine(e.Message);
+                Console.WriteLine("-------------------------");
+                failedApplications.Add(appDisplayName);
             }
-
-            Console.WriteLine("=========================");
-            Console.WriteLine("Summary:");
-            Console.WriteLine("-------------------------");
-            Console.WriteLine($"number of existing applications: {existingApplicationSet.Count}");
-            Console.WriteLine($"number of expected applications: {expectedApplications.Count()}");
-            Console.WriteLine($"number of missing applications: {missingApplications.Count()}");
-            Console.WriteLine($"number of successfully created applications in this run: {succeededApplications.Count}");
-            Console.WriteLine($"number of failed application creation attempts: {failedApplications.Count}");
-            Console.WriteLine("=========================");
-
-            PrintApplicationNames("Successfully Created Applications", succeededApplications);
-            PrintApplicationNames("Failed Attempts", failedApplications);
         }
 
-        private static void PrintApplicationNames(string title, IEnumerable<string> names)
-        {
-            if ((names?.Count() ?? 0) < 1)
-            {
-                return;
-            }
+        Console.WriteLine("=========================");
+        Console.WriteLine("Summary:");
+        Console.WriteLine("-------------------------");
+        Console.WriteLine($"number of existing applications: {existingApplicationSet.Count}");
+        Console.WriteLine($"number of expected applications: {expectedApplications.Count()}");
+        Console.WriteLine($"number of missing applications: {missingApplications.Count()}");
+        Console.WriteLine($"number of successfully created applications in this run: {succeededApplications.Count}");
+        Console.WriteLine($"number of failed application creation attempts: {failedApplications.Count}");
+        Console.WriteLine("=========================");
 
-            var namesList = names.ToList();
-            namesList.Sort();
-            Console.WriteLine("=========================");
-            Console.WriteLine(title);
-            Console.WriteLine("-------------------------");
-            namesList.ForEach(Console.WriteLine);
-            Console.WriteLine("=========================");
+        PrintApplicationNames("Successfully Created Applications", succeededApplications);
+        PrintApplicationNames("Failed Attempts", failedApplications);
+    }
+
+    private static void PrintApplicationNames(string title, IEnumerable<string> names)
+    {
+        if ((names?.Count() ?? 0) < 1)
+        {
+            return;
         }
+
+        var namesList = names.ToList();
+        namesList.Sort();
+        Console.WriteLine("=========================");
+        Console.WriteLine(title);
+        Console.WriteLine("-------------------------");
+        namesList.ForEach(Console.WriteLine);
+        Console.WriteLine("=========================");
     }
 }

--- a/JavaBetaKnownFailureTests/KnownFailuresBeta.cs
+++ b/JavaBetaKnownFailureTests/KnownFailuresBeta.cs
@@ -3,34 +3,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace JavaBetaKnownFailureTests
-{
-    [TestFixture]
-    public class KnownFailuresBeta
-    {
-        /// <summary>
-        /// Gets TestCaseData for Beta known failures
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
-            new RunSettings(TestContext.Parameters)
-            {
-                Version = Versions.Beta,
-                Language = Languages.Java,
-                TestType = TestType.CompilationKnownIssues
-            });
+namespace JavaBetaKnownFailureTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(KnownFailuresBeta), nameof(TestDataBeta))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class KnownFailuresBeta
+{
+    /// <summary>
+    /// Gets TestCaseData for Beta known failures
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
+        new RunSettings(TestContext.Parameters)
         {
-            JavaTestRunner.Run(testData);
-        }
+            Version = Versions.Beta,
+            Language = Languages.Java,
+            TestType = TestType.CompilationKnownIssues
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(KnownFailuresBeta), nameof(TestDataBeta))]
+    public void Test(LanguageTestData testData)
+    {
+        JavaTestRunner.Run(testData);
     }
 }

--- a/JavaBetaTests/SnippetCompileBetaTests.cs
+++ b/JavaBetaTests/SnippetCompileBetaTests.cs
@@ -3,34 +3,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace JavaBetaTests
-{
-    [TestFixture]
-    public class SnippetCompileBetaTests
-    {
-        /// <summary>
-        /// Gets TestCaseData for Beta
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
-            new RunSettings(TestContext.Parameters)
-            {
-                Version = Versions.Beta,
-                Language = Languages.Java,
-                TestType = TestType.CompilationStable
-            });
+namespace JavaBetaTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(SnippetCompileBetaTests), nameof(TestDataBeta))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetCompileBetaTests
+{
+    /// <summary>
+    /// Gets TestCaseData for Beta
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataBeta => TestDataGenerator.GetTestCaseData(
+        new RunSettings(TestContext.Parameters)
         {
-            JavaTestRunner.Run(testData);
-        }
+            Version = Versions.Beta,
+            Language = Languages.Java,
+            TestType = TestType.CompilationStable
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(SnippetCompileBetaTests), nameof(TestDataBeta))]
+    public void Test(LanguageTestData testData)
+    {
+        JavaTestRunner.Run(testData);
     }
 }

--- a/JavaV1KnownFailureTests/KnownFailuresV1.cs
+++ b/JavaV1KnownFailureTests/KnownFailuresV1.cs
@@ -3,34 +3,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace JavaV1KnownFailureTests
-{
-    [TestFixture]
-    public class KnownFailuresV1
-    {
-        /// <summary>
-        /// Gets TestCaseData for V1 known failures
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
-            new RunSettings(TestContext.Parameters)
-            {
-                Version = Versions.V1,
-                Language = Languages.Java,
-                TestType = TestType.CompilationKnownIssues
-            });
+namespace JavaV1KnownFailureTests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(KnownFailuresV1), nameof(TestDataV1))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class KnownFailuresV1
+{
+    /// <summary>
+    /// Gets TestCaseData for V1 known failures
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
+        new RunSettings(TestContext.Parameters)
         {
-            JavaTestRunner.Run(testData);
-        }
+            Version = Versions.V1,
+            Language = Languages.Java,
+            TestType = TestType.CompilationKnownIssues
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(KnownFailuresV1), nameof(TestDataV1))]
+    public void Test(LanguageTestData testData)
+    {
+        JavaTestRunner.Run(testData);
     }
 }

--- a/JavaV1Tests/SnippetCompileV1Tests.cs
+++ b/JavaV1Tests/SnippetCompileV1Tests.cs
@@ -3,34 +3,33 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using TestsCommon;
 
-namespace JavaV1Tests
-{
-    [TestFixture]
-    public class SnippetCompileV1Tests
-    {
-        /// <summary>
-        /// Gets TestCaseData for V1
-        /// TestCaseData contains snippet file name, version and test case name
-        /// </summary>
-        public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
-            new RunSettings(TestContext.Parameters)
-            {
-                Version = Versions.V1,
-                Language = Languages.Java,
-                TestType = TestType.CompilationStable
-            });
+namespace JavaV1Tests;
 
-        /// <summary>
-        /// Represents test runs generated from test case data
-        /// </summary>
-        /// <param name="fileName">snippet file name in docs repo</param>
-        /// <param name="docsLink">documentation page where the snippet is shown</param>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        [Test]
-        [TestCaseSource(typeof(SnippetCompileV1Tests), nameof(TestDataV1))]
-        public void Test(LanguageTestData testData)
+[TestFixture]
+public class SnippetCompileV1Tests
+{
+    /// <summary>
+    /// Gets TestCaseData for V1
+    /// TestCaseData contains snippet file name, version and test case name
+    /// </summary>
+    public static IEnumerable<TestCaseData> TestDataV1 => TestDataGenerator.GetTestCaseData(
+        new RunSettings(TestContext.Parameters)
         {
-            JavaTestRunner.Run(testData);
-        }
+            Version = Versions.V1,
+            Language = Languages.Java,
+            TestType = TestType.CompilationStable
+        });
+
+    /// <summary>
+    /// Represents test runs generated from test case data
+    /// </summary>
+    /// <param name="fileName">snippet file name in docs repo</param>
+    /// <param name="docsLink">documentation page where the snippet is shown</param>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    [Test]
+    [TestCaseSource(typeof(SnippetCompileV1Tests), nameof(TestDataV1))]
+    public void Test(LanguageTestData testData)
+    {
+        JavaTestRunner.Run(testData);
     }
 }

--- a/ReportGenerator/GlobalUsings.cs
+++ b/ReportGenerator/GlobalUsings.cs
@@ -1,0 +1,6 @@
+﻿global using System.Collections.Generic;
+global using System;
+global using System.Linq;
+global using System.IO;
+global using MsGraphSDKSnippetsCompiler.Models;
+global using TestsCommon;

--- a/ReportGenerator/IssueType.cs
+++ b/ReportGenerator/IssueType.cs
@@ -1,10 +1,7 @@
-namespace ReportGenerator
+namespace ReportGenerator;
+
+internal enum IssueType
 {
-    internal enum IssueType
-    {
-        Compilation,
-        Execution
-    }
+    Compilation,
+    Execution
 }
-
-

--- a/ReportGenerator/IssueTypeExtensions.cs
+++ b/ReportGenerator/IssueTypeExtensions.cs
@@ -1,18 +1,14 @@
-namespace ReportGenerator
-{
-    internal static class IssueTypeExtensions
-    {
-        internal static string Suffix(this IssueType issueType)
-        {
-            return issueType == IssueType.Compilation ? "compiles" : "executes";
-        }
+namespace ReportGenerator;
 
-        internal static string LowerName(this IssueType issueType)
-        {
-            return issueType.ToString().ToLowerInvariant();
-        }
+internal static class IssueTypeExtensions
+{
+    internal static string Suffix(this IssueType issueType)
+    {
+        return issueType == IssueType.Compilation ? "compiles" : "executes";
     }
 
+    internal static string LowerName(this IssueType issueType)
+    {
+        return issueType.ToString().ToLowerInvariant();
+    }
 }
-
-

--- a/ReportGenerator/ReportEntry.cs
+++ b/ReportGenerator/ReportEntry.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using TestsCommon;
-
-namespace ReportGenerator;
+﻿namespace ReportGenerator;
 
 internal class ReportEntry
 {

--- a/ReportGenerator/ReportEntry.cs
+++ b/ReportGenerator/ReportEntry.cs
@@ -3,59 +3,58 @@ using System.Collections.Generic;
 using System.Linq;
 using TestsCommon;
 
-namespace ReportGenerator
+namespace ReportGenerator;
+
+internal class ReportEntry
 {
-    internal class ReportEntry
+    private readonly string Category;
+    private readonly string TestName;
+    private readonly string DocumentationLink;
+    private readonly string GitHubIssue;
+    private readonly string CustomMessage;
+
+    internal ReportEntry(string testName, string documentationLink, KnownIssue knownIssue)
     {
-        private readonly string Category;
-        private readonly string TestName;
-        private readonly string DocumentationLink;
-        private readonly string GitHubIssue;
-        private readonly string CustomMessage;
+        this.TestName = testName;
+        this.DocumentationLink = documentationLink;
+        this.Category = knownIssue.Owner;
+        this.GitHubIssue = knownIssue.GitHubIssue;
+        this.CustomMessage = knownIssue.CustomMessage;
+    }
 
-        internal ReportEntry(string testName, string documentationLink, KnownIssue knownIssue)
-        {
-            this.TestName = testName;
-            this.DocumentationLink = documentationLink;
-            this.Category = knownIssue.Owner;
-            this.GitHubIssue = knownIssue.GitHubIssue;
-            this.CustomMessage = knownIssue.CustomMessage;
-        }
-
-        internal static List<string> GetMarkdownTable(IEnumerable<ReportEntry> entries)
-        {
-            var sortedEntries = entries.OrderBy(entry => entry.CustomMessage).ThenBy(entry => entry.Category);
-            var markdownTable = new List<string>{
+    internal static List<string> GetMarkdownTable(IEnumerable<ReportEntry> entries)
+    {
+        var sortedEntries = entries.OrderBy(entry => entry.CustomMessage).ThenBy(entry => entry.Category);
+        var markdownTable = new List<string>{
                 "| Category | Test Name | Documentation Link | GitHub Issue | Custom Message |",
                 "| --- | --- | --- | --- | --- |"
             };
-            markdownTable.AddRange(sortedEntries.Select(entry => entry.ToMarkdownTableRow()));
-            return markdownTable;
-        }
+        markdownTable.AddRange(sortedEntries.Select(entry => entry.ToMarkdownTableRow()));
+        return markdownTable;
+    }
 
-        private string ToMarkdownTableRow()
+    private string ToMarkdownTableRow()
+    {
+        return $"| {Category} | {TestName} | [docs page]({DocumentationLink}) | {GetGitHubIssueLink()} | {CustomMessage} |";
+    }
+
+    private string GetGitHubIssueLink()
+    {
+        if (string.IsNullOrEmpty(GitHubIssue))
         {
-            return $"| {Category} | {TestName} | [docs page]({DocumentationLink}) | {GetGitHubIssueLink()} | {CustomMessage} |";
+            return string.Empty;
         }
 
-        private string GetGitHubIssueLink()
+        // example valid GitHubIssue value: https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/744
+        var segments = GitHubIssue.Split('/');
+        if (segments.Length < 3)
         {
-            if (string.IsNullOrEmpty(GitHubIssue))
-            {
-                return string.Empty;
-            }
-
-            // example valid GitHubIssue value: https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/744
-            var segments = GitHubIssue.Split('/');
-            if (segments.Length < 3)
-            {
-                throw new ArgumentException($"Invalid GitHub issue: {GitHubIssue}");
-            }
-
-            var issueNumber = segments.Last();
-            var repo = segments[^3];
-
-            return string.IsNullOrWhiteSpace(GitHubIssue) ? "-" : $"[{repo}#{issueNumber}]({GitHubIssue})";
+            throw new ArgumentException($"Invalid GitHub issue: {GitHubIssue}");
         }
+
+        var issueNumber = segments.Last();
+        var repo = segments[^3];
+
+        return string.IsNullOrWhiteSpace(GitHubIssue) ? "-" : $"[{repo}#{issueNumber}]({GitHubIssue})";
     }
 }

--- a/ReportGenerator/ReportGenerator.cs
+++ b/ReportGenerator/ReportGenerator.cs
@@ -5,140 +5,140 @@ using System.IO;
 using MsGraphSDKSnippetsCompiler.Models;
 using TestsCommon;
 
-namespace ReportGenerator
+namespace ReportGenerator;
+
+class ReportGenerator
 {
-    class ReportGenerator
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
+        KnownIssuesTextReport(Versions.V1, Languages.CSharp, IssueType.Execution);
+        KnownIssuesVisualReport(Versions.V1, Languages.CSharp, IssueType.Execution);
+    }
+
+    // create text report for v1 execution known issues
+    private static void KnownIssuesTextReport(Versions version, Languages language, IssueType issueType)
+    {
+        if (language != Languages.CSharp)
         {
-            KnownIssuesTextReport(Versions.V1, Languages.CSharp, IssueType.Execution);
-            KnownIssuesVisualReport(Versions.V1, Languages.CSharp, IssueType.Execution);
+            throw new NotImplementedException();
         }
 
-        // create text report for v1 execution known issues
-        private static void KnownIssuesTextReport(Versions version, Languages language, IssueType issueType)
+        if (issueType != IssueType.Execution)
         {
-            if (language != Languages.CSharp)
-            {
-                throw new NotImplementedException();
-            }
-
-            if (issueType != IssueType.Execution)
-            {
-                throw new NotImplementedException();
-            }
-
-            var issues = CSharpKnownIssues.GetCSharpExecutionKnownIssues(version);
-            var documentationLinks = TestDataGenerator.GetDocumentationLinks(version, language);
-            var testNameSuffix = $"{version}-{issueType.Suffix()}";
-
-            var unreferencedIssues = new HashSet<string>();
-
-            var reportEntries = new List<ReportEntry>();
-
-            foreach (KeyValuePair<string, KnownIssue> kv in issues.Where(kv => kv.Key.EndsWith(testNameSuffix)))
-            {
-                var testName = kv.Key;
-                var knownIssue = kv.Value;
-                var documentationLinkLookupKey = testName.Replace(testNameSuffix, "snippets.md");
-                if (!documentationLinks.ContainsKey(documentationLinkLookupKey))
-                {
-                    unreferencedIssues.Add(testName);
-                }
-                else
-                {
-                    var documentationLink = documentationLinks[documentationLinkLookupKey];
-                    reportEntries.Add(new ReportEntry
-                    (
-                        testName,
-                        documentationLink,
-                        knownIssue
-                    ));
-                }
-            }
-
-            if (unreferencedIssues.Count > 0)
-            {
-                var message = "There are known issue entries which are not referenced in the documentation," +
-                    " please make sure that you have the latest changes from docs repo" +
-                    " and remove the following from known issues list:" +
-                    $"{Environment.NewLine}{string.Join(Environment.NewLine, unreferencedIssues)}";
-                throw new InvalidDataException(message);
-            }
-
-            var fileName = $"{version}-{language.AsString()}-{issueType.LowerName()}-known-issues.md";
-            WriteReportEntriesToFile(fileName, reportEntries);
+            throw new NotImplementedException();
         }
 
-        // output list of ReportEntry to a text file
-        private static void WriteReportEntriesToFile(string fileName, IEnumerable<ReportEntry> reportEntries)
+        var issues = CSharpKnownIssues.GetCSharpExecutionKnownIssues(version);
+        var documentationLinks = TestDataGenerator.GetDocumentationLinks(version, language);
+        var testNameSuffix = $"{version}-{issueType.Suffix()}";
+
+        var unreferencedIssues = new HashSet<string>();
+
+        var reportEntries = new List<ReportEntry>();
+
+        foreach (KeyValuePair<string, KnownIssue> kv in issues.Where(kv => kv.Key.EndsWith(testNameSuffix)))
         {
-            var filePath = Path.Combine(GetReportPath(), fileName);
-
-            File.WriteAllLines(filePath, ReportEntry.GetMarkdownTable(reportEntries));
-
-            Console.WriteLine($"Wrote markdown table report to {filePath}");
+            var testName = kv.Key;
+            var knownIssue = kv.Value;
+            var documentationLinkLookupKey = testName.Replace(testNameSuffix, "snippets.md");
+            if (!documentationLinks.ContainsKey(documentationLinkLookupKey))
+            {
+                unreferencedIssues.Add(testName);
+            }
+            else
+            {
+                var documentationLink = documentationLinks[documentationLinkLookupKey];
+                reportEntries.Add(new ReportEntry
+                (
+                    testName,
+                    documentationLink,
+                    knownIssue
+                ));
+            }
         }
 
-        private static string GetReportPath()
+        if (unreferencedIssues.Count > 0)
         {
-            return Path.Combine(Environment.GetEnvironmentVariable("BUILD_SOURCESDIRECTORY"), "msgraph-sdk-raptor", "report");
+            var message = "There are known issue entries which are not referenced in the documentation," +
+                " please make sure that you have the latest changes from docs repo" +
+                " and remove the following from known issues list:" +
+                $"{Environment.NewLine}{string.Join(Environment.NewLine, unreferencedIssues)}";
+            throw new InvalidDataException(message);
         }
 
-        // create known issue visual report
-        private static void KnownIssuesVisualReport(Versions version, Languages language, IssueType issueType)
+        var fileName = $"{version}-{language.AsString()}-{issueType.LowerName()}-known-issues.md";
+        WriteReportEntriesToFile(fileName, reportEntries);
+    }
+
+    // output list of ReportEntry to a text file
+    private static void WriteReportEntriesToFile(string fileName, IEnumerable<ReportEntry> reportEntries)
+    {
+        var filePath = Path.Combine(GetReportPath(), fileName);
+
+        File.WriteAllLines(filePath, ReportEntry.GetMarkdownTable(reportEntries));
+
+        Console.WriteLine($"Wrote markdown table report to {filePath}");
+    }
+
+    private static string GetReportPath()
+    {
+        return Path.Combine(Environment.GetEnvironmentVariable("BUILD_SOURCESDIRECTORY"), "msgraph-sdk-raptor", "report");
+    }
+
+    // create known issue visual report
+    private static void KnownIssuesVisualReport(Versions version, Languages language, IssueType issueType)
+    {
+        if (language != Languages.CSharp)
         {
-            if (language != Languages.CSharp)
-            {
-                throw new NotImplementedException();
-            }
-
-            if (issueType != IssueType.Execution)
-            {
-                throw new NotImplementedException();
-            }
-
-            var issues = CSharpKnownIssues.GetCSharpExecutionKnownIssues(version);
-            var counter = new Dictionary<string, int>();
-            foreach (KeyValuePair<string, KnownIssue> kv in issues)
-            {
-                if (!kv.Key.EndsWith($"{version}-{issueType.Suffix()}"))
-                {
-                    continue;
-                }
-
-                if (counter.ContainsKey(kv.Value.Owner))
-                {
-                    counter[kv.Value.Owner]++;
-                }
-                else
-                {
-                    counter.Add(kv.Value.Owner, 1);
-                }
-            }
-
-            var counterList = counter.ToList();
-            var ordered = counterList.OrderByDescending(x => x.Value);
-
-            Console.WriteLine($"{version} {issueType.LowerName()} known issues");
-            foreach (KeyValuePair<string, int> kv in ordered)
-            {
-                Console.WriteLine($"{kv.Key}: {kv.Value}");
-            }
-
-            var fileName = Path.Combine(GetReportPath(), $"{version}-{language.AsString()}-{issueType.LowerName()}-known-issues-report.html");
-            VisualizeData(ordered, fileName, version);
+            throw new NotImplementedException();
         }
 
-        // visualize data using chart.js
-        // https://www.chartjs.org/docs/latest/charts/bar.html
-        public static void VisualizeData(IOrderedEnumerable<KeyValuePair<string, int>> data, string fileName, Versions version = Versions.V1)
+        if (issueType != IssueType.Execution)
         {
-            var labels = data.Select(x => x.Key).ToList();
-            var values = data.Select(x => x.Value).ToList();
+            throw new NotImplementedException();
+        }
 
-            // create the HTML
-            var html = @"<!DOCTYPE html>
+        var issues = CSharpKnownIssues.GetCSharpExecutionKnownIssues(version);
+        var counter = new Dictionary<string, int>();
+        foreach (KeyValuePair<string, KnownIssue> kv in issues)
+        {
+            if (!kv.Key.EndsWith($"{version}-{issueType.Suffix()}"))
+            {
+                continue;
+            }
+
+            if (counter.ContainsKey(kv.Value.Owner))
+            {
+                counter[kv.Value.Owner]++;
+            }
+            else
+            {
+                counter.Add(kv.Value.Owner, 1);
+            }
+        }
+
+        var counterList = counter.ToList();
+        var ordered = counterList.OrderByDescending(x => x.Value);
+
+        Console.WriteLine($"{version} {issueType.LowerName()} known issues");
+        foreach (KeyValuePair<string, int> kv in ordered)
+        {
+            Console.WriteLine($"{kv.Key}: {kv.Value}");
+        }
+
+        var fileName = Path.Combine(GetReportPath(), $"{version}-{language.AsString()}-{issueType.LowerName()}-known-issues-report.html");
+        VisualizeData(ordered, fileName, version);
+    }
+
+    // visualize data using chart.js
+    // https://www.chartjs.org/docs/latest/charts/bar.html
+    public static void VisualizeData(IOrderedEnumerable<KeyValuePair<string, int>> data, string fileName, Versions version = Versions.V1)
+    {
+        var labels = data.Select(x => x.Key).ToList();
+        var values = data.Select(x => x.Value).ToList();
+
+        // create the HTML
+        var html = @"<!DOCTYPE html>
 <html>
 <head>
     <title>" + $"{version} execution known issues" + @"</title>
@@ -191,9 +191,8 @@ namespace ReportGenerator
     </script>
 </body>
 </html>";
-            // write the HTML to a file
-            File.WriteAllText(fileName, html);
-            Console.WriteLine($"Wrote html bar chart report to {fileName}");
-        }
+        // write the HTML to a file
+        File.WriteAllText(fileName, html);
+        Console.WriteLine($"Wrote html bar chart report to {fileName}");
     }
 }

--- a/ReportGenerator/ReportGenerator.cs
+++ b/ReportGenerator/ReportGenerator.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections.Generic;
-using System;
-using System.Linq;
-using System.IO;
-using MsGraphSDKSnippetsCompiler.Models;
-using TestsCommon;
-
-namespace ReportGenerator;
+﻿namespace ReportGenerator;
 
 class ReportGenerator
 {

--- a/TestsCommon/AssemblyInfo.cs
+++ b/TestsCommon/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 [assembly:CLSCompliant(false)]
 [assembly:InternalsVisibleTo("UnitTests")]

--- a/TestsCommon/BaseTestRunner.cs
+++ b/TestsCommon/BaseTestRunner.cs
@@ -1,22 +1,21 @@
-﻿namespace TestsCommon
-{
-    public static class BaseTestRunner
-    {
-        /// <summary>
-        /// Embeds C# snippet from docs repo into a compilable template
-        /// </summary>
-        /// <param name="snippet">code snippet from docs repo</param>
-        /// <returns>
-        /// code snippet embedded into compilable template
-        /// </returns>
-        internal static string ConcatBaseTemplateWithSnippet(string snippet, string SDKShellTemplate)
-        {
-            // there are mixture of line endings, namely \r\n and \n, normalize that into \r\n
-            string codeToCompile = SDKShellTemplate
-                       .Replace("//insert-code-here", snippet)
-                       .Replace("\r\n", "\n").Replace("\n", "\r\n");
+﻿namespace TestsCommon;
 
-            return codeToCompile;
-        }
+public static class BaseTestRunner
+{
+    /// <summary>
+    /// Embeds C# snippet from docs repo into a compilable template
+    /// </summary>
+    /// <param name="snippet">code snippet from docs repo</param>
+    /// <returns>
+    /// code snippet embedded into compilable template
+    /// </returns>
+    internal static string ConcatBaseTemplateWithSnippet(string snippet, string SDKShellTemplate)
+    {
+        // there are mixture of line endings, namely \r\n and \n, normalize that into \r\n
+        string codeToCompile = SDKShellTemplate
+                   .Replace("//insert-code-here", snippet)
+                   .Replace("\r\n", "\n").Replace("\n", "\r\n");
+
+        return codeToCompile;
     }
 }

--- a/TestsCommon/CSharpKnownIssues.cs
+++ b/TestsCommon/CSharpKnownIssues.cs
@@ -2,19 +2,19 @@
 using MsGraphSDKSnippetsCompiler.Models;
 using static TestsCommon.KnownIssues;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+public static class CSharpKnownIssues
 {
-    public static class CSharpKnownIssues
+    /// <summary>
+    /// Gets known issues
+    /// </summary>
+    /// <param name="versionEnum">version to get the known issues for</param>
+    /// <returns>A mapping of test names into known CSharp issues</returns>
+    public static Dictionary<string, KnownIssue> GetCSharpCompilationKnownIssues(Versions versionEnum)
     {
-        /// <summary>
-        /// Gets known issues
-        /// </summary>
-        /// <param name="versionEnum">version to get the known issues for</param>
-        /// <returns>A mapping of test names into known CSharp issues</returns>
-        public static Dictionary<string, KnownIssue> GetCSharpCompilationKnownIssues(Versions versionEnum)
-        {
-            var version = versionEnum.ToString();
-            return new Dictionary<string, KnownIssue>()
+        var version = versionEnum.ToString();
+        return new Dictionary<string, KnownIssue>()
             {
                 {$"delete-userflowlanguagepage-csharp-{version}-compiles", new KnownIssue(SDK, StreamRequestDoesNotSupportDelete) },
                 {$"unfollow-site-csharp-{version}-compiles", new KnownIssue(SDK, "SDK doesn't convert actions defined on collections to methods. https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/250") },
@@ -114,17 +114,17 @@ namespace TestsCommon
                 { "clear--presence-csharp-V1-compiles", NeedsAnalysisKnownIssue },
                 { "managementactiontenantdeploymentstatus-changedeploymentstatus-csharp-Beta-compiles", NeedsAnalysisKnownIssue}
             };
-        }
+    }
 
-        /// <summary>
-        /// Gets execution known issues
-        /// </summary>
-        /// <param name="versionEnum">version to get the execution known issues for</param>
-        /// <returns>A mapping of test names into known CSharp issues</returns>
-        public static Dictionary<string, KnownIssue> GetCSharpExecutionKnownIssues(Versions versionEnum)
-        {
-            var version = versionEnum.ToString();
-            return new Dictionary<string, KnownIssue>()
+    /// <summary>
+    /// Gets execution known issues
+    /// </summary>
+    /// <param name="versionEnum">version to get the execution known issues for</param>
+    /// <returns>A mapping of test names into known CSharp issues</returns>
+    public static Dictionary<string, KnownIssue> GetCSharpExecutionKnownIssues(Versions versionEnum)
+    {
+        var version = versionEnum.ToString();
+        return new Dictionary<string, KnownIssue>()
             {
                 { "accesspackageassignment-filterbycurrentuser-csharp-Beta-executes", NeedsAnalysisKnownIssue },
                 { "accesspackageassignmentrequest-filterbycurrentuser-csharp-Beta-executes", NeedsAnalysisKnownIssue },
@@ -902,6 +902,5 @@ namespace TestsCommon
                 { "get-bitlockerrecoverykey-key-csharp-V1-executes", MissingDataKnownIssue },
                 { "get-bitlockerrecoverykey-csharp-V1-executes", MissingDataKnownIssue }
             };
-        }
     }
 }

--- a/TestsCommon/CSharpKnownIssues.cs
+++ b/TestsCommon/CSharpKnownIssues.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using MsGraphSDKSnippetsCompiler.Models;
-using static TestsCommon.KnownIssues;
-
-namespace TestsCommon;
+﻿namespace TestsCommon;
 
 public static class CSharpKnownIssues
 {

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -1,15 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
-using MsGraphSDKSnippetsCompiler;
-using MsGraphSDKSnippetsCompiler.Models;
-
-using NUnit.Framework;
-
-using System;
-using System.IO;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-
 namespace TestsCommon;
 
 /// <summary>

--- a/TestsCommon/CSharpTestRunner.cs
+++ b/TestsCommon/CSharpTestRunner.cs
@@ -10,17 +10,17 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+/// <summary>
+/// TestRunner for C# compilation tests
+/// </summary>
+public static class CSharpTestRunner
 {
     /// <summary>
-    /// TestRunner for C# compilation tests
+    /// template to compile snippets in
     /// </summary>
-    public static class CSharpTestRunner
-    {
-        /// <summary>
-        /// template to compile snippets in
-        /// </summary>
-        private const string SDKShellTemplate = @"using System;
+    private const string SDKShellTemplate = @"using System;
 using Microsoft.Graph;
 using MsGraphSDKSnippetsCompiler;
 using System.Text.Json;
@@ -54,221 +54,221 @@ public class GraphSDKTest
     }
 }";
 
-        /// <summary>
-        /// matches csharp snippet from C# snippets markdown output
-        /// </summary>
-        private const string CSharpSnippetPattern = @"```csharp(.*)```";
+    /// <summary>
+    /// matches csharp snippet from C# snippets markdown output
+    /// </summary>
+    private const string CSharpSnippetPattern = @"```csharp(.*)```";
 
-        /// <summary>
-        /// compiled version of the C# markdown regular expression
-        /// uses Singleline so that (.*) matches new line characters as well
-        /// </summary>
-        private static readonly Regex CSharpSnippetRegex = new Regex(CSharpSnippetPattern, RegexOptions.Singleline | RegexOptions.Compiled);
+    /// <summary>
+    /// compiled version of the C# markdown regular expression
+    /// uses Singleline so that (.*) matches new line characters as well
+    /// </summary>
+    private static readonly Regex CSharpSnippetRegex = new Regex(CSharpSnippetPattern, RegexOptions.Singleline | RegexOptions.Compiled);
 
-        /// <summary>
-        /// matches result variable name from code snippets
-        /// </summary>
-        private const string ResultVariablePattern = "var ([@_a-zA-Z][_a-zA-Z0-9]+) = await graphClient";
+    /// <summary>
+    /// matches result variable name from code snippets
+    /// </summary>
+    private const string ResultVariablePattern = "var ([@_a-zA-Z][_a-zA-Z0-9]+) = await graphClient";
 
-        /// <summary>
-        /// compiled version of the regex matching result variable name from code snippets
-        /// </summary>
-        internal static readonly Regex ResultVariableRegex = new Regex(ResultVariablePattern, RegexOptions.Singleline | RegexOptions.Compiled);
+    /// <summary>
+    /// compiled version of the regex matching result variable name from code snippets
+    /// </summary>
+    internal static readonly Regex ResultVariableRegex = new Regex(ResultVariablePattern, RegexOptions.Singleline | RegexOptions.Compiled);
 
-        /// <summary>
-        /// 1. Fetches snippet from docs repo
-        /// 2. Asserts that there is one and only one snippet in the file
-        /// 3. Wraps snippet with compilable template
-        /// 4. Attempts to compile and reports errors if there is any
-        /// </summary>
-        /// <param name="testData">Test data containing information such as snippet file name</param>
-        public static void Compile(LanguageTestData testData)
+    /// <summary>
+    /// 1. Fetches snippet from docs repo
+    /// 2. Asserts that there is one and only one snippet in the file
+    /// 3. Wraps snippet with compilable template
+    /// 4. Attempts to compile and reports errors if there is any
+    /// </summary>
+    /// <param name="testData">Test data containing information such as snippet file name</param>
+    public static void Compile(LanguageTestData testData)
+    {
+        if (testData == null)
         {
-            if (testData == null)
-            {
-                throw new ArgumentNullException(nameof(testData));
-            }
-
-            var (codeToCompile, codeSnippetFormatted) = GetCodeToCompile(testData.FileContent);
-
-            // Compile Code
-            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData);
-            var compilationResultsModel = microsoftGraphCSharpCompiler.CompileSnippet(codeToCompile, testData.Version);
-
-            var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsCompilationKnownIssue);
-            EvaluateCompilationResult(compilationResultsModel, testData, codeSnippetFormatted, compilationOutputMessage);
-
-            Assert.Pass();
+            throw new ArgumentNullException(nameof(testData));
         }
 
-        /// <summary>
-        /// 1. Fetches snippet from docs repo
-        /// 2. Asserts that there is one and only one snippet in the file
-        /// 3. Wraps snippet with compilable template
-        /// 4. Attempts to compile and reports errors if there is any
-        /// 5. It uses the compiled binary to make a request to the demo tenant and reports error if there's a service exception i.e 4XX or 5xx response
-        /// </summary>
-        /// <param name="testData">Test data containing information such as snippet file name</param>
-        public static async Task Execute(LanguageTestData testData)
+        var (codeToCompile, codeSnippetFormatted) = GetCodeToCompile(testData.FileContent);
+
+        // Compile Code
+        var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData);
+        var compilationResultsModel = microsoftGraphCSharpCompiler.CompileSnippet(codeToCompile, testData.Version);
+
+        var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsCompilationKnownIssue);
+        EvaluateCompilationResult(compilationResultsModel, testData, codeSnippetFormatted, compilationOutputMessage);
+
+        Assert.Pass();
+    }
+
+    /// <summary>
+    /// 1. Fetches snippet from docs repo
+    /// 2. Asserts that there is one and only one snippet in the file
+    /// 3. Wraps snippet with compilable template
+    /// 4. Attempts to compile and reports errors if there is any
+    /// 5. It uses the compiled binary to make a request to the demo tenant and reports error if there's a service exception i.e 4XX or 5xx response
+    /// </summary>
+    /// <param name="testData">Test data containing information such as snippet file name</param>
+    public static async Task Execute(LanguageTestData testData)
+    {
+        if (testData == null)
         {
-            if (testData == null)
-            {
-                throw new ArgumentNullException(nameof(testData));
-            }
-
-            var (codeToCompile, codeSnippetFormatted) = GetCodeToExecute(testData.FileContent);
-
-            // Compile Code
-            var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData);
-            var executionResultsModel = await microsoftGraphCSharpCompiler
-                .ExecuteSnippet(codeToCompile, testData.Version)
-                .ConfigureAwait(false);
-            var compilationOutputMessage = new CompilationOutputMessage(
-                executionResultsModel.CompilationResult,
-                codeToCompile,
-                testData.DocsLink,
-                testData.KnownIssueMessage,
-                testData.IsCompilationKnownIssue);
-
-            EvaluateCompilationResult(executionResultsModel.CompilationResult, testData, codeSnippetFormatted, compilationOutputMessage);
-
-            if (!executionResultsModel.Success)
-            {
-                Assert.Fail($"{compilationOutputMessage}{Environment.NewLine}{executionResultsModel.ExceptionMessage}");
-            }
-
-            Assert.Pass(compilationOutputMessage.ToString());
+            throw new ArgumentNullException(nameof(testData));
         }
 
-        private static void EvaluateCompilationResult(CompilationResultsModel compilationResult, LanguageTestData testData, string codeSnippetFormatted, CompilationOutputMessage compilationOutputMessage)
+        var (codeToCompile, codeSnippetFormatted) = GetCodeToExecute(testData.FileContent);
+
+        // Compile Code
+        var microsoftGraphCSharpCompiler = new MicrosoftGraphCSharpCompiler(testData);
+        var executionResultsModel = await microsoftGraphCSharpCompiler
+            .ExecuteSnippet(codeToCompile, testData.Version)
+            .ConfigureAwait(false);
+        var compilationOutputMessage = new CompilationOutputMessage(
+            executionResultsModel.CompilationResult,
+            codeToCompile,
+            testData.DocsLink,
+            testData.KnownIssueMessage,
+            testData.IsCompilationKnownIssue);
+
+        EvaluateCompilationResult(executionResultsModel.CompilationResult, testData, codeSnippetFormatted, compilationOutputMessage);
+
+        if (!executionResultsModel.Success)
         {
-            if (!compilationResult.IsSuccess)
+            Assert.Fail($"{compilationOutputMessage}{Environment.NewLine}{executionResultsModel.ExceptionMessage}");
+        }
+
+        Assert.Pass(compilationOutputMessage.ToString());
+    }
+
+    private static void EvaluateCompilationResult(CompilationResultsModel compilationResult, LanguageTestData testData, string codeSnippetFormatted, CompilationOutputMessage compilationOutputMessage)
+    {
+        if (!compilationResult.IsSuccess)
+        {
+            // environment variable for sources directory is defined only for cloud runs
+            var config = TestsSetup.Config.Value;
+            if (config.IsLocalRun)
             {
-                // environment variable for sources directory is defined only for cloud runs
-                var config = TestsSetup.Config.Value;
-                if (config.IsLocalRun)
+                var linqPadQueriesDefaultFolder = Path.Join(
+                    Environment.GetEnvironmentVariable("USERPROFILE"),
+                    "/OneDrive - Microsoft", // remove this if you are not syncing your Documents to OneDrive
+                    "/Documents",
+                    "/LINQPad Queries");
+
+                if (Directory.Exists(linqPadQueriesDefaultFolder))
                 {
-                    var linqPadQueriesDefaultFolder = Path.Join(
-                        Environment.GetEnvironmentVariable("USERPROFILE"),
-                        "/OneDrive - Microsoft", // remove this if you are not syncing your Documents to OneDrive
-                        "/Documents",
-                        "/LINQPad Queries");
-
-                    if (Directory.Exists(linqPadQueriesDefaultFolder))
-                    {
-                        WriteLinqFile(testData, linqPadQueriesDefaultFolder, codeSnippetFormatted);
-                    }
+                    WriteLinqFile(testData, linqPadQueriesDefaultFolder, codeSnippetFormatted);
                 }
-
-                Assert.Fail($"{compilationOutputMessage}");
             }
+
+            Assert.Fail($"{compilationOutputMessage}");
         }
+    }
 
-        /// <summary>
-        /// Modifies snippet to return HttpRequestMessage object so that we can extract the generated URL
-        /// </summary>
-        /// <param name="codeSnippet">code snippet</param>
-        /// <returns>Code snippet that returns an HttpRequestMessage</returns>
+    /// <summary>
+    /// Modifies snippet to return HttpRequestMessage object so that we can extract the generated URL
+    /// </summary>
+    /// <param name="codeSnippet">code snippet</param>
+    /// <returns>Code snippet that returns an HttpRequestMessage</returns>
 
-        internal static string ReturnHttpRequestMessage(string codeSnippet)
-        {
-            var resultVariable = GetResultVariable(codeSnippet);
+    internal static string ReturnHttpRequestMessage(string codeSnippet)
+    {
+        var resultVariable = GetResultVariable(codeSnippet);
 
-            codeSnippet = codeSnippet.Replace("await graphClient", "graphClient")
-                .Replace(".GetAsync();", $@".GetHttpRequestMessage();
+        codeSnippet = codeSnippet.Replace("await graphClient", "graphClient")
+            .Replace(".GetAsync();", $@".GetHttpRequestMessage();
 
         return {resultVariable};");
 
-            var intendedClosingStatement = codeSnippet.LastIndexOf($"{resultVariable};", StringComparison.OrdinalIgnoreCase);
-            // Semi-Colon closing the snippet is at LastIndexOf the return variable + Length of resultVariable + 1
-            var closingSemiColonIndex = intendedClosingStatement + resultVariable.Length + 1;
-            // Remove all text from intended closing statement to the end. 
-            codeSnippet = codeSnippet.Remove(closingSemiColonIndex);
-            return codeSnippet;
-        }
-        private static string GetResultVariable(string codeToCompile)
+        var intendedClosingStatement = codeSnippet.LastIndexOf($"{resultVariable};", StringComparison.OrdinalIgnoreCase);
+        // Semi-Colon closing the snippet is at LastIndexOf the return variable + Length of resultVariable + 1
+        var closingSemiColonIndex = intendedClosingStatement + resultVariable.Length + 1;
+        // Remove all text from intended closing statement to the end.
+        codeSnippet = codeSnippet.Remove(closingSemiColonIndex);
+        return codeSnippet;
+    }
+    private static string GetResultVariable(string codeToCompile)
+    {
+        string resultVariable = null;
+        var resultVariableMatch = ResultVariableRegex.Match(codeToCompile);
+        if (resultVariableMatch.Success)
         {
-            string resultVariable = null;
-            var resultVariableMatch = ResultVariableRegex.Match(codeToCompile);
-            if (resultVariableMatch.Success)
-            {
-                resultVariable = resultVariableMatch.Groups[1].Value;
-            }
-            else
-            {
-                Assert.Fail("Regex {0}, against code {1} Failed", ResultVariablePattern, codeToCompile);
-            }
-
-            return resultVariable;
+            resultVariable = resultVariableMatch.Groups[1].Value;
+        }
+        else
+        {
+            Assert.Fail("Regex {0}, against code {1} Failed", ResultVariablePattern, codeToCompile);
         }
 
-        /// <summary>
-        /// Gets code to be executed
-        /// </summary>
-        /// <param name="fileContent">snippet file content</param>
-        /// <returns>code to be executed</returns>
-        private static (string, string) GetCodeToExecute(string fileContent)
-        {
-            var (codeToCompile, codeSnippetFormatted) = GetCodeToCompile(IdentifierReplacer.Instance.ReplaceIds(fileContent));
+        return resultVariable;
+    }
 
-            // have another transformation to insert GetRequestMessage method
-            codeToCompile = codeToCompile.Replace("GraphServiceClient( authProvider );", "GraphServiceClient( authProvider, httpProvider );");
-            codeToCompile = codeToCompile.Replace("return null; //return-request-message", "//insert-code-here");
-            codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(ReturnHttpRequestMessage(codeSnippetFormatted), codeToCompile);
-            return (codeToCompile, codeSnippetFormatted);
+    /// <summary>
+    /// Gets code to be executed
+    /// </summary>
+    /// <param name="fileContent">snippet file content</param>
+    /// <returns>code to be executed</returns>
+    private static (string, string) GetCodeToExecute(string fileContent)
+    {
+        var (codeToCompile, codeSnippetFormatted) = GetCodeToCompile(IdentifierReplacer.Instance.ReplaceIds(fileContent));
+
+        // have another transformation to insert GetRequestMessage method
+        codeToCompile = codeToCompile.Replace("GraphServiceClient( authProvider );", "GraphServiceClient( authProvider, httpProvider );");
+        codeToCompile = codeToCompile.Replace("return null; //return-request-message", "//insert-code-here");
+        codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(ReturnHttpRequestMessage(codeSnippetFormatted), codeToCompile);
+        return (codeToCompile, codeSnippetFormatted);
+    }
+
+    /// <summary>
+    /// Gets code to be compiled
+    /// </summary>
+    /// <param name="fileContent">snippet file content</param>
+    /// <returns>code to be compiled</returns>
+    private static (string, string) GetCodeToCompile(string fileContent)
+    {
+        var match = CSharpSnippetRegex.Match(fileContent);
+        Assert.IsTrue(match.Success, "Csharp snippet file is not in expected format!");
+
+        var codeSnippetFormatted = match.Groups[1].Value
+            .Replace("\r\n", "\r\n        ")            // add indentation to match with the template
+            .Replace("\r\n        \r\n", "\r\n\r\n")    // remove indentation added to empty lines
+            .Replace("\t", "    ");                     // do not use tabs
+
+        while (codeSnippetFormatted.Contains("\r\n\r\n"))
+        {
+            codeSnippetFormatted = codeSnippetFormatted.Replace("\r\n\r\n", "\r\n"); // do not have empty lines for shorter error messages
         }
 
-        /// <summary>
-        /// Gets code to be compiled
-        /// </summary>
-        /// <param name="fileContent">snippet file content</param>
-        /// <returns>code to be compiled</returns>
-        private static (string, string) GetCodeToCompile(string fileContent)
-        {
-            var match = CSharpSnippetRegex.Match(fileContent);
-            Assert.IsTrue(match.Success, "Csharp snippet file is not in expected format!");
+        var codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(codeSnippetFormatted, SDKShellTemplate);
 
-            var codeSnippetFormatted = match.Groups[1].Value
-                .Replace("\r\n", "\r\n        ")            // add indentation to match with the template
-                .Replace("\r\n        \r\n", "\r\n\r\n")    // remove indentation added to empty lines
-                .Replace("\t", "    ");                     // do not use tabs
+        return (codeToCompile, codeSnippetFormatted);
+    }
 
-            while (codeSnippetFormatted.Contains("\r\n\r\n"))
-            {
-                codeSnippetFormatted = codeSnippetFormatted.Replace("\r\n\r\n", "\r\n"); // do not have empty lines for shorter error messages
-            }
+    /// <summary>
+    /// Generates .linq file in default My Queries folder so that the results are visible in LinqPad right away
+    /// </summary>
+    /// <param name="testData">test data</param>
+    /// <param name="linqPadQueriesDefaultFolder">path to linqpad queries folder</param>
+    /// <param name="codeSnippetFormatted">code snippet</param>
+    private static void WriteLinqFile(LanguageTestData testData, string linqPadQueriesDefaultFolder, string codeSnippetFormatted)
+    {
+        var linqDirectory = Path.Join(
+                linqPadQueriesDefaultFolder,
+                "/RaptorResults",
+                (testData.Version, testData.IsCompilationKnownIssue) switch
+                {
+                    (Versions.Beta, false) => "/Beta",
+                    (Versions.Beta, true) => "/BetaKnown",
+                    (Versions.V1, false) => "/V1",
+                    (Versions.V1, true) => "/V1Known",
+                    _ => throw new ArgumentException("unsupported version", nameof(testData))
+                });
 
-            var codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(codeSnippetFormatted, SDKShellTemplate);
+        Directory.CreateDirectory(linqDirectory);
 
-            return (codeToCompile, codeSnippetFormatted);
-        }
+        var linqFilePath = Path.Join(linqDirectory, testData.FileName.Replace(".md", ".linq"));
 
-        /// <summary>
-        /// Generates .linq file in default My Queries folder so that the results are visible in LinqPad right away
-        /// </summary>
-        /// <param name="testData">test data</param>
-        /// <param name="linqPadQueriesDefaultFolder">path to linqpad queries folder</param>
-        /// <param name="codeSnippetFormatted">code snippet</param>
-        private static void WriteLinqFile(LanguageTestData testData, string linqPadQueriesDefaultFolder, string codeSnippetFormatted)
-        {
-            var linqDirectory = Path.Join(
-                    linqPadQueriesDefaultFolder,
-                    "/RaptorResults",
-                    (testData.Version, testData.IsCompilationKnownIssue) switch
-                    {
-                        (Versions.Beta, false) => "/Beta",
-                        (Versions.Beta, true) => "/BetaKnown",
-                        (Versions.V1, false) => "/V1",
-                        (Versions.V1, true) => "/V1Known",
-                        _ => throw new ArgumentException("unsupported version", nameof(testData))
-                    });
-
-            Directory.CreateDirectory(linqDirectory);
-
-            var linqFilePath = Path.Join(linqDirectory, testData.FileName.Replace(".md", ".linq"));
-
-            const string LinqTemplateStart = "<Query Kind=\"Statements\">";
-            string LinqTemplateEnd =
+        const string LinqTemplateStart = "<Query Kind=\"Statements\">";
+        string LinqTemplateEnd =
 @$"
   <Namespace>DayOfWeek = Microsoft.Graph.DayOfWeek</Namespace>
   <Namespace>KeyValuePair = Microsoft.Graph.KeyValuePair</Namespace>
@@ -279,17 +279,16 @@ public class GraphSDKTest
 // {testData.DocsLink}{(testData.IsCompilationKnownIssue ? (Environment.NewLine + "/* " + testData.KnownIssueMessage + " */") : string.Empty)}
 IAuthenticationProvider authProvider  = null;";
 
-            File.WriteAllText(linqFilePath,
-                LinqTemplateStart
-                + Environment.NewLine
-                + (testData.Version) switch
-                {
-                    Versions.Beta => "  <NuGetReference Prerelease=\"true\">Microsoft.Graph.Beta</NuGetReference>",
-                    Versions.V1 => "  <NuGetReference>Microsoft.Graph</NuGetReference>",
-                    _ => throw new ArgumentException("unsupported version", nameof(testData))
-                }
-                + LinqTemplateEnd
-                + codeSnippetFormatted.Replace("\n        ", "\n"));
-        }
+        File.WriteAllText(linqFilePath,
+            LinqTemplateStart
+            + Environment.NewLine
+            + (testData.Version) switch
+            {
+                Versions.Beta => "  <NuGetReference Prerelease=\"true\">Microsoft.Graph.Beta</NuGetReference>",
+                Versions.V1 => "  <NuGetReference>Microsoft.Graph</NuGetReference>",
+                _ => throw new ArgumentException("unsupported version", nameof(testData))
+            }
+            + LinqTemplateEnd
+            + codeSnippetFormatted.Replace("\n        ", "\n"));
     }
 }

--- a/TestsCommon/CompilationOutputMessage.cs
+++ b/TestsCommon/CompilationOutputMessage.cs
@@ -4,120 +4,119 @@ using MsGraphSDKSnippetsCompiler.Models;
 using System.Globalization;
 using System.Text;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+/// <summary>
+/// String represenation of compilation errors
+/// </summary>
+/// <param name="Model">Compilation result</param>
+/// <param name="Code">Code that was attempted to be compiled</param>
+/// <param name="DocsLink">documentation page where the snippet is shown</param>
+/// <param name="KnownIssueMessage">message for known issue</param>
+/// <param name="IsKnownIssue">whether issue is known</param>
+/// <param name="Language">compilation language</param>
+public record CompilationOutputMessage(CompilationResultsModel Model, string Code, string DocsLink, string KnownIssueMessage, bool IsKnownIssue, Languages Language = Languages.CSharp)
 {
     /// <summary>
-    /// String represenation of compilation errors
+    /// String representation of compilation result
     /// </summary>
-    /// <param name="Model">Compilation result</param>
-    /// <param name="Code">Code that was attempted to be compiled</param>
-    /// <param name="DocsLink">documentation page where the snippet is shown</param>
-    /// <param name="KnownIssueMessage">message for known issue</param>
-    /// <param name="IsKnownIssue">whether issue is known</param>
-    /// <param name="Language">compilation language</param>
-    public record CompilationOutputMessage (CompilationResultsModel Model, string Code, string DocsLink, string KnownIssueMessage, bool IsKnownIssue, Languages Language = Languages.CSharp)
+    /// <returns>
+    /// Code with line numbers and compiler errors
+    /// </returns>
+    public override string ToString() => GetKnownIssueMessage() + GetDocsLink() + GetCodeWithLineNumbers() + CompilerErrors();
+
+    /// <summary>
+    /// Get string representation of known issue message
+    /// </summary>
+    /// <returns>Known issue message if the issue is known, empty string if not</returns>
+    private string GetKnownIssueMessage() => IsKnownIssue ? $"Known Issue: {KnownIssueMessage}\r\n" : string.Empty;
+
+    /// <summary>
+    /// Gets documentation link for the snippet
+    /// </summary>
+    /// <returns>Documentation link for the snippet</returns>
+    private string GetDocsLink() => $"[Docs Link]({DocsLink})\r\n";
+
+    /// <summary>
+    /// For each compiler error, generates an error string with code location references
+    /// </summary>
+    /// <returns>
+    /// diagnostic-id: (line, character) error-message
+    /// e.g. C1000: (25,8) Cannot convert type from string to byte[]
+    /// </returns>
+    private string CompilerErrors()
     {
-        /// <summary>
-        /// String representation of compilation result
-        /// </summary>
-        /// <returns>
-        /// Code with line numbers and compiler errors
-        /// </returns>
-        public override string ToString() => GetKnownIssueMessage() + GetDocsLink() + GetCodeWithLineNumbers() + CompilerErrors();
-
-        /// <summary>
-        /// Get string representation of known issue message
-        /// </summary>
-        /// <returns>Known issue message if the issue is known, empty string if not</returns>
-        private string GetKnownIssueMessage() => IsKnownIssue ? $"Known Issue: {KnownIssueMessage}\r\n" : string.Empty;
-
-        /// <summary>
-        /// Gets documentation link for the snippet
-        /// </summary>
-        /// <returns>Documentation link for the snippet</returns>
-        private string GetDocsLink() => $"[Docs Link]({DocsLink})\r\n";
-
-        /// <summary>
-        /// For each compiler error, generates an error string with code location references
-        /// </summary>
-        /// <returns>
-        /// diagnostic-id: (line, character) error-message
-        /// e.g. C1000: (25,8) Cannot convert type from string to byte[]
-        /// </returns>
-        private string CompilerErrors()
+        if (Model?.Diagnostics == null)
         {
-            if (Model?.Diagnostics == null)
-            {
-                return "No diagnostics from the compiler!";
-            }
-
-            var result = new StringBuilder("\r\n");
-            foreach (var diagnostic in Model.Diagnostics)
-            {
-                var lineSpan = diagnostic.Location.GetLineSpan();
-                var line = lineSpan.StartLinePosition.Line + 1; // 0 indexed
-                var column = lineSpan.StartLinePosition.Character;
-
-                result.Append(CultureInfo.InvariantCulture, $"\r\n{diagnostic.Id}: (Line:{line}, Column:{column}) {diagnostic.GetMessage(CultureInfo.InvariantCulture)}");
-            }
-
-            return result.ToString();
+            return "No diagnostics from the compiler!";
         }
 
-        /// <summary>
-        /// Adds line numbers to a piece of code for easy reference
-        /// Line numbers are right-aligned
-        /// </summary>
-        /// <returns>
-        /// Code decorated with line numbers
-        /// </returns>
-        private string GetCodeWithLineNumbers()
+        var result = new StringBuilder("\r\n");
+        foreach (var diagnostic in Model.Diagnostics)
         {
-            if (string.IsNullOrEmpty(Code))
-            {
-                return string.Empty;
-            }
+            var lineSpan = diagnostic.Location.GetLineSpan();
+            var line = lineSpan.StartLinePosition.Line + 1; // 0 indexed
+            var column = lineSpan.StartLinePosition.Character;
 
-            var lines = Code.Split("\r\n");
-
-            var widestLineNumberWidth = lines.Length.ToString(CultureInfo.InvariantCulture).Length;
-
-            var builder = new StringBuilder("\r\n```\r\n");
-
-            var isPrinting = false;
-            var relevantStart = GetRelevantLinesStart();
-            for (int lineNumber = 1; lineNumber < lines.Length + 1; lineNumber++)
-            {
-                var line = lines[lineNumber - 1];
-                var trimmedLine = line.Trim();
-
-                if (!isPrinting && trimmedLine.Equals(relevantStart, StringComparison.Ordinal))
-                {
-                    isPrinting = true;
-                }
-
-                if (isPrinting)
-                {
-                    builder.Append(lineNumber.ToString(CultureInfo.InvariantCulture).PadLeft(widestLineNumberWidth)) // align line numbers to the right
-                        .Append(' ')
-                        .Append(line)
-                        .Append("\r\n");
-                }
-            }
-
-            builder.Append("```\r\n");
-
-            return builder.ToString();
+            result.Append(CultureInfo.InvariantCulture, $"\r\n{diagnostic.Id}: (Line:{line}, Column:{column}) {diagnostic.GetMessage(CultureInfo.InvariantCulture)}");
         }
 
-        private string GetRelevantLinesStart()
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// Adds line numbers to a piece of code for easy reference
+    /// Line numbers are right-aligned
+    /// </summary>
+    /// <returns>
+    /// Code decorated with line numbers
+    /// </returns>
+    private string GetCodeWithLineNumbers()
+    {
+        if (string.IsNullOrEmpty(Code))
         {
-            return Language switch
-            {
-                Languages.CSharp => "GraphServiceClient graphClient = new GraphServiceClient( authProvider );",
-                Languages.Java => "GraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();",
-                _ => throw new NotImplementedException($"Language {Language} is not supported"),
-            };
+            return string.Empty;
         }
+
+        var lines = Code.Split("\r\n");
+
+        var widestLineNumberWidth = lines.Length.ToString(CultureInfo.InvariantCulture).Length;
+
+        var builder = new StringBuilder("\r\n```\r\n");
+
+        var isPrinting = false;
+        var relevantStart = GetRelevantLinesStart();
+        for (int lineNumber = 1; lineNumber < lines.Length + 1; lineNumber++)
+        {
+            var line = lines[lineNumber - 1];
+            var trimmedLine = line.Trim();
+
+            if (!isPrinting && trimmedLine.Equals(relevantStart, StringComparison.Ordinal))
+            {
+                isPrinting = true;
+            }
+
+            if (isPrinting)
+            {
+                builder.Append(lineNumber.ToString(CultureInfo.InvariantCulture).PadLeft(widestLineNumberWidth)) // align line numbers to the right
+                    .Append(' ')
+                    .Append(line)
+                    .Append("\r\n");
+            }
+        }
+
+        builder.Append("```\r\n");
+
+        return builder.ToString();
+    }
+
+    private string GetRelevantLinesStart()
+    {
+        return Language switch
+        {
+            Languages.CSharp => "GraphServiceClient graphClient = new GraphServiceClient( authProvider );",
+            Languages.Java => "GraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();",
+            _ => throw new NotImplementedException($"Language {Language} is not supported"),
+        };
     }
 }

--- a/TestsCommon/CompilationOutputMessage.cs
+++ b/TestsCommon/CompilationOutputMessage.cs
@@ -1,9 +1,4 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-using System;
-using MsGraphSDKSnippetsCompiler.Models;
-using System.Globalization;
-using System.Text;
-
 namespace TestsCommon;
 
 /// <summary>

--- a/TestsCommon/GlobalUsings.cs
+++ b/TestsCommon/GlobalUsings.cs
@@ -1,0 +1,13 @@
+﻿global using System;
+global using System.IO;
+global using System.Threading.Tasks;
+global using MsGraphSDKSnippetsCompiler;
+global using MsGraphSDKSnippetsCompiler.Models;
+global using System.Globalization;
+global using System.Text;
+global using NUnit.Framework;
+global using System.Linq;
+global using System.Text.RegularExpressions;
+global using System.Threading;
+global using System.Collections.Generic;
+global using static TestsCommon.KnownIssues;

--- a/TestsCommon/GraphDocsDirectory.cs
+++ b/TestsCommon/GraphDocsDirectory.cs
@@ -2,51 +2,50 @@
 using MsGraphSDKSnippetsCompiler.Models;
 using System.IO;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+/// <summary>
+/// Init-once access to snippets directory
+/// </summary>
+public static class GraphDocsDirectory
 {
     /// <summary>
-    /// Init-once access to snippets directory
+    /// Represents where the snippets are stored. Expected to refer to a single directory for each assembly.
     /// </summary>
-    public static class GraphDocsDirectory
+    private static string SnippetsDirectory;
+
+    /// <summary>
+    /// Sets snippets directory only once and refers to the string if it is already set
+    /// Assumes that default "git clone <remote-reference>" command is used, in other words,
+    /// the repo is always in microsoft-graph-docs folder under RootDirectory defined above
+    /// </summary>
+    /// <param name="version">Docs version (e.g. V1 or Beta)</param>
+    /// <returns>
+    /// C# snippets directory
+    /// </returns>
+    public static string GetSnippetsDirectory(Versions version, Languages language)
     {
-        /// <summary>
-        /// Represents where the snippets are stored. Expected to refer to a single directory for each assembly.
-        /// </summary>
-        private static string SnippetsDirectory;
-
-        /// <summary>
-        /// Sets snippets directory only once and refers to the string if it is already set
-        /// Assumes that default "git clone <remote-reference>" command is used, in other words,
-        /// the repo is always in microsoft-graph-docs folder under RootDirectory defined above
-        /// </summary>
-        /// <param name="version">Docs version (e.g. V1 or Beta)</param>
-        /// <returns>
-        /// C# snippets directory
-        /// </returns>
-        public static string GetSnippetsDirectory(Versions version, Languages language)
+        if (SnippetsDirectory is object)
         {
-            if (SnippetsDirectory is object)
-            {
-                return SnippetsDirectory;
-            }
-
-            var msGraphDocsRepoLocation = TestsSetup.Config.Value.DocsRepoCheckoutDirectory;
-            SnippetsDirectory = Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}includes{Path.DirectorySeparatorChar}snippets{Path.DirectorySeparatorChar}{language.AsString()}");
-
             return SnippetsDirectory;
         }
 
-        /// <summary>
-        /// Gets directory holding Microsoft Graph documentation in markdown format
-        /// </summary>
-        /// <param name="version">Docs version (e.g. V1 or Beta)</param>
-        /// <returns>
-        /// Directory holding Microsoft Graph documentation in markdown format
-        /// </returns>
-        public static string GetDocumentationDirectory(Versions version)
-        {
-            var msGraphDocsRepoLocation = TestsSetup.Config.Value.DocsRepoCheckoutDirectory;
-            return Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}api");
-        }
+        var msGraphDocsRepoLocation = TestsSetup.Config.Value.DocsRepoCheckoutDirectory;
+        SnippetsDirectory = Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}includes{Path.DirectorySeparatorChar}snippets{Path.DirectorySeparatorChar}{language.AsString()}");
+
+        return SnippetsDirectory;
+    }
+
+    /// <summary>
+    /// Gets directory holding Microsoft Graph documentation in markdown format
+    /// </summary>
+    /// <param name="version">Docs version (e.g. V1 or Beta)</param>
+    /// <returns>
+    /// Directory holding Microsoft Graph documentation in markdown format
+    /// </returns>
+    public static string GetDocumentationDirectory(Versions version)
+    {
+        var msGraphDocsRepoLocation = TestsSetup.Config.Value.DocsRepoCheckoutDirectory;
+        return Path.Join(msGraphDocsRepoLocation, $@"microsoft-graph-docs{Path.DirectorySeparatorChar}api-reference{Path.DirectorySeparatorChar}{new VersionString(version)}{Path.DirectorySeparatorChar}api");
     }
 }

--- a/TestsCommon/GraphDocsDirectory.cs
+++ b/TestsCommon/GraphDocsDirectory.cs
@@ -1,7 +1,4 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
-using MsGraphSDKSnippetsCompiler.Models;
-using System.IO;
-
 namespace TestsCommon;
 
 /// <summary>

--- a/TestsCommon/JavaKnownIssues.cs
+++ b/TestsCommon/JavaKnownIssues.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using MsGraphSDKSnippetsCompiler.Models;
-using static TestsCommon.KnownIssues;
-
-namespace TestsCommon;
+﻿namespace TestsCommon;
 
 internal static class JavaKnownIssues
 {

--- a/TestsCommon/JavaKnownIssues.cs
+++ b/TestsCommon/JavaKnownIssues.cs
@@ -2,19 +2,19 @@
 using MsGraphSDKSnippetsCompiler.Models;
 using static TestsCommon.KnownIssues;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+internal static class JavaKnownIssues
 {
-    internal static class JavaKnownIssues
+    /// <summary>
+    /// Gets known issues
+    /// </summary>
+    /// <param name="versionEnum">version to get the known issues for</param>
+    /// <returns>A mapping of test names into known Java issues</returns>
+    internal static Dictionary<string, KnownIssue> GetJavaCompilationKnownIssues(Versions versionEnum)
     {
-        /// <summary>
-        /// Gets known issues
-        /// </summary>
-        /// <param name="versionEnum">version to get the known issues for</param>
-        /// <returns>A mapping of test names into known Java issues</returns>
-        internal static Dictionary<string, KnownIssue> GetJavaCompilationKnownIssues(Versions versionEnum)
-        {
-            var version = versionEnum == Versions.V1 ? "V1" : "Beta";
-            return new Dictionary<string, KnownIssue>()
+        var version = versionEnum == Versions.V1 ? "V1" : "Beta";
+        return new Dictionary<string, KnownIssue>()
             {
                 {$"unfollow-site-java-{version}-compiles", new KnownIssue(SDK, "SDK doesn't convert actions defined on collections to methods. https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/250") },
                 {$"follow-site-java-{version}-compiles", new KnownIssue(SDK, "SDK doesn't convert actions defined on collections to methods. https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/250") },
@@ -446,6 +446,5 @@ namespace TestsCommon
                 { "update-samlorwsfedexternaldomainfederation-java-Beta-compiles", new KnownIssue(NeedsAnalysis, NeedsAnalysisText)},
                 { "update-settings-java-Beta-compiles", new KnownIssue(NeedsAnalysis, NeedsAnalysisText)}
             };
-        }
     }
 }

--- a/TestsCommon/JavaTestRunner.cs
+++ b/TestsCommon/JavaTestRunner.cs
@@ -7,14 +7,14 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+public static class JavaTestRunner
 {
-    public static class JavaTestRunner
-    {
-        /// <summary>
-        /// template to compile snippets in
-        /// </summary>
-        private const string SDKShellTemplate = @"package com.microsoft.graph.raptor;
+    /// <summary>
+    /// template to compile snippets in
+    /// </summary>
+    private const string SDKShellTemplate = @"package com.microsoft.graph.raptor;
 import com.microsoft.graph.httpcore.*;
 import com.microsoft.graph.requests.*;
 import com.microsoft.graph.models.*;
@@ -46,78 +46,77 @@ public class App
         //insert-code-here
     }
 }";
-        private const string authProviderCurrent = @"        final IAuthenticationProvider authProvider = new IAuthenticationProvider() {
+    private const string authProviderCurrent = @"        final IAuthenticationProvider authProvider = new IAuthenticationProvider() {
             @Override
             public CompletableFuture<String> getAuthorizationTokenAsync(final URL requestUrl) {
                 return CompletableFuture.completedFuture("""");
             }
         };";
-        /// <summary>
-        /// matches csharp snippet from C# snippets markdown output
-        /// </summary>
-        private const string Pattern = @"```java(.*)```";
+    /// <summary>
+    /// matches csharp snippet from C# snippets markdown output
+    /// </summary>
+    private const string Pattern = @"```java(.*)```";
 
-        /// <summary>
-        /// compiled version of the C# markdown regular expression
-        /// uses Singleline so that (.*) matches new line characters as well
-        /// </summary>
-        private static readonly Regex RegExp = new Regex(Pattern, RegexOptions.Singleline | RegexOptions.Compiled);
+    /// <summary>
+    /// compiled version of the C# markdown regular expression
+    /// uses Singleline so that (.*) matches new line characters as well
+    /// </summary>
+    private static readonly Regex RegExp = new Regex(Pattern, RegexOptions.Singleline | RegexOptions.Compiled);
 
 
-        /// <summary>
-        /// 1. Fetches snippet from docs repo
-        /// 2. Asserts that there is one and only one snippet in the file
-        /// 3. Wraps snippet with compilable template
-        /// 4. Attempts to compile and reports errors if there is any
-        /// </summary>
-        /// <param name="testData">Test data containing information such as snippet file name</param>
-        public static void Run(LanguageTestData testData)
+    /// <summary>
+    /// 1. Fetches snippet from docs repo
+    /// 2. Asserts that there is one and only one snippet in the file
+    /// 3. Wraps snippet with compilable template
+    /// 4. Attempts to compile and reports errors if there is any
+    /// </summary>
+    /// <param name="testData">Test data containing information such as snippet file name</param>
+    public static void Run(LanguageTestData testData)
+    {
+        if (testData == null)
         {
-            if (testData == null)
+            throw new ArgumentNullException(nameof(testData));
+        }
+
+        var fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(testData.Version, Languages.Java), testData.FileName);
+        Assert.IsTrue(File.Exists(fullPath), "Snippet file referenced in documentation is not found!");
+
+        var fileContent = File.ReadAllText(fullPath);
+        var match = RegExp.Match(fileContent);
+        Assert.IsTrue(match.Success, "Java snippet file is not in expected format!");
+
+        var codeSnippetFormatted = match.Groups[1].Value
+            .Replace("\r\n", "\r\n        ")            // add indentation to match with the template
+            .Replace("\r\n        \r\n", "\r\n\r\n")    // remove indentation added to empty lines
+            .Replace("\t", "    ")                      // do not use tabs
+            .Replace("\r\n\r\n\r\n", "\r\n\r\n");       // do not have two consecutive empty lines
+        var isCurrentSdk = string.IsNullOrEmpty(testData.JavaPreviewLibPath);
+        var codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(codeSnippetFormatted, SDKShellTemplate
+                                                                        .Replace("--auth--", authProviderCurrent));
+
+        // Compile Code
+        var microsoftGraphCSharpCompiler = new MicrosoftGraphJavaCompiler(testData.FileName, testData.JavaPreviewLibPath, testData.JavaLibVersion, testData.JavaCoreVersion);
+
+        var jvmRetryAttmptsLeft = 3;
+        while (jvmRetryAttmptsLeft > 0)
+        {
+            var compilationResultsModel = microsoftGraphCSharpCompiler.CompileSnippet(codeToCompile, testData.Version);
+
+            if (compilationResultsModel.IsSuccess)
             {
-                throw new ArgumentNullException(nameof(testData));
+                Assert.Pass();
+            }
+            else if (compilationResultsModel.Diagnostics.Any(x => x.GetMessage().Contains("Starting a Gradle Daemon")))
+            {//the JVM takes time to start making the first test to be run to be flaky, this is a workaround
+                jvmRetryAttmptsLeft--;
+                Thread.Sleep(20000);
+                continue;
             }
 
-            var fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(testData.Version, Languages.Java), testData.FileName);
-            Assert.IsTrue(File.Exists(fullPath), "Snippet file referenced in documentation is not found!");
+            var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsCompilationKnownIssue, Languages.Java);
 
-            var fileContent = File.ReadAllText(fullPath);
-            var match = RegExp.Match(fileContent);
-            Assert.IsTrue(match.Success, "Java snippet file is not in expected format!");
-
-            var codeSnippetFormatted = match.Groups[1].Value
-                .Replace("\r\n", "\r\n        ")            // add indentation to match with the template
-                .Replace("\r\n        \r\n", "\r\n\r\n")    // remove indentation added to empty lines
-                .Replace("\t", "    ")                      // do not use tabs
-                .Replace("\r\n\r\n\r\n", "\r\n\r\n");       // do not have two consecutive empty lines
-            var isCurrentSdk = string.IsNullOrEmpty(testData.JavaPreviewLibPath);
-            var codeToCompile = BaseTestRunner.ConcatBaseTemplateWithSnippet(codeSnippetFormatted, SDKShellTemplate
-                                                                            .Replace("--auth--", authProviderCurrent));
-
-            // Compile Code
-            var microsoftGraphCSharpCompiler = new MicrosoftGraphJavaCompiler(testData.FileName, testData.JavaPreviewLibPath, testData.JavaLibVersion, testData.JavaCoreVersion);
-
-            var jvmRetryAttmptsLeft = 3;
-            while (jvmRetryAttmptsLeft > 0)
-            {
-                var compilationResultsModel = microsoftGraphCSharpCompiler.CompileSnippet(codeToCompile, testData.Version);
-
-                if (compilationResultsModel.IsSuccess)
-                {
-                    Assert.Pass();
-                }
-                else if(compilationResultsModel.Diagnostics.Any(x => x.GetMessage().Contains("Starting a Gradle Daemon")))
-                {//the JVM takes time to start making the first test to be run to be flaky, this is a workaround
-                    jvmRetryAttmptsLeft--;
-                    Thread.Sleep(20000);
-                    continue;
-                }
-
-                var compilationOutputMessage = new CompilationOutputMessage(compilationResultsModel, codeToCompile, testData.DocsLink, testData.KnownIssueMessage, testData.IsCompilationKnownIssue, Languages.Java);
-
-                Assert.Fail($"{compilationOutputMessage}");
-                break;
-            }
+            Assert.Fail($"{compilationOutputMessage}");
+            break;
         }
     }
 }

--- a/TestsCommon/JavaTestRunner.cs
+++ b/TestsCommon/JavaTestRunner.cs
@@ -1,13 +1,4 @@
-﻿using MsGraphSDKSnippetsCompiler;
-using MsGraphSDKSnippetsCompiler.Models;
-using NUnit.Framework;
-using System;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
-
-namespace TestsCommon;
+﻿namespace TestsCommon;
 
 public static class JavaTestRunner
 {

--- a/TestsCommon/KnownIssues.cs
+++ b/TestsCommon/KnownIssues.cs
@@ -5,153 +5,153 @@ using MsGraphSDKSnippetsCompiler.Models;
 using static TestsCommon.JavaKnownIssues;
 using static TestsCommon.CSharpKnownIssues;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+public static class KnownIssues
 {
-    public static class KnownIssues
+    #region SDK issues
+
+    internal const string SearchHeaderIsNotSupported = "Search header is not supported by the SDK";
+    internal const string CountIsNotSupported = "OData $count is not supported by the SDK at the moment.\r\n"
+        + "https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/402";
+    internal const string MissingContentProperty = "IReportRootGetM365AppPlatformUserCountsRequestBuilder is missing Content property";
+    internal const string StreamRequestDoesNotSupportDelete = "Stream requests only support PUT and GET.";
+    internal const string DeleteAsyncIsNotSupportedForReferences = "DeleteAsync is not supported for reference collections\r\n"
+        + "https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/471";
+    internal const string TypeCastIsNotSupported = "Type cast operation is not supported in SDK.\n"
+        + "https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/304";
+
+    internal const string ComplexTypeNavigationProperties = "Complex Type navigation properties are not generated\r\n"
+        + "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1003";
+
+    #endregion
+
+    #region HTTP Snippet Issues
+    internal const string HttpSnippetWrong = "Http snippet should be fixed";
+    internal const string RefNeeded = "URL needs to end with /$ref for reference types";
+    internal const string RefShouldBeRemoved = "URL shouldn't end with /$ref";
+    #endregion
+
+    #region Metadata Issues
+    internal const string MetadataWrong = "Metadata should be fixed";
+    internal const string IdentityRiskEvents = "identityRiskEvents not defined in metadata.";
+    #endregion
+
+    #region Metadata Preprocessing Issues
+    internal const string EventActionsShouldNotBeReordered = "There is a reorder rule in XSLT. It should be removed" +
+        " See https://github.com/microsoftgraph/msgraph-metadata/pull/64";
+    internal const string EducationAssignmentRubricContainsTargetPreprocessor = "EducationRubric containsTarget should be False to use $ref." +
+        " See https://github.com/microsoftgraph/msgraph-metadata/issues/81";
+    #endregion
+
+    #region Snipppet Generation Issues
+    internal const string SnippetGenerationCreateAsyncSupport = "Snippet generation doesn't use CreateAsync" +
+        " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/301";
+    internal const string StructuralPropertiesAreNotHandled = "We don't generate request builders for URL navigation to structural properties." +
+        " We should build a custom request with URL as this is not supported in SDK." +
+        " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/485";
+    internal const string SameBlockNames = "Same block names indeterministic snippet generation" +
+        " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/463";
+    internal const string NamespaceOdataTypeAnnotationsWithoutHashSymbol = "We do not support namespacing when odata.type annotations are not prepended with hash symbol." +
+        " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/580";
+    internal const string DateTimeOffsetHandlingInUrls = "Dates supplied via GET request urls are not parsed to dates\r\n"
+        + "https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/612";
+    internal const string IdentitySetAndIdentityShouldNestAdditionalData = "https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/613";
+    #endregion
+
+    #region Needs analysis
+    internal const string NeedsAnalysisText = "This is a consistently failing test, the root cause is not yet identified";
+    internal const string NeedsAnalysisTestNamePrefix = "known-issue-needs-analysis-";
+    #endregion
+
+    #region Missing data
+    internal const string MissingDataText = "This test is missing data in identifiers.json file";
+    internal const string MissingDataTestNamePrefix = "known-issue-missing-data-";
+    #endregion
+
+    #region Missing permission scope
+    internal const string MissingPermissionScopeText = "DevX API is not returning any delegated or application permissions for the URI.";
+    internal const string MissingPermissionScopeTestNamePrefix = "known-issue-missing-permission-scope-";
+    #endregion
+
+    #region Test Owner values (to categorize results in Azure DevOps)
+    internal const string Permissions = "DevX API Permissions";
+    internal const string Raptor = nameof(Raptor);
+    internal const string SDK = nameof(SDK);
+    internal const string HTTP = nameof(HTTP);
+    internal const string HTTPCamelCase = nameof(HTTPCamelCase);
+    internal const string HTTPMethodWrong = nameof(HTTPMethodWrong);
+    internal const string Metadata = nameof(Metadata);
+    internal const string MetadataPreprocessing = nameof(MetadataPreprocessing);
+    internal const string SnippetGeneration = nameof(SnippetGeneration);
+    internal const string TestGeneration = nameof(TestGeneration);
+    internal const string NeedsAnalysis = nameof(NeedsAnalysis);
+    internal const string MissingData = nameof(MissingData);
+    internal const string MissingPermissionScope = nameof(MissingPermissionScope);
+    #endregion
+
+    #region HTTP methods
+    internal const string DELETE = nameof(DELETE);
+    internal const string PUT = nameof(PUT);
+    internal const string POST = nameof(POST);
+    internal const string GET = nameof(GET);
+    internal const string PATCH = nameof(PATCH);
+    #endregion
+
+    internal static readonly KnownIssue PermissionsExcelIdKnownIssue = new KnownIssue(Permissions, GitHubIssue: "https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/745", TestNamePrefix: "known-issue-permissions-excel-id-");
+    internal static readonly KnownIssue SnippetGenerationKnownIssue = new KnownIssue(SnippetGeneration, CustomMessage: "Snippet generation should be fixed", TestNamePrefix: "known-issue-snippet-generation-");
+    internal static readonly KnownIssue MetadataMissingNavigationPropertyKnownIssue = new KnownIssue(Metadata, GitHubIssue: "https://github.com/microsoftgraph/microsoft-graph-docs/issues/14703", TestNamePrefix: "known-issue-metadata-missing-navigation-property-");
+    internal static readonly KnownIssue RaptorInfrastructureKnownIssue = new KnownIssue(Raptor, CustomMessage: "Raptor infrastructure work is needed", TestNamePrefix: "known-issue-raptor-infrastructure-");
+    internal static readonly KnownIssue SDKFunctionParameterKnownIssue = new KnownIssue(SDK, GitHubIssue: "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1156", TestNamePrefix: "known-issue-sdk-function-parameter-");
+    internal static readonly KnownIssue HTTPKnownIssue = new KnownIssue(HTTP, CustomMessage: HttpSnippetWrong, TestNamePrefix: "known-issue-http-snippet-wrong-");
+    internal static readonly KnownIssue SDKMissingCountSupportKnownIssue = new KnownIssue(SDK, "SDK doesn't have support for $count", "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/875", "known-issue-sdk-missing-count-support-");
+    internal static readonly KnownIssue NeedsAnalysisKnownIssue = new KnownIssue(NeedsAnalysis, CustomMessage: NeedsAnalysisText, TestNamePrefix: NeedsAnalysisTestNamePrefix);
+    internal static readonly KnownIssue MissingDataKnownIssue = new KnownIssue(MissingData, CustomMessage: MissingDataText, TestNamePrefix: MissingDataTestNamePrefix);
+    internal static readonly KnownIssue MissingPermissionScopeKnownIssue = new KnownIssue(MissingPermissionScope, CustomMessage: MissingPermissionScopeText, TestNamePrefix: MissingPermissionScopeTestNamePrefix);
+
+    /// <summary>
+    /// Constructs property not found message
+    /// </summary>
+    /// <param name="type">Type that need to define the property</param>
+    /// <param name="property">Property that needs to be defined but missing in metadata</param>
+    /// <returns>String representation of property not found message</returns>
+    internal static string GetPropertyNotFoundMessage(string type, string property)
     {
-        #region SDK issues
+        return HttpSnippetWrong + $": {type} does not contain definition of {property} in metadata";
+    }
 
-        internal const string SearchHeaderIsNotSupported = "Search header is not supported by the SDK";
-        internal const string CountIsNotSupported = "OData $count is not supported by the SDK at the moment.\r\n"
-            + "https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/402";
-        internal const string MissingContentProperty = "IReportRootGetM365AppPlatformUserCountsRequestBuilder is missing Content property";
-        internal const string StreamRequestDoesNotSupportDelete = "Stream requests only support PUT and GET.";
-        internal const string DeleteAsyncIsNotSupportedForReferences = "DeleteAsync is not supported for reference collections\r\n"
-            + "https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/471";
-        internal const string TypeCastIsNotSupported = "Type cast operation is not supported in SDK.\n"
-            + "https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/304";
+    /// <summary>
+    /// Constructs metadata errors where a reference property has ContainsTarget=true
+    /// </summary>
+    /// <param name="type">Type in metadata</param>
+    /// <param name="property">Property in metadata</param>
+    /// <returns>String representation of metadata error</returns>
+    internal static string GetContainsTargetRemoveMessage(string type, string property)
+    {
+        return MetadataWrong + $": {type}->{property} shouldn't have `ContainsTarget=true`";
+    }
 
-        internal const string ComplexTypeNavigationProperties = "Complex Type navigation properties are not generated\r\n"
-            + "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1003";
+    /// <summary>
+    /// Constructs error message where HTTP method is wrong
+    /// </summary>
+    /// <param name="docsMethod">wrong HTTP method in docs</param>
+    /// <param name="expectedMethod">expected HTTP method in the samples</param>
+    /// <returns>String representation of HTTP method wrong error</returns>
+    internal static string GetMethodWrongMessage(string docsMethod, string expectedMethod)
+    {
+        return HttpSnippetWrong + $": Docs has HTTP method {docsMethod}, it should be {expectedMethod}";
+    }
 
-        #endregion
-
-        #region HTTP Snippet Issues
-        internal const string HttpSnippetWrong = "Http snippet should be fixed";
-        internal const string RefNeeded = "URL needs to end with /$ref for reference types";
-        internal const string RefShouldBeRemoved = "URL shouldn't end with /$ref";
-        #endregion
-
-        #region Metadata Issues
-        internal const string MetadataWrong = "Metadata should be fixed";
-        internal const string IdentityRiskEvents = "identityRiskEvents not defined in metadata.";
-        #endregion
-
-        #region Metadata Preprocessing Issues
-        internal const string EventActionsShouldNotBeReordered = "There is a reorder rule in XSLT. It should be removed" +
-            " See https://github.com/microsoftgraph/msgraph-metadata/pull/64";
-        internal const string EducationAssignmentRubricContainsTargetPreprocessor = "EducationRubric containsTarget should be False to use $ref." +
-            " See https://github.com/microsoftgraph/msgraph-metadata/issues/81";
-        #endregion
-
-        #region Snipppet Generation Issues
-        internal const string SnippetGenerationCreateAsyncSupport = "Snippet generation doesn't use CreateAsync" +
-            " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/301";
-        internal const string StructuralPropertiesAreNotHandled = "We don't generate request builders for URL navigation to structural properties." +
-            " We should build a custom request with URL as this is not supported in SDK." +
-            " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/485";
-        internal const string SameBlockNames = "Same block names indeterministic snippet generation" +
-            " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/463";
-        internal const string NamespaceOdataTypeAnnotationsWithoutHashSymbol = "We do not support namespacing when odata.type annotations are not prepended with hash symbol." +
-            " See https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/580";
-        internal const string DateTimeOffsetHandlingInUrls = "Dates supplied via GET request urls are not parsed to dates\r\n"
-            + "https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/612";
-        internal const string IdentitySetAndIdentityShouldNestAdditionalData = "https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/613";
-        #endregion
-
-        #region Needs analysis
-        internal const string NeedsAnalysisText = "This is a consistently failing test, the root cause is not yet identified";
-        internal const string NeedsAnalysisTestNamePrefix = "known-issue-needs-analysis-";
-        #endregion
-
-        #region Missing data
-        internal const string MissingDataText = "This test is missing data in identifiers.json file";
-        internal const string MissingDataTestNamePrefix = "known-issue-missing-data-";
-        #endregion
-
-        #region Missing permission scope
-        internal const string MissingPermissionScopeText = "DevX API is not returning any delegated or application permissions for the URI.";
-        internal const string MissingPermissionScopeTestNamePrefix = "known-issue-missing-permission-scope-";
-        #endregion
-
-        #region Test Owner values (to categorize results in Azure DevOps)
-        internal const string Permissions = "DevX API Permissions";
-        internal const string Raptor = nameof(Raptor);
-        internal const string SDK = nameof(SDK);
-        internal const string HTTP = nameof(HTTP);
-        internal const string HTTPCamelCase = nameof(HTTPCamelCase);
-        internal const string HTTPMethodWrong = nameof(HTTPMethodWrong);
-        internal const string Metadata = nameof(Metadata);
-        internal const string MetadataPreprocessing = nameof(MetadataPreprocessing);
-        internal const string SnippetGeneration = nameof(SnippetGeneration);
-        internal const string TestGeneration = nameof(TestGeneration);
-        internal const string NeedsAnalysis = nameof(NeedsAnalysis);
-        internal const string MissingData = nameof(MissingData);
-        internal const string MissingPermissionScope = nameof(MissingPermissionScope);
-        #endregion
-
-        #region HTTP methods
-        internal const string DELETE = nameof(DELETE);
-        internal const string PUT = nameof(PUT);
-        internal const string POST = nameof(POST);
-        internal const string GET = nameof(GET);
-        internal const string PATCH = nameof(PATCH);
-        #endregion
-
-        internal static readonly KnownIssue PermissionsExcelIdKnownIssue = new KnownIssue(Permissions, GitHubIssue: "https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/745", TestNamePrefix: "known-issue-permissions-excel-id-");
-        internal static readonly KnownIssue SnippetGenerationKnownIssue = new KnownIssue(SnippetGeneration, CustomMessage: "Snippet generation should be fixed", TestNamePrefix:"known-issue-snippet-generation-");
-        internal static readonly KnownIssue MetadataMissingNavigationPropertyKnownIssue = new KnownIssue(Metadata, GitHubIssue: "https://github.com/microsoftgraph/microsoft-graph-docs/issues/14703", TestNamePrefix: "known-issue-metadata-missing-navigation-property-");
-        internal static readonly KnownIssue RaptorInfrastructureKnownIssue = new KnownIssue(Raptor, CustomMessage: "Raptor infrastructure work is needed", TestNamePrefix: "known-issue-raptor-infrastructure-");
-        internal static readonly KnownIssue SDKFunctionParameterKnownIssue = new KnownIssue(SDK, GitHubIssue: "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1156", TestNamePrefix: "known-issue-sdk-function-parameter-");
-        internal static readonly KnownIssue HTTPKnownIssue = new KnownIssue(HTTP, CustomMessage: HttpSnippetWrong, TestNamePrefix: "known-issue-http-snippet-wrong-");
-        internal static readonly KnownIssue SDKMissingCountSupportKnownIssue = new KnownIssue(SDK, "SDK doesn't have support for $count", "https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/875", "known-issue-sdk-missing-count-support-");
-        internal static readonly KnownIssue NeedsAnalysisKnownIssue = new KnownIssue(NeedsAnalysis, CustomMessage: NeedsAnalysisText, TestNamePrefix: NeedsAnalysisTestNamePrefix);
-        internal static readonly KnownIssue MissingDataKnownIssue = new KnownIssue(MissingData, CustomMessage: MissingDataText, TestNamePrefix: MissingDataTestNamePrefix);
-        internal static readonly KnownIssue MissingPermissionScopeKnownIssue = new KnownIssue(MissingPermissionScope, CustomMessage: MissingPermissionScopeText, TestNamePrefix: MissingPermissionScopeTestNamePrefix);
-
-        /// <summary>
-        /// Constructs property not found message
-        /// </summary>
-        /// <param name="type">Type that need to define the property</param>
-        /// <param name="property">Property that needs to be defined but missing in metadata</param>
-        /// <returns>String representation of property not found message</returns>
-        internal static string GetPropertyNotFoundMessage(string type, string property)
-        {
-            return HttpSnippetWrong + $": {type} does not contain definition of {property} in metadata";
-        }
-
-        /// <summary>
-        /// Constructs metadata errors where a reference property has ContainsTarget=true
-        /// </summary>
-        /// <param name="type">Type in metadata</param>
-        /// <param name="property">Property in metadata</param>
-        /// <returns>String representation of metadata error</returns>
-        internal static string GetContainsTargetRemoveMessage(string type, string property)
-        {
-            return MetadataWrong + $": {type}->{property} shouldn't have `ContainsTarget=true`";
-        }
-
-        /// <summary>
-        /// Constructs error message where HTTP method is wrong
-        /// </summary>
-        /// <param name="docsMethod">wrong HTTP method in docs</param>
-        /// <param name="expectedMethod">expected HTTP method in the samples</param>
-        /// <returns>String representation of HTTP method wrong error</returns>
-        internal static string GetMethodWrongMessage(string docsMethod, string expectedMethod)
-        {
-            return HttpSnippetWrong + $": Docs has HTTP method {docsMethod}, it should be {expectedMethod}";
-        }
-
-        /// <summary>
-        /// Returns a mapping of issues of which the source comes from service/documentation/metadata and are common accross langauges
-        /// </summary>
-        /// <param name="language">language to generate the exception from</param>
-        /// <returns>mapping of issues of which the source comes from service/documentation/metadata and are common accross langauges</returns>
-        public static Dictionary<string, KnownIssue> GetCompilationCommonIssues(Languages language, Versions versionEnum)
-        {
-            var version = versionEnum.ToString();
-            var lng = language.AsString();
-            return new Dictionary<string, KnownIssue>()
+    /// <summary>
+    /// Returns a mapping of issues of which the source comes from service/documentation/metadata and are common accross langauges
+    /// </summary>
+    /// <param name="language">language to generate the exception from</param>
+    /// <returns>mapping of issues of which the source comes from service/documentation/metadata and are common accross langauges</returns>
+    public static Dictionary<string, KnownIssue> GetCompilationCommonIssues(Languages language, Versions versionEnum)
+    {
+        var version = versionEnum.ToString();
+        var lng = language.AsString();
+        return new Dictionary<string, KnownIssue>()
             {
                 { $"call-updatemetadata-{lng}-Beta-compiles", new KnownIssue(Metadata, "updateMetadata doesn't exist in metadata") },
                 { $"create-directoryobject-from-featurerolloutpolicy-{lng}-{version}-compiles", new KnownIssue(Metadata, GetContainsTargetRemoveMessage("featureRolloutPolicy", "appliesTo"))},
@@ -190,38 +190,36 @@ namespace TestsCommon
                 {$"shift-get-{lng}-Beta-compiles", new KnownIssue(HTTP, "https://github.com/microsoftgraph/microsoft-graph-docs/issues/11521") },
                 {$"shift-get-{lng}-V1-compiles", new KnownIssue(HTTP, "https://github.com/microsoftgraph/microsoft-graph-docs/issues/11521") },
             };
-        }
-
-        /// <summary>
-        /// Gets known issues by language
-        /// </summary>
-        /// <param name="language">language to get the issues for</param>
-        /// <param name="version">version to get the issues for</param>
-        /// <returns>A mapping of test names into known issues</returns>
-        public static Dictionary<string, KnownIssue> GetCompilationKnownIssues(Languages language, Versions version)
-        {
-            return (language switch
-            {
-                Languages.CSharp => GetCSharpCompilationKnownIssues(version),
-                Languages.Java => GetJavaCompilationKnownIssues(version),
-                _ => new Dictionary<string, KnownIssue>()
-            }).Union(GetCompilationCommonIssues(language, version)).ToDictionary(x => x.Key, x => x.Value);
-        }
-
-        /// <summary>
-        /// Gets known issues by language
-        /// </summary>
-        /// <param name="language">language to get the issues for</param>
-        /// <param name="version">version to get the issues for</param>
-        /// <returns>A mapping of test names into known issues</returns>
-        public static Dictionary<string, KnownIssue> GetExecutionKnownIssues(Languages language, Versions version)
-        {
-            return language switch
-            {
-                Languages.CSharp => GetCSharpExecutionKnownIssues(version),
-                _ => new Dictionary<string, KnownIssue>()
-            };
-        }
     }
 
+    /// <summary>
+    /// Gets known issues by language
+    /// </summary>
+    /// <param name="language">language to get the issues for</param>
+    /// <param name="version">version to get the issues for</param>
+    /// <returns>A mapping of test names into known issues</returns>
+    public static Dictionary<string, KnownIssue> GetCompilationKnownIssues(Languages language, Versions version)
+    {
+        return (language switch
+        {
+            Languages.CSharp => GetCSharpCompilationKnownIssues(version),
+            Languages.Java => GetJavaCompilationKnownIssues(version),
+            _ => new Dictionary<string, KnownIssue>()
+        }).Union(GetCompilationCommonIssues(language, version)).ToDictionary(x => x.Key, x => x.Value);
+    }
+
+    /// <summary>
+    /// Gets known issues by language
+    /// </summary>
+    /// <param name="language">language to get the issues for</param>
+    /// <param name="version">version to get the issues for</param>
+    /// <returns>A mapping of test names into known issues</returns>
+    public static Dictionary<string, KnownIssue> GetExecutionKnownIssues(Languages language, Versions version)
+    {
+        return language switch
+        {
+            Languages.CSharp => GetCSharpExecutionKnownIssues(version),
+            _ => new Dictionary<string, KnownIssue>()
+        };
+    }
 }

--- a/TestsCommon/KnownIssues.cs
+++ b/TestsCommon/KnownIssues.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using MsGraphSDKSnippetsCompiler.Models;
-using static TestsCommon.JavaKnownIssues;
+﻿using static TestsCommon.JavaKnownIssues;
 using static TestsCommon.CSharpKnownIssues;
 
 namespace TestsCommon;

--- a/TestsCommon/RetryTestCaseSourceAttribute.cs
+++ b/TestsCommon/RetryTestCaseSourceAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using NUnit.Framework;
-using NUnit.Framework.Interfaces;
+﻿using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 
 namespace TestsCommon;

--- a/TestsCommon/RetryTestCaseSourceAttribute.cs
+++ b/TestsCommon/RetryTestCaseSourceAttribute.cs
@@ -3,22 +3,24 @@ using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 
-namespace TestsCommon
-{
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-    public sealed class RetryTestCaseSourceAttribute : TestCaseSourceAttribute, IRepeatTest
-    {
-        #region constructors
-        public RetryTestCaseSourceAttribute(string sourceName) : base(sourceName){}
-        public RetryTestCaseSourceAttribute(Type sourceType) : base(sourceType){}
-        public RetryTestCaseSourceAttribute(Type sourceType, string sourceName) : base(sourceType, sourceName){}
-        public RetryTestCaseSourceAttribute(string sourceName, object[] methodParams) : base(sourceName, methodParams){}
-        public RetryTestCaseSourceAttribute(Type sourceType, string sourceName, object[] methodParams) : base(sourceType, sourceName, methodParams){}
-        #endregion
+namespace TestsCommon;
 
-        #region repeat components
-        public int MaxTries { get; set; }
-        TestCommand ICommandWrapper.Wrap(TestCommand command) => new RetryAttribute.RetryCommand(command, MaxTries);
-        #endregion
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+public sealed class RetryTestCaseSourceAttribute : TestCaseSourceAttribute, IRepeatTest
+{
+    #region constructors
+    public RetryTestCaseSourceAttribute(string sourceName) : base(sourceName) { }
+    public RetryTestCaseSourceAttribute(Type sourceType) : base(sourceType) { }
+    public RetryTestCaseSourceAttribute(Type sourceType, string sourceName) : base(sourceType, sourceName) { }
+    public RetryTestCaseSourceAttribute(string sourceName, object[] methodParams) : base(sourceName, methodParams) { }
+    public RetryTestCaseSourceAttribute(Type sourceType, string sourceName, object[] methodParams) : base(sourceType, sourceName, methodParams) { }
+    #endregion
+
+    #region repeat components
+    public int MaxTries
+    {
+        get; set;
     }
+    TestCommand ICommandWrapper.Wrap(TestCommand command) => new RetryAttribute.RetryCommand(command, MaxTries);
+    #endregion
 }

--- a/TestsCommon/RunSettings.cs
+++ b/TestsCommon/RunSettings.cs
@@ -5,108 +5,124 @@ using NUnit.Framework;
 using System;
 using System.IO;
 
-namespace TestsCommon
+namespace TestsCommon;
+
+/// <summary>
+/// Converts a runsettings file into an object after validating settings
+/// </summary>
+public record RunSettings
 {
-    /// <summary>
-    /// Converts a runsettings file into an object after validating settings
-    /// </summary>
-    public record RunSettings
+    public Versions Version
     {
-        public Versions Version { get; init; }
-        public string DllPath { get; init; }
-        public TestType TestType { get; init; }
-        public Languages Language { get; init; }
-        public string JavaCoreVersion { get; init; } = "2.0.0";
-        private string _javaLibVersion;
-        public string JavaLibVersion
+        get; init;
+    }
+    public string DllPath
+    {
+        get; init;
+    }
+    public TestType TestType
+    {
+        get; init;
+    }
+    public Languages Language
+    {
+        get; init;
+    }
+    public string JavaCoreVersion { get; init; } = "2.0.0";
+    private string _javaLibVersion;
+    public string JavaLibVersion
+    {
+        get
         {
-            get
+            if (string.IsNullOrEmpty(_javaLibVersion))
             {
-                if (string.IsNullOrEmpty(_javaLibVersion))
-                {
-                    return Version == Versions.V1 ? "3.0.0" : "0.6.0-SNAPSHOT";
-                }
-                else
-                {
-                    return _javaLibVersion;
-                }
-            }
-            set => _javaLibVersion = value;
-        }
-        public string JavaPreviewLibPath { get; init; }
-        private const string DashDash = "---";
-        public RunSettings() { }
-
-        public RunSettings(TestParameters parameters)
-        {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-
-            var versionString = parameters.Get("Version");
-            var dllPath = parameters.Get("DllPath");
-            var testType = parameters.Get("TestType");
-
-            var lng = parameters.Get("Language");
-            if (!string.IsNullOrEmpty(lng) && !lng.Contains(DashDash))
-            {
-                Language = lng.ToUpperInvariant() switch
-                {
-                    "CSHARP" => Languages.CSharp,
-                    "C#" => Languages.CSharp,
-                    "JAVA" => Languages.Java,
-                    "JAVASCRIPT" => Languages.JavaScript,
-                    "JS" => Languages.JavaScript,
-                    "OBJC" => Languages.ObjC,
-                    "OBJECTIVEC" => Languages.ObjC,
-                    "OBJECTIVE-C" => Languages.ObjC,
-                    _ => Languages.CSharp
-                };
-            }
-
-            if (!string.IsNullOrEmpty(dllPath) && !dllPath.Contains(DashDash))
-            {
-                DllPath = dllPath;
-                if (Language == Languages.CSharp && !File.Exists(dllPath))
-                {
-                    throw new ArgumentException("File specified with DllPath in Test.runsettings doesn't exist!");
-                }
-            }
-            if (!string.IsNullOrEmpty(versionString) && !versionString.Contains(DashDash))
-            {
-                Version = VersionString.GetVersion(versionString);
-            }
-
-            if (!string.IsNullOrEmpty(testType))
-            {
-                if (Enum.TryParse(testType, out TestType testTypeEnum))
-                {
-                    TestType = testTypeEnum;
-                }
-                else
-                {
-                    throw new ArgumentException($"Unexpected test type specified: {testType}");
-                }
-            }
-
-            JavaCoreVersion = InitializeParameter(parameters, nameof(JavaCoreVersion)) ?? JavaCoreVersion;
-            JavaLibVersion = InitializeParameter(parameters, nameof(JavaLibVersion)); // we don't have the Graph version information just yet as it could be provided later with parameter initizaliation
-            JavaPreviewLibPath = InitializeParameter(parameters, nameof(JavaPreviewLibPath)) ?? JavaPreviewLibPath;
-        }
-
-        private static string InitializeParameter(TestParameters parameters, string parameterName)
-        {
-            var value = parameters.Get(parameterName);
-
-            if (!string.IsNullOrEmpty(value) && !value.Contains(DashDash))
-            {
-                return value;
+                return Version == Versions.V1 ? "3.0.0" : "0.6.0-SNAPSHOT";
             }
             else
             {
-                return null;
+                return _javaLibVersion;
             }
+        }
+        set => _javaLibVersion = value;
+    }
+    public string JavaPreviewLibPath
+    {
+        get; init;
+    }
+    private const string DashDash = "---";
+    public RunSettings()
+    {
+    }
+
+    public RunSettings(TestParameters parameters)
+    {
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        var versionString = parameters.Get("Version");
+        var dllPath = parameters.Get("DllPath");
+        var testType = parameters.Get("TestType");
+
+        var lng = parameters.Get("Language");
+        if (!string.IsNullOrEmpty(lng) && !lng.Contains(DashDash))
+        {
+            Language = lng.ToUpperInvariant() switch
+            {
+                "CSHARP" => Languages.CSharp,
+                "C#" => Languages.CSharp,
+                "JAVA" => Languages.Java,
+                "JAVASCRIPT" => Languages.JavaScript,
+                "JS" => Languages.JavaScript,
+                "OBJC" => Languages.ObjC,
+                "OBJECTIVEC" => Languages.ObjC,
+                "OBJECTIVE-C" => Languages.ObjC,
+                _ => Languages.CSharp
+            };
+        }
+
+        if (!string.IsNullOrEmpty(dllPath) && !dllPath.Contains(DashDash))
+        {
+            DllPath = dllPath;
+            if (Language == Languages.CSharp && !File.Exists(dllPath))
+            {
+                throw new ArgumentException("File specified with DllPath in Test.runsettings doesn't exist!");
+            }
+        }
+        if (!string.IsNullOrEmpty(versionString) && !versionString.Contains(DashDash))
+        {
+            Version = VersionString.GetVersion(versionString);
+        }
+
+        if (!string.IsNullOrEmpty(testType))
+        {
+            if (Enum.TryParse(testType, out TestType testTypeEnum))
+            {
+                TestType = testTypeEnum;
+            }
+            else
+            {
+                throw new ArgumentException($"Unexpected test type specified: {testType}");
+            }
+        }
+
+        JavaCoreVersion = InitializeParameter(parameters, nameof(JavaCoreVersion)) ?? JavaCoreVersion;
+        JavaLibVersion = InitializeParameter(parameters, nameof(JavaLibVersion)); // we don't have the Graph version information just yet as it could be provided later with parameter initizaliation
+        JavaPreviewLibPath = InitializeParameter(parameters, nameof(JavaPreviewLibPath)) ?? JavaPreviewLibPath;
+    }
+
+    private static string InitializeParameter(TestParameters parameters, string parameterName)
+    {
+        var value = parameters.Get(parameterName);
+
+        if (!string.IsNullOrEmpty(value) && !value.Contains(DashDash))
+        {
+            return value;
+        }
+        else
+        {
+            return null;
         }
     }
 }

--- a/TestsCommon/RunSettings.cs
+++ b/TestsCommon/RunSettings.cs
@@ -1,10 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
-using MsGraphSDKSnippetsCompiler.Models;
-using NUnit.Framework;
-using System;
-using System.IO;
-
 namespace TestsCommon;
 
 /// <summary>

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -1,13 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using MsGraphSDKSnippetsCompiler.Models;
-using NUnit.Framework;
-
 namespace TestsCommon;
 
 // Owner is used to categorize known test failures, so that we can redirect issues faster

--- a/TestsCommon/TestDataGenerator.cs
+++ b/TestsCommon/TestDataGenerator.cs
@@ -8,134 +8,133 @@ using System.Text.RegularExpressions;
 using MsGraphSDKSnippetsCompiler.Models;
 using NUnit.Framework;
 
-namespace TestsCommon
-{
-    // Owner is used to categorize known test failures, so that we can redirect issues faster
-    public record KnownIssue (
-        string Owner,
-        string CustomMessage = null,
-        string GitHubIssue = null,
-        string TestNamePrefix = "known-issue-")
-        {
-            public string Message => string.Join(Environment.NewLine, new[] { CustomMessage, GitHubIssue }.Where(s => !string.IsNullOrEmpty(s)));
-        };
+namespace TestsCommon;
 
+// Owner is used to categorize known test failures, so that we can redirect issues faster
+public record KnownIssue(
+    string Owner,
+    string CustomMessage = null,
+    string GitHubIssue = null,
+    string TestNamePrefix = "known-issue-")
+{
+    public string Message => string.Join(Environment.NewLine, new[] { CustomMessage, GitHubIssue }.Where(s => !string.IsNullOrEmpty(s)));
+};
+
+
+/// <summary>
+/// Generates TestCaseData for NUnit
+/// </summary>
+public static class TestDataGenerator
+{
+    /// <summary>
+    /// Generates a dictionary mapping from snippet file name to documentation page listing the snippet.
+    /// </summary>
+    /// <param name="version">Docs version (e.g. V1, Beta)</param>
+    /// <returns>Dictionary holding the mapping from snippet file name to documentation page listing the snippet.</returns>
+    public static Dictionary<string, string> GetDocumentationLinks(Versions version, Languages language)
+    {
+        var documentationLinks = new Dictionary<string, string>();
+        var documentationDirectory = GraphDocsDirectory.GetDocumentationDirectory(version);
+        var files = Directory.GetFiles(documentationDirectory);
+        var languageName = language.AsString();
+        var SnippetLinkPattern = @$"includes\/snippets\/{languageName}\/(.*)\-{languageName}\-snippets\.md";
+        var SnippetLinkRegex = new Regex(SnippetLinkPattern, RegexOptions.Compiled);
+        foreach (var file in files)
+        {
+            var content = File.ReadAllText(file);
+            var fileName = Path.GetFileNameWithoutExtension(file);
+            var docsLink = $"https://docs.microsoft.com/en-us/graph/api/{fileName}?view=graph-rest-{new VersionString(version).DocsUrlSegment()}&tabs={languageName}";
+
+            var match = SnippetLinkRegex.Match(content);
+            while (match.Success)
+            {
+                documentationLinks[$"{match.Groups[1].Value}-{languageName}-snippets.md"] = docsLink;
+                match = match.NextMatch();
+            }
+        }
+
+        return documentationLinks;
+    }
 
     /// <summary>
-    /// Generates TestCaseData for NUnit
+    /// For each snippet file creates a test case which takes the file name and version as reference
+    /// Test case name is also set to to unique name based on file name
     /// </summary>
-    public static class TestDataGenerator
+    /// <param name="runSettings">Test run settings</param>
+    /// <returns>
+    /// TestCaseData to be consumed by C# compilation tests
+    /// </returns>
+    public static IEnumerable<TestCaseData> GetTestCaseData(RunSettings runSettings)
     {
-        /// <summary>
-        /// Generates a dictionary mapping from snippet file name to documentation page listing the snippet.
-        /// </summary>
-        /// <param name="version">Docs version (e.g. V1, Beta)</param>
-        /// <returns>Dictionary holding the mapping from snippet file name to documentation page listing the snippet.</returns>
-        public static Dictionary<string, string> GetDocumentationLinks(Versions version, Languages language)
+        return from testData in GetLanguageTestData(runSettings)
+               where !(testData.IsCompilationKnownIssue ^ runSettings.TestType == TestType.CompilationKnownIssues) // select known compilation issues iff requested
+               select new TestCaseData(testData).SetName(testData.TestName).SetProperty("Owner", testData.Owner);
+    }
+
+    /// <summary>
+    /// For each snippet file creates a test case which takes the file name and version as reference
+    /// Test case name is also set to to unique name based on file name
+    /// </summary>
+    /// <param name="runSettings">Test run settings</param>
+    /// <returns>
+    /// TestCaseData to be consumed by C# execution tests
+    /// </returns>
+    public static IEnumerable<TestCaseData> GetExecutionTestData(RunSettings runSettings)
+    {
+        return from testData in GetLanguageTestData(runSettings)
+               let executionTestData = testData with
+               {
+                   TestName = testData.TestName.Replace("-compiles", "-executes"),
+               }
+               where !executionTestData.IsCompilationKnownIssue // select compiling tests
+               && !(executionTestData.IsExecutionKnownIssue ^ runSettings.TestType == TestType.ExecutionKnownIssues) // select known execution issues iff requested
+               && executionTestData.FileContent.Contains("GetAsync()") // select only the get tests
+               select new TestCaseData(executionTestData).SetName(executionTestData.KnownIssueTestNamePrefix + executionTestData.TestName).SetProperty("Owner", executionTestData.Owner);
+    }
+
+    private static IEnumerable<LanguageTestData> GetLanguageTestData(RunSettings runSettings)
+    {
+        if (runSettings == null)
         {
-            var documentationLinks = new Dictionary<string, string>();
-            var documentationDirectory = GraphDocsDirectory.GetDocumentationDirectory(version);
-            var files = Directory.GetFiles(documentationDirectory);
-            var languageName = language.AsString();
-            var SnippetLinkPattern = @$"includes\/snippets\/{languageName}\/(.*)\-{languageName}\-snippets\.md";
-            var SnippetLinkRegex = new Regex(SnippetLinkPattern, RegexOptions.Compiled);
-            foreach (var file in files)
-            {
-                var content = File.ReadAllText(file);
-                var fileName = Path.GetFileNameWithoutExtension(file);
-                var docsLink = $"https://docs.microsoft.com/en-us/graph/api/{fileName}?view=graph-rest-{new VersionString(version).DocsUrlSegment()}&tabs={languageName}";
-
-                var match = SnippetLinkRegex.Match(content);
-                while (match.Success)
-                {
-                    documentationLinks[$"{match.Groups[1].Value}-{languageName}-snippets.md"] = docsLink;
-                    match = match.NextMatch();
-                }
-            }
-
-            return documentationLinks;
+            throw new ArgumentNullException(nameof(runSettings));
         }
 
-        /// <summary>
-        /// For each snippet file creates a test case which takes the file name and version as reference
-        /// Test case name is also set to to unique name based on file name
-        /// </summary>
-        /// <param name="runSettings">Test run settings</param>
-        /// <returns>
-        /// TestCaseData to be consumed by C# compilation tests
-        /// </returns>
-        public static IEnumerable<TestCaseData> GetTestCaseData(RunSettings runSettings)
-        {
-            return from testData in GetLanguageTestData(runSettings)
-                   where !(testData.IsCompilationKnownIssue ^ runSettings.TestType == TestType.CompilationKnownIssues) // select known compilation issues iff requested
-                   select new TestCaseData(testData).SetName(testData.TestName).SetProperty("Owner", testData.Owner);
-        }
-
-        /// <summary>
-        /// For each snippet file creates a test case which takes the file name and version as reference
-        /// Test case name is also set to to unique name based on file name
-        /// </summary>
-        /// <param name="runSettings">Test run settings</param>
-        /// <returns>
-        /// TestCaseData to be consumed by C# execution tests
-        /// </returns>
-        public static IEnumerable<TestCaseData> GetExecutionTestData(RunSettings runSettings)
-        {
-            return from testData in GetLanguageTestData(runSettings)
-                   let executionTestData = testData with
-                   {
-                       TestName = testData.TestName.Replace("-compiles", "-executes"),
-                   }
-                   where !executionTestData.IsCompilationKnownIssue // select compiling tests
-                   && !(executionTestData.IsExecutionKnownIssue ^ runSettings.TestType == TestType.ExecutionKnownIssues) // select known execution issues iff requested
-                   && executionTestData.FileContent.Contains("GetAsync()") // select only the get tests
-                   select new TestCaseData(executionTestData).SetName(executionTestData.KnownIssueTestNamePrefix + executionTestData.TestName).SetProperty("Owner", executionTestData.Owner);
-        }
-
-        private static IEnumerable<LanguageTestData> GetLanguageTestData(RunSettings runSettings)
-        {
-            if (runSettings == null)
-            {
-                throw new ArgumentNullException(nameof(runSettings));
-            }
-
-            var language = runSettings.Language;
-            var version = runSettings.Version;
-            var documentationLinks = GetDocumentationLinks(version, language);
-            var compilationKnownIssues = KnownIssues.GetCompilationKnownIssues(language, version);
-            var executionKnownIssues = KnownIssues.GetExecutionKnownIssues(language, version);
-            var snippetFileNames = documentationLinks.Keys.ToList();
-            return from fileName in snippetFileNames                                            // e.g. application-addpassword-csharp-snippets.md
-                   let arbitraryDllPostfix = runSettings.DllPath == null || runSettings.Language != Languages.CSharp ? string.Empty : "arbitraryDll-"
-                   let testNamePostfix = arbitraryDllPostfix + version.ToString() + "-compiles" // e.g. Beta-compiles or arbitraryDll-Beta-compiles
-                   let testName = fileName.Replace("snippets.md", testNamePostfix)              // e.g. application-addpassword-csharp-Beta-compiles
-                   let docsLink = documentationLinks[fileName]
-                   let knownIssueLookupKey = testName.Replace("arbitraryDll-", string.Empty)
-                   let executionIssueLookupKey = testName.Replace("-compiles", "-executes")
-                   let isCompilationKnownIssue = compilationKnownIssues.ContainsKey(knownIssueLookupKey)
-                   let compilationKnownIssue = isCompilationKnownIssue ? compilationKnownIssues[knownIssueLookupKey] : null
-                   let isExecutionKnownIssue = executionKnownIssues.ContainsKey(executionIssueLookupKey)
-                   let executionKnownIssue = isExecutionKnownIssue ? executionKnownIssues[executionIssueLookupKey] : null
-                   let knownIssueMessage = compilationKnownIssue?.Message ?? executionKnownIssue?.Message ?? string.Empty
-                   let knownIssueTestNamePrefix = compilationKnownIssue?.TestNamePrefix ?? executionKnownIssue?.TestNamePrefix ?? string.Empty
-                   let owner = compilationKnownIssue?.Owner ?? executionKnownIssue?.Owner ?? string.Empty
-                   let fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(version, runSettings.Language), fileName)
-                   let fileContent = File.ReadAllText(fullPath)
-                   select new LanguageTestData(
-                           version,
-                           isCompilationKnownIssue,
-                           isExecutionKnownIssue,
-                           knownIssueMessage,
-                           knownIssueTestNamePrefix,
-                           docsLink,
-                           fileName,
-                           runSettings.DllPath,
-                           runSettings.JavaCoreVersion,
-                           runSettings.JavaLibVersion,
-                           runSettings.JavaPreviewLibPath,
-                           testName,
-                           owner,
-                           fileContent);
-        }
+        var language = runSettings.Language;
+        var version = runSettings.Version;
+        var documentationLinks = GetDocumentationLinks(version, language);
+        var compilationKnownIssues = KnownIssues.GetCompilationKnownIssues(language, version);
+        var executionKnownIssues = KnownIssues.GetExecutionKnownIssues(language, version);
+        var snippetFileNames = documentationLinks.Keys.ToList();
+        return from fileName in snippetFileNames                                            // e.g. application-addpassword-csharp-snippets.md
+               let arbitraryDllPostfix = runSettings.DllPath == null || runSettings.Language != Languages.CSharp ? string.Empty : "arbitraryDll-"
+               let testNamePostfix = arbitraryDllPostfix + version.ToString() + "-compiles" // e.g. Beta-compiles or arbitraryDll-Beta-compiles
+               let testName = fileName.Replace("snippets.md", testNamePostfix)              // e.g. application-addpassword-csharp-Beta-compiles
+               let docsLink = documentationLinks[fileName]
+               let knownIssueLookupKey = testName.Replace("arbitraryDll-", string.Empty)
+               let executionIssueLookupKey = testName.Replace("-compiles", "-executes")
+               let isCompilationKnownIssue = compilationKnownIssues.ContainsKey(knownIssueLookupKey)
+               let compilationKnownIssue = isCompilationKnownIssue ? compilationKnownIssues[knownIssueLookupKey] : null
+               let isExecutionKnownIssue = executionKnownIssues.ContainsKey(executionIssueLookupKey)
+               let executionKnownIssue = isExecutionKnownIssue ? executionKnownIssues[executionIssueLookupKey] : null
+               let knownIssueMessage = compilationKnownIssue?.Message ?? executionKnownIssue?.Message ?? string.Empty
+               let knownIssueTestNamePrefix = compilationKnownIssue?.TestNamePrefix ?? executionKnownIssue?.TestNamePrefix ?? string.Empty
+               let owner = compilationKnownIssue?.Owner ?? executionKnownIssue?.Owner ?? string.Empty
+               let fullPath = Path.Join(GraphDocsDirectory.GetSnippetsDirectory(version, runSettings.Language), fileName)
+               let fileContent = File.ReadAllText(fullPath)
+               select new LanguageTestData(
+                       version,
+                       isCompilationKnownIssue,
+                       isExecutionKnownIssue,
+                       knownIssueMessage,
+                       knownIssueTestNamePrefix,
+                       docsLink,
+                       fileName,
+                       runSettings.DllPath,
+                       runSettings.JavaCoreVersion,
+                       runSettings.JavaLibVersion,
+                       runSettings.JavaPreviewLibPath,
+                       testName,
+                       owner,
+                       fileContent);
     }
 }

--- a/TestsCommon/TestType.cs
+++ b/TestsCommon/TestType.cs
@@ -1,10 +1,9 @@
-﻿namespace TestsCommon
+﻿namespace TestsCommon;
+
+public enum TestType
 {
-    public enum TestType
-    {
-        CompilationStable,
-        CompilationKnownIssues,
-        ExecutionStable,
-        ExecutionKnownIssues
-    }
+    CompilationStable,
+    CompilationKnownIssues,
+    ExecutionStable,
+    ExecutionKnownIssues
 }

--- a/UnitTests/AppSettingsTests.cs
+++ b/UnitTests/AppSettingsTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Configuration;
-using MsGraphSDKSnippetsCompiler;
-using NUnit.Framework;
-
-namespace UnitTests;
+﻿namespace UnitTests;
 
 static class AppSettingsTests
 {

--- a/UnitTests/AppSettingsTests.cs
+++ b/UnitTests/AppSettingsTests.cs
@@ -4,53 +4,52 @@ using Microsoft.Extensions.Configuration;
 using MsGraphSDKSnippetsCompiler;
 using NUnit.Framework;
 
-namespace UnitTests
+namespace UnitTests;
+
+static class AppSettingsTests
 {
-    static class AppSettingsTests
-    {
-        private const string CustomLabel = "Development.Codespaces";
-        private const string RaptorConfigLabel = "RAPTOR_CONFIGLABEL";
+    private const string CustomLabel = "Development.Codespaces";
+    private const string RaptorConfigLabel = "RAPTOR_CONFIGLABEL";
 
-        public static IConfigurationRoot EmptyConfig => new ConfigurationBuilder().Build();
+    public static IConfigurationRoot EmptyConfig => new ConfigurationBuilder().Build();
 
-        public static IConfigurationRoot ConfigWithCustomLabel => new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>()
-                {
+    public static IConfigurationRoot ConfigWithCustomLabel => new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>()
+            {
                     { RaptorConfigLabel, CustomLabel }
-                }).Build();
+            }).Build();
 
-        [Test]
-        public static void CustomLabelExistsInLocalRun()
-        {
-            var label = AppSettings.GetAppConfigLabel(ConfigWithCustomLabel, isLocalRun: true);
-            Assert.AreEqual(CustomLabel, label);
-        }
+    [Test]
+    public static void CustomLabelExistsInLocalRun()
+    {
+        var label = AppSettings.GetAppConfigLabel(ConfigWithCustomLabel, isLocalRun: true);
+        Assert.AreEqual(CustomLabel, label);
+    }
 
-        [Test]
-        public static void CustomLabelExistsInCI()
-        {
-            var label = AppSettings.GetAppConfigLabel(ConfigWithCustomLabel, isLocalRun: false);
-            Assert.AreEqual(CustomLabel, label);
-        }
+    [Test]
+    public static void CustomLabelExistsInCI()
+    {
+        var label = AppSettings.GetAppConfigLabel(ConfigWithCustomLabel, isLocalRun: false);
+        Assert.AreEqual(CustomLabel, label);
+    }
 
-        [Test]
-        public static void CustomLabelDoesNotExistInLocalRun()
-        {
-            var label = AppSettings.GetAppConfigLabel(EmptyConfig, isLocalRun: true);
-            Assert.AreEqual("Development", label);
-        }
+    [Test]
+    public static void CustomLabelDoesNotExistInLocalRun()
+    {
+        var label = AppSettings.GetAppConfigLabel(EmptyConfig, isLocalRun: true);
+        Assert.AreEqual("Development", label);
+    }
 
-        [Test]
-        public static void CustomLabelDoesNotExistInCI()
-        {
-            var label = AppSettings.GetAppConfigLabel(EmptyConfig, isLocalRun: false);
-            Assert.AreEqual("CI", label);
-        }
+    [Test]
+    public static void CustomLabelDoesNotExistInCI()
+    {
+        var label = AppSettings.GetAppConfigLabel(EmptyConfig, isLocalRun: false);
+        Assert.AreEqual("CI", label);
+    }
 
-        [Test]
-        public static void ExpectExceptionIfConfigIsNull()
-        {
-            Assert.Throws<ArgumentNullException>(() => AppSettings.GetAppConfigLabel(null, false));
-        }
+    [Test]
+    public static void ExpectExceptionIfConfigIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => AppSettings.GetAppConfigLabel(null, false));
     }
 }

--- a/UnitTests/AssemblyInfo.cs
+++ b/UnitTests/AssemblyInfo.cs
@@ -1,2 +1,1 @@
-﻿using System;
-[assembly: CLSCompliant(false)]
+﻿[assembly: CLSCompliant(false)]

--- a/UnitTests/CSharpTestRunnerTests.cs
+++ b/UnitTests/CSharpTestRunnerTests.cs
@@ -1,8 +1,4 @@
-﻿using NUnit.Framework;
-
-using TestsCommon;
-
-namespace UnitTests;
+﻿namespace UnitTests;
 
 /// <summary>
 ///     Checks that the CSharpTestRunner Regex is able to

--- a/UnitTests/CSharpTestRunnerTests.cs
+++ b/UnitTests/CSharpTestRunnerTests.cs
@@ -2,44 +2,44 @@
 
 using TestsCommon;
 
-namespace UnitTests
+namespace UnitTests;
+
+/// <summary>
+///     Checks that the CSharpTestRunner Regex is able to
+///     get identifiers for all identifiers as would be valid C#
+///     https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names
+/// </summary>
+public class CSharpTestRunnerTests
 {
     /// <summary>
-    ///     Checks that the CSharpTestRunner Regex is able to
-    ///     get identifiers for all identifiers as would be valid C#
-    ///     https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names
+    ///     Verbatim Identifier such as @event
+    ///     https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim
     /// </summary>
-    public class CSharpTestRunnerTests
-    {
-        /// <summary>
-        ///     Verbatim Identifier such as @event
-        ///     https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim
-        /// </summary>
-        private const string VerbatimIdentifer = @"
+    private const string VerbatimIdentifer = @"
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 var @event = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
                                 .Events[\""<group_event>\""]
                                 .Request()
                                 .GetAsync();
 ";
-        private const string UnderScoreIdentifier = @"
+    private const string UnderScoreIdentifier = @"
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 var _event = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
                                 .Events[\""<group_event>\""]
                                 .Request()
                                 .GetAsync();
 ";
-        /// <summary>
-        ///     @_event is an allowed identifier
-        /// </summary>
-        private const string VerbatimIdentifierWithUnderScore = @"
+    /// <summary>
+    ///     @_event is an allowed identifier
+    /// </summary>
+    private const string VerbatimIdentifierWithUnderScore = @"
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 var @_event = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
                                 .Events[\""<group_event>\""]
                                 .Request()
                                 .GetAsync();
 ";
-        private const string IncorrectVerbatimIdentifier = @"
+    private const string IncorrectVerbatimIdentifier = @"
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 var ev@ent = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""]
                                 .Events[\""<group_event>\""]
@@ -47,29 +47,28 @@ var ev@ent = await graphClient.Groups[\""8730b5a6-eca3-400d-9011-1f4202418218\""
                                 .GetAsync();
 ";
 
-        [TestCase("@event", VerbatimIdentifer, TestName = "@event")]
-        [TestCase("@_event", VerbatimIdentifierWithUnderScore, TestName = "@_event")]
-        [TestCase("_event", UnderScoreIdentifier, TestName = "_event")]
-        public void ShouldHandleVerbatimVariableIdentifier(string variableName, string testSnippet)
-        {
-            var match = CSharpTestRunner.ResultVariableRegex.Match(testSnippet);
-            Assert.True(match.Success);
-            Assert.AreEqual(match.Groups.Count, 2);
-            Assert.AreEqual(match.Groups[1].Value, variableName);
-        }
+    [TestCase("@event", VerbatimIdentifer, TestName = "@event")]
+    [TestCase("@_event", VerbatimIdentifierWithUnderScore, TestName = "@_event")]
+    [TestCase("_event", UnderScoreIdentifier, TestName = "_event")]
+    public void ShouldHandleVerbatimVariableIdentifier(string variableName, string testSnippet)
+    {
+        var match = CSharpTestRunner.ResultVariableRegex.Match(testSnippet);
+        Assert.True(match.Success);
+        Assert.AreEqual(match.Groups.Count, 2);
+        Assert.AreEqual(match.Groups[1].Value, variableName);
+    }
 
-        [TestCase(VerbatimIdentifer, TestName = "@event")]
-        [TestCase(VerbatimIdentifierWithUnderScore, TestName = "@_event")]
-        [TestCase(UnderScoreIdentifier, TestName = "_event")]
-        public void ShouldReturnHttpRequestMessage(string testSnippet)
-        {
-            Assert.DoesNotThrow(() => CSharpTestRunner.ReturnHttpRequestMessage(testSnippet));
-        }
+    [TestCase(VerbatimIdentifer, TestName = "@event")]
+    [TestCase(VerbatimIdentifierWithUnderScore, TestName = "@_event")]
+    [TestCase(UnderScoreIdentifier, TestName = "_event")]
+    public void ShouldReturnHttpRequestMessage(string testSnippet)
+    {
+        Assert.DoesNotThrow(() => CSharpTestRunner.ReturnHttpRequestMessage(testSnippet));
+    }
 
-        [TestCase(IncorrectVerbatimIdentifier, TestName = "ev@ent", Description = "Incorrect Verbatim Identifier")]
-        public void ShouldFailWhenReturningHttpRequestMessageWithIncorrectSnippet(string testSnippet)
-        {
-            Assert.Throws<AssertionException>(() => CSharpTestRunner.ReturnHttpRequestMessage(testSnippet));
-        }
+    [TestCase(IncorrectVerbatimIdentifier, TestName = "ev@ent", Description = "Incorrect Verbatim Identifier")]
+    public void ShouldFailWhenReturningHttpRequestMessageWithIncorrectSnippet(string testSnippet)
+    {
+        Assert.Throws<AssertionException>(() => CSharpTestRunner.ReturnHttpRequestMessage(testSnippet));
     }
 }

--- a/UnitTests/GlobalUsings.cs
+++ b/UnitTests/GlobalUsings.cs
@@ -1,0 +1,9 @@
+﻿global using System;
+global using System.Collections.Generic;
+global using MsGraphSDKSnippetsCompiler;
+global using MsGraphSDKSnippetsCompiler.Models;
+global using NUnit.Framework;
+global using Microsoft.Extensions.Configuration;
+global using System.Text.Json;
+global using System.Text.RegularExpressions;
+global using TestsCommon;

--- a/UnitTests/IDTreeTests.cs
+++ b/UnitTests/IDTreeTests.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text.Json;
-using System.Text.RegularExpressions;
-using NUnit.Framework;
-using MsGraphSDKSnippetsCompiler.Models;
-
-namespace UnitTests;
+﻿namespace UnitTests;
 
 public class IDTreeTests
 {

--- a/UnitTests/IDTreeTests.cs
+++ b/UnitTests/IDTreeTests.cs
@@ -4,117 +4,117 @@ using System.Text.RegularExpressions;
 using NUnit.Framework;
 using MsGraphSDKSnippetsCompiler.Models;
 
-namespace UnitTests
+namespace UnitTests;
+
+public class IDTreeTests
 {
-    public class IDTreeTests
-    {
-        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.EqualTestCases))]
+    [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.EqualTestCases))]
 #pragma warning disable CA1062 // Validate arguments of public methods
-        public void Equal(IDTree a, IDTree b) => Assert.IsTrue(a.Equals(b));
+    public void Equal(IDTree a, IDTree b) => Assert.IsTrue(a.Equals(b));
 
-        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.NotEqualTestCases))]
-        public void NotEqual(IDTree a, IDTree b) => Assert.IsFalse(a.Equals(b));
+    [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.NotEqualTestCases))]
+    public void NotEqual(IDTree a, IDTree b) => Assert.IsFalse(a.Equals(b));
 
-        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.LosslessSerializationTestCases))]
-        public void LosslessSerialization(IDTree a)
-        {
-            a.Equals(JsonSerializer.Deserialize<IDTree>(JsonSerializer.Serialize(a)));
-        }
+    [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.LosslessSerializationTestCases))]
+    public void LosslessSerialization(IDTree a)
+    {
+        a.Equals(JsonSerializer.Deserialize<IDTree>(JsonSerializer.Serialize(a)));
+    }
 #pragma warning restore CA1062 // Validate arguments of public methods
-        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.SerializationTestCases))]
-        public void Serialization(IDTree a, string json)
-        {
-            var actual = JsonSerializer.Serialize(a);
-            actual = Regex.Replace(actual, @"\s", string.Empty);
+    [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.SerializationTestCases))]
+    public void Serialization(IDTree a, string json)
+    {
+        var actual = JsonSerializer.Serialize(a);
+        actual = Regex.Replace(actual, @"\s", string.Empty);
 
-            var expected = Regex.Replace(json, @"\s", string.Empty);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.TreeWithNonStringValues))]
-        public void HandleNonStringValues(string jsonTree)
-        {
-            Assert.DoesNotThrow(() =>
-            {
-                JsonSerializer.Deserialize<IDTree>(jsonTree);
-            });
-        }
+        var expected = Regex.Replace(json, @"\s", string.Empty);
+        Assert.AreEqual(expected, actual);
     }
 
-    public static class IDTreeTestCases
+    [TestCaseSource(typeof(IDTreeTestCases), nameof(IDTreeTestCases.TreeWithNonStringValues))]
+    public void HandleNonStringValues(string jsonTree)
     {
-        private static readonly IDTree EmptyTree = new IDTree();
-        private static readonly IDTree EmptyTree2 = new IDTree();
-
-        private static readonly IDTree OneItemTree = new IDTree()
+        Assert.DoesNotThrow(() =>
         {
-            ["application"] = new IDTree("(application)")
-        };
+            JsonSerializer.Deserialize<IDTree>(jsonTree);
+        });
+    }
+}
 
-        private static readonly IDTree OneItemTree2 = new IDTree()
-        {
-            ["application"] = new IDTree("(application)")
-        };
+public static class IDTreeTestCases
+{
+    private static readonly IDTree EmptyTree = new IDTree();
+    private static readonly IDTree EmptyTree2 = new IDTree();
 
-        private static readonly IDTree TwoItemTree = new IDTree()
-        {
-            ["application"] = new IDTree("(application)"),
-            ["team"] = new IDTree("(team)")
-        };
+    private static readonly IDTree OneItemTree = new IDTree()
+    {
+        ["application"] = new IDTree("(application)")
+    };
 
-        private static readonly IDTree DepthTwoTree = new IDTree()
+    private static readonly IDTree OneItemTree2 = new IDTree()
+    {
+        ["application"] = new IDTree("(application)")
+    };
+
+    private static readonly IDTree TwoItemTree = new IDTree()
+    {
+        ["application"] = new IDTree("(application)"),
+        ["team"] = new IDTree("(team)")
+    };
+
+    private static readonly IDTree DepthTwoTree = new IDTree()
+    {
+        ["application"] = new IDTree("(application)")
         {
-            ["application"] = new IDTree("(application)")
+            ["child"] = new IDTree("(application_child)")
+        }
+    };
+
+    private static readonly IDTree DepthTwoTree2 = new IDTree()
+    {
+        ["application"] = new IDTree("(application)")
+        {
+            ["child"] = new IDTree("(application_child)")
+        }
+    };
+
+    private static readonly IDTree DepthTwoWithNullChild = new IDTree()
+    {
+        ["application"] = new IDTree("(application)")
+        {
+            ["child"] = null
+        }
+    };
+
+    private static readonly IDTree OneItemTreeValueDifferent = new IDTree()
+    {
+        ["application"] = new IDTree("(application2)")
+    };
+
+    private static readonly IDTree OneItemTreeKeyDifferent = new IDTree()
+    {
+        ["application2"] = new IDTree("(application)")
+    };
+
+    private static readonly IDTree ComplexTree = new IDTree()
+    {
+        ["application"] = new IDTree("(application)"),
+        ["team"] = new IDTree("(team)")
+        {
+            ["channel"] = new IDTree("(team_channel)")
             {
-                ["child"] = new IDTree("(application_child)")
-            }
-        };
-
-        private static readonly IDTree DepthTwoTree2 = new IDTree()
-        {
-            ["application"] = new IDTree("(application)")
-            {
-                ["child"] = new IDTree("(application_child)")
-            }
-        };
-
-        private static readonly IDTree DepthTwoWithNullChild = new IDTree()
-        {
-            ["application"] = new IDTree("(application)")
-            {
-                ["child"] = null
-            }
-        };
-
-        private static readonly IDTree OneItemTreeValueDifferent = new IDTree()
-        {
-            ["application"] = new IDTree("(application2)")
-        };
-
-        private static readonly IDTree OneItemTreeKeyDifferent = new IDTree()
-        {
-            ["application2"] = new IDTree("(application)")
-        };
-
-        private static readonly IDTree ComplexTree = new IDTree()
-        {
-            ["application"] = new IDTree("(application)"),
-            ["team"] = new IDTree("(team)")
-            {
-                ["channel"] = new IDTree("(team_channel)")
-                {
-                    ["conversationMember"] = new IDTree("(team_channel_conversationMember)")
-                },
-                ["conversationMember"] = new IDTree("(team_conversationMember)")
+                ["conversationMember"] = new IDTree("(team_channel_conversationMember)")
             },
-            ["chat"] = new IDTree("(chat)")
-            {
-                ["conversationMember"] = new IDTree("(chat_conversationMember)")
-            },
-            ["callRecords.callRecord"] = new IDTree("(callRecords.callRecord)")
-        };
+            ["conversationMember"] = new IDTree("(team_conversationMember)")
+        },
+        ["chat"] = new IDTree("(chat)")
+        {
+            ["conversationMember"] = new IDTree("(chat_conversationMember)")
+        },
+        ["callRecords.callRecord"] = new IDTree("(callRecords.callRecord)")
+    };
 
-        private const string SerializedComplexTree = @"{
+    private const string SerializedComplexTree = @"{
     ""application"": {
     ""_value"": ""(application)""
     },
@@ -141,7 +141,7 @@ namespace UnitTests
     }
 }";
 
-        private const string TreeWithNumberValue = @"{
+    private const string TreeWithNumberValue = @"{
         ""workbookTable"": {
             ""_value"": ""{somevalue}"",
         ""workbookTableColumn"": {
@@ -153,7 +153,7 @@ namespace UnitTests
     }
 }";
 
-        private const string TreeWithNullValue = @"{
+    private const string TreeWithNullValue = @"{
         ""workbookTable"": {
             ""_value"": ""{somevalue}"",
         ""workbookTableColumn"": {
@@ -165,58 +165,57 @@ namespace UnitTests
     }
 }";
 
-        public static IEnumerable<TestCaseData> EqualTestCases()
-        {
-            yield return new TestCaseData(EmptyTree, EmptyTree2);
+    public static IEnumerable<TestCaseData> EqualTestCases()
+    {
+        yield return new TestCaseData(EmptyTree, EmptyTree2);
 
-            yield return new TestCaseData(OneItemTree, OneItemTree2);
-            yield return new TestCaseData(OneItemTree2, OneItemTree);
+        yield return new TestCaseData(OneItemTree, OneItemTree2);
+        yield return new TestCaseData(OneItemTree2, OneItemTree);
 
-            yield return new TestCaseData(DepthTwoTree, DepthTwoTree2);
-            yield return new TestCaseData(DepthTwoTree2, DepthTwoTree);
-        }
+        yield return new TestCaseData(DepthTwoTree, DepthTwoTree2);
+        yield return new TestCaseData(DepthTwoTree2, DepthTwoTree);
+    }
 
-        public static IEnumerable<TestCaseData> NotEqualTestCases()
-        {
-            yield return new TestCaseData(EmptyTree, null);
-            yield return new TestCaseData(OneItemTree, null);
+    public static IEnumerable<TestCaseData> NotEqualTestCases()
+    {
+        yield return new TestCaseData(EmptyTree, null);
+        yield return new TestCaseData(OneItemTree, null);
 
-            // check for same-value false equivelance
-            yield return new TestCaseData(OneItemTree, OneItemTreeKeyDifferent);
-            yield return new TestCaseData(OneItemTreeKeyDifferent, OneItemTree);
+        // check for same-value false equivelance
+        yield return new TestCaseData(OneItemTree, OneItemTreeKeyDifferent);
+        yield return new TestCaseData(OneItemTreeKeyDifferent, OneItemTree);
 
-            // check for same-key false equivelance
-            yield return new TestCaseData(OneItemTree, OneItemTreeValueDifferent);
-            yield return new TestCaseData(OneItemTreeValueDifferent, OneItemTree);
+        // check for same-key false equivelance
+        yield return new TestCaseData(OneItemTree, OneItemTreeValueDifferent);
+        yield return new TestCaseData(OneItemTreeValueDifferent, OneItemTree);
 
-            // check for subset or superset false equivelance with breadth
-            yield return new TestCaseData(OneItemTree, TwoItemTree);
-            yield return new TestCaseData(TwoItemTree, OneItemTree);
+        // check for subset or superset false equivelance with breadth
+        yield return new TestCaseData(OneItemTree, TwoItemTree);
+        yield return new TestCaseData(TwoItemTree, OneItemTree);
 
-            // check for subset or superset false equivelance with depth
-            yield return new TestCaseData(OneItemTree, DepthTwoTree);
-            yield return new TestCaseData(DepthTwoTree, OneItemTree);
+        // check for subset or superset false equivelance with depth
+        yield return new TestCaseData(OneItemTree, DepthTwoTree);
+        yield return new TestCaseData(DepthTwoTree, OneItemTree);
 
-            yield return new TestCaseData(DepthTwoWithNullChild, DepthTwoTree);
-        }
+        yield return new TestCaseData(DepthTwoWithNullChild, DepthTwoTree);
+    }
 
-        public static IEnumerable<TestCaseData> LosslessSerializationTestCases()
-        {
-            yield return new TestCaseData(EmptyTree);
-            yield return new TestCaseData(OneItemTree);
-            yield return new TestCaseData(TwoItemTree);
-            yield return new TestCaseData(DepthTwoTree);
-            yield return new TestCaseData(ComplexTree);
-        }
+    public static IEnumerable<TestCaseData> LosslessSerializationTestCases()
+    {
+        yield return new TestCaseData(EmptyTree);
+        yield return new TestCaseData(OneItemTree);
+        yield return new TestCaseData(TwoItemTree);
+        yield return new TestCaseData(DepthTwoTree);
+        yield return new TestCaseData(ComplexTree);
+    }
 
-        public static IEnumerable<TestCaseData> TreeWithNonStringValues()
-        {
-            yield return new TestCaseData(TreeWithNumberValue);
-            yield return new TestCaseData(TreeWithNullValue);
-        }
-        public static IEnumerable<TestCaseData> SerializationTestCases()
-        {
-            yield return new TestCaseData(ComplexTree, SerializedComplexTree);
-        }
+    public static IEnumerable<TestCaseData> TreeWithNonStringValues()
+    {
+        yield return new TestCaseData(TreeWithNumberValue);
+        yield return new TestCaseData(TreeWithNullValue);
+    }
+    public static IEnumerable<TestCaseData> SerializationTestCases()
+    {
+        yield return new TestCaseData(ComplexTree, SerializedComplexTree);
     }
 }

--- a/UnitTests/IdentiferReplacerTests.cs
+++ b/UnitTests/IdentiferReplacerTests.cs
@@ -1,7 +1,4 @@
-﻿using NUnit.Framework;
-using MsGraphSDKSnippetsCompiler.Models;
-
-namespace UnitTests;
+﻿namespace UnitTests;
 
 public class Tests
 {

--- a/UnitTests/IdentiferReplacerTests.cs
+++ b/UnitTests/IdentiferReplacerTests.cs
@@ -1,41 +1,40 @@
 ﻿using NUnit.Framework;
 using MsGraphSDKSnippetsCompiler.Models;
 
-namespace UnitTests
+namespace UnitTests;
+
+public class Tests
 {
-    public class Tests
+    private IdentifierReplacer idReplacer;
+
+    [SetUp]
+    public void Setup()
     {
-        private IdentifierReplacer idReplacer;
+        // identifiers.json holds sample tree constructed from V1 urls
+        var identifiersJson = System.IO.File.ReadAllText("identifiers.json");
+        var tree = System.Text.Json.JsonSerializer.Deserialize<IDTree>(identifiersJson);
 
-        [SetUp]
-        public void Setup()
-        {
-            // identifiers.json holds sample tree constructed from V1 urls
-            var identifiersJson = System.IO.File.ReadAllText("identifiers.json");
-            var tree = System.Text.Json.JsonSerializer.Deserialize<IDTree>(identifiersJson);
-
-            idReplacer = new IdentifierReplacer(tree);
-        }
-
-        [TestCase("https://graph.microsoft.com/v1.0/applications/{application-id}/owners",
-                  "https://graph.microsoft.com/v1.0/applications/application/owners")]
-        [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}",
-                  "https://graph.microsoft.com/v1.0/teams/team/channels/team_channel/members/team_channel_conversationMember")]
-        [TestCase("https://graph.microsoft.com/v1.0/communications/callRecords/{callRecords.callRecord-id}?$expand=sessions($expand=segments)",
-                  "https://graph.microsoft.com/v1.0/communications/callRecords/callRecords.callRecord?$expand=sessions($expand=segments)")]
-        [TestCase("https://graph.microsoft.com/v1.0/chats/{chat-id}/members/{conversationMember-id}",
-                  "https://graph.microsoft.com/v1.0/chats/chat/members/chat_conversationMember")]
-        [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/members/{conversationMember-id}",
-                  "https://graph.microsoft.com/v1.0/teams/team/members/team_conversationMember")]
-        [TestCase("https://graph.microsoft.com/v1.0/education/schools/{educationSchool-id}/users",
-                  "https://graph.microsoft.com/v1.0/education/schools/educationSchool/users")]
-#pragma warning disable CA1054 // URI-like parameters should not be strings
-        public void TestIds(string snippetUrl, string expectedUrl)
-#pragma warning restore CA1054 // URI-like parameters should not be strings
-        {
-            var newUrl = idReplacer.ReplaceIds(snippetUrl);
-            Assert.AreEqual(expectedUrl, newUrl);
-        }
-
+        idReplacer = new IdentifierReplacer(tree);
     }
+
+    [TestCase("https://graph.microsoft.com/v1.0/applications/{application-id}/owners",
+              "https://graph.microsoft.com/v1.0/applications/application/owners")]
+    [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}",
+              "https://graph.microsoft.com/v1.0/teams/team/channels/team_channel/members/team_channel_conversationMember")]
+    [TestCase("https://graph.microsoft.com/v1.0/communications/callRecords/{callRecords.callRecord-id}?$expand=sessions($expand=segments)",
+              "https://graph.microsoft.com/v1.0/communications/callRecords/callRecords.callRecord?$expand=sessions($expand=segments)")]
+    [TestCase("https://graph.microsoft.com/v1.0/chats/{chat-id}/members/{conversationMember-id}",
+              "https://graph.microsoft.com/v1.0/chats/chat/members/chat_conversationMember")]
+    [TestCase("https://graph.microsoft.com/v1.0/teams/{team-id}/members/{conversationMember-id}",
+              "https://graph.microsoft.com/v1.0/teams/team/members/team_conversationMember")]
+    [TestCase("https://graph.microsoft.com/v1.0/education/schools/{educationSchool-id}/users",
+              "https://graph.microsoft.com/v1.0/education/schools/educationSchool/users")]
+#pragma warning disable CA1054 // URI-like parameters should not be strings
+    public void TestIds(string snippetUrl, string expectedUrl)
+#pragma warning restore CA1054 // URI-like parameters should not be strings
+    {
+        var newUrl = idReplacer.ReplaceIds(snippetUrl);
+        Assert.AreEqual(expectedUrl, newUrl);
+    }
+
 }

--- a/msgraph-sdk-raptor-compiler-lib/AppSettings.cs
+++ b/msgraph-sdk-raptor-compiler-lib/AppSettings.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Azure.Identity;
-
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.AzureAppConfiguration;
-
-using NUnit.Framework;
+﻿using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 
 namespace MsGraphSDKSnippetsCompiler;
 

--- a/msgraph-sdk-raptor-compiler-lib/AppSettings.cs
+++ b/msgraph-sdk-raptor-compiler-lib/AppSettings.cs
@@ -8,118 +8,117 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 
 using NUnit.Framework;
 
-namespace MsGraphSDKSnippetsCompiler
+namespace MsGraphSDKSnippetsCompiler;
+
+public static class AppSettings
 {
-    public static class AppSettings
+    public static IConfigurationRoot Config()
     {
-        public static IConfigurationRoot Config()
-        {
-            const string RaptorConnectionString = "RAPTOR_CONFIGCONNECTIONSTRING";
-            const string RaptorConfigEndpoint = "RAPTOR_CONFIGENDPOINT";
+        const string RaptorConnectionString = "RAPTOR_CONFIGCONNECTIONSTRING";
+        const string RaptorConfigEndpoint = "RAPTOR_CONFIGENDPOINT";
 
-            // environment variables expected to be set only in Azure DevOps runs.
-            const string BuildReason = "BUILD_REASON";
-            const string BuildBuildId = "BUILD_BUILDID";
+        // environment variables expected to be set only in Azure DevOps runs.
+        const string BuildReason = "BUILD_REASON";
+        const string BuildBuildId = "BUILD_BUILDID";
 
-            var configBuilder = new ConfigurationBuilder()
-                .SetBasePath(System.IO.Directory.GetCurrentDirectory())
-                .AddEnvironmentVariables();
+        var configBuilder = new ConfigurationBuilder()
+            .SetBasePath(System.IO.Directory.GetCurrentDirectory())
+            .AddEnvironmentVariables();
 
-            var config = configBuilder.Build();
+        var config = configBuilder.Build();
 
-            var isAzureDevOpsEnvironment = !string.IsNullOrEmpty(config[BuildReason]) && !string.IsNullOrEmpty(config[BuildBuildId]);
-            var isLocalRun = !isAzureDevOpsEnvironment;
+        var isAzureDevOpsEnvironment = !string.IsNullOrEmpty(config[BuildReason]) && !string.IsNullOrEmpty(config[BuildBuildId]);
+        var isLocalRun = !isAzureDevOpsEnvironment;
 
-            configBuilder.AddInMemoryCollection(new Dictionary<string, string>()
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string>()
             {
                 { "IsLocalRun", isLocalRun.ToString() }
             });
 
-            configBuilder.AddAzureAppConfiguration(options =>
+        configBuilder.AddAzureAppConfiguration(options =>
+        {
+            var raptorConfigConnectionString = config[RaptorConnectionString];
+            if (IsRaptorConfigAddressCorrect(raptorConfigConnectionString))
             {
-                var raptorConfigConnectionString = config[RaptorConnectionString];
-                if (IsRaptorConfigAddressCorrect(raptorConfigConnectionString))
+                options.Connect(raptorConfigConnectionString);
+            }
+            else
+            {
+                var raptorEndpoint = config[RaptorConfigEndpoint];
+                if (IsRaptorConfigAddressCorrect(raptorEndpoint))
                 {
-                    options.Connect(raptorConfigConnectionString);
+                    var credentials = new DefaultAzureCredential(includeInteractiveCredentials: true);
+                    options.Connect(new Uri(raptorEndpoint), credentials);
                 }
                 else
                 {
-                    var raptorEndpoint = config[RaptorConfigEndpoint];
-                    if (IsRaptorConfigAddressCorrect(raptorEndpoint))
-                    {
-                        var credentials = new DefaultAzureCredential(includeInteractiveCredentials: true);
-                        options.Connect(new Uri(raptorEndpoint), credentials);
-                    }
-                    else
-                    {
-                        Assert.Fail($"Incorrect Raptor Config. Please Set {RaptorConnectionString} or {RaptorConfigEndpoint}");
-                    }
+                    Assert.Fail($"Incorrect Raptor Config. Please Set {RaptorConnectionString} or {RaptorConfigEndpoint}");
                 }
-
-                var runEnvironmentLabel = GetAppConfigLabel(config, isLocalRun);
-                options.Select(keyFilter: KeyFilter.Any, runEnvironmentLabel)
-                    .UseFeatureFlags(flagOptions =>
-                    {
-                        flagOptions.Label = runEnvironmentLabel;
-                    });
-            });
-
-            return configBuilder.Build();
-        }
-
-        /// <summary>
-        /// determines which label to pick in Azure App Config
-        /// </summary>
-        /// <param name="config">config containing environment variables</param>
-        /// <param name="isLocalRun">whether the context is local run or not</param>
-        /// <returns>
-        /// - custom label if specified in environment variable RAPTOR_CONFIGLABEL
-        /// - "Development" if running locally
-        /// - "CI" if running in Azure DevOps
-        /// </returns>
-        public static string GetAppConfigLabel(IConfigurationRoot config, bool isLocalRun)
-        {
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
             }
 
-            const string RaptorConfigLabel = "RAPTOR_CONFIGLABEL";
-            var customLabel = config[RaptorConfigLabel];
-            if (!string.IsNullOrEmpty(customLabel))
-            {
-                return customLabel;
-            }
+            var runEnvironmentLabel = GetAppConfigLabel(config, isLocalRun);
+            options.Select(keyFilter: KeyFilter.Any, runEnvironmentLabel)
+                .UseFeatureFlags(flagOptions =>
+                {
+                    flagOptions.Label = runEnvironmentLabel;
+                });
+        });
 
-            return isLocalRun ? "Development" : "CI";
-        }
+        return configBuilder.Build();
+    }
 
-        /// <summary>
-        ///     Validate Raptor Configuration Address (Endpoint or Connection String) is not null, empty or placeholder text.
-        /// </summary>
-        /// <param name="raptorConfigAddress"></param>
-        /// <returns></returns>
-        private static bool IsRaptorConfigAddressCorrect(string raptorConfigAddress)
+    /// <summary>
+    /// determines which label to pick in Azure App Config
+    /// </summary>
+    /// <param name="config">config containing environment variables</param>
+    /// <param name="isLocalRun">whether the context is local run or not</param>
+    /// <returns>
+    /// - custom label if specified in environment variable RAPTOR_CONFIGLABEL
+    /// - "Development" if running locally
+    /// - "CI" if running in Azure DevOps
+    /// </returns>
+    public static string GetAppConfigLabel(IConfigurationRoot config, bool isLocalRun)
+    {
+        if (config == null)
         {
-            const string variablePlaceHolder = "[ENTER_VALUE]";
-            return !string.IsNullOrWhiteSpace(raptorConfigAddress) && !string.Equals(raptorConfigAddress, variablePlaceHolder, StringComparison.OrdinalIgnoreCase);
+            throw new ArgumentNullException(nameof(config));
         }
 
-        /// <summary>
-        /// Extracts the configuration value, throws if empty string
-        /// </summary>
-        /// <param name="config">configuration</param>
-        /// <param name="key">lookup key</param>
-        /// <returns>non-empty configuration value if found</returns>
-        public static string GetNonEmptyValue(this IConfigurationRoot config, string key)
+        const string RaptorConfigLabel = "RAPTOR_CONFIGLABEL";
+        var customLabel = config[RaptorConfigLabel];
+        if (!string.IsNullOrEmpty(customLabel))
         {
-            var value = config?.GetSection(key)?.Value;
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                throw new InvalidDataException($"Value for {key} is not found in appsettings.json");
-            }
-
-            return value;
+            return customLabel;
         }
+
+        return isLocalRun ? "Development" : "CI";
+    }
+
+    /// <summary>
+    ///     Validate Raptor Configuration Address (Endpoint or Connection String) is not null, empty or placeholder text.
+    /// </summary>
+    /// <param name="raptorConfigAddress"></param>
+    /// <returns></returns>
+    private static bool IsRaptorConfigAddressCorrect(string raptorConfigAddress)
+    {
+        const string variablePlaceHolder = "[ENTER_VALUE]";
+        return !string.IsNullOrWhiteSpace(raptorConfigAddress) && !string.Equals(raptorConfigAddress, variablePlaceHolder, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Extracts the configuration value, throws if empty string
+    /// </summary>
+    /// <param name="config">configuration</param>
+    /// <param name="key">lookup key</param>
+    /// <returns>non-empty configuration value if found</returns>
+    public static string GetNonEmptyValue(this IConfigurationRoot config, string key)
+    {
+        var value = config?.GetSection(key)?.Value;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidDataException($"Value for {key} is not found in appsettings.json");
+        }
+
+        return value;
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/AssemblyInfo.cs
+++ b/msgraph-sdk-raptor-compiler-lib/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UnitTests")]
 [assembly: CLSCompliant(false)]

--- a/msgraph-sdk-raptor-compiler-lib/CustomHttpProvider.cs
+++ b/msgraph-sdk-raptor-compiler-lib/CustomHttpProvider.cs
@@ -5,33 +5,32 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Graph;
 
-namespace MsGraphSDKSnippetsCompiler
+namespace MsGraphSDKSnippetsCompiler;
+
+/// <summary>
+///     Provides interception to catch errors thrown during execution.
+/// </summary>
+public class CustomHttpProvider : HttpProvider, IHttpProvider
 {
-    /// <summary>
-    ///     Provides interception to catch errors thrown during execution.
-    /// </summary>
-    public class CustomHttpProvider : HttpProvider, IHttpProvider
+    async Task<HttpResponseMessage> IHttpProvider.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
     {
-        async Task<HttpResponseMessage> IHttpProvider.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        var uri = request.RequestUri;
+        var headers = request.Headers;
+
+        var stopWatch = new Stopwatch();
+        try
         {
-            var uri = request.RequestUri;
-            var headers = request.Headers;
-            
-            var stopWatch = new Stopwatch();
-            try
-            {
-                stopWatch.Start();
-                var response = await SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
-                stopWatch.Stop();
-                Console.WriteLine($"\nRequest Uri:\t{uri}");
-                Console.WriteLine($"\nResponse Headers:\n{response.Headers}");
-                Console.WriteLine($"\nRequest Duration: \n{stopWatch.Elapsed}");
-                return response;
-            }
-            catch (Exception e)
-            {
-                throw new AggregateException($"Request URI: {uri}{Environment.NewLine}Request Headers:{Environment.NewLine}{headers}", e);
-            }
+            stopWatch.Start();
+            var response = await SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+            stopWatch.Stop();
+            Console.WriteLine($"\nRequest Uri:\t{uri}");
+            Console.WriteLine($"\nResponse Headers:\n{response.Headers}");
+            Console.WriteLine($"\nRequest Duration: \n{stopWatch.Elapsed}");
+            return response;
+        }
+        catch (Exception e)
+        {
+            throw new AggregateException($"Request URI: {uri}{Environment.NewLine}Request Headers:{Environment.NewLine}{headers}", e);
         }
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/CustomHttpProvider.cs
+++ b/msgraph-sdk-raptor-compiler-lib/CustomHttpProvider.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Graph;
-
-namespace MsGraphSDKSnippetsCompiler;
+﻿namespace MsGraphSDKSnippetsCompiler;
 
 /// <summary>
 ///     Provides interception to catch errors thrown during execution.

--- a/msgraph-sdk-raptor-compiler-lib/GlobalUsings.cs
+++ b/msgraph-sdk-raptor-compiler-lib/GlobalUsings.cs
@@ -1,0 +1,30 @@
+﻿global using Azure.Identity;
+global using System;
+global using System.Text.Json;
+global using System.Text.Json.Serialization;
+global using System.Threading.Tasks;
+global using MsGraphSDKSnippetsCompiler.Models;
+global using Microsoft.CodeAnalysis;
+global using Microsoft.CodeAnalysis.Text;
+global using System.Collections.Generic;
+global using System.Diagnostics;
+global using System.Globalization;
+global using System.IO;
+global using System.Linq;
+global using System.Text;
+global using System.Text.RegularExpressions;
+global using System.Threading;
+global using Microsoft.Graph;
+global using System.Net.Http;
+global using NUnit.Framework;
+global using Microsoft.Extensions.Configuration;
+
+// Microsoft.Graph has very generic names in the namespaces
+// disambiguate collisions
+global using Diagnostic = Microsoft.CodeAnalysis.Diagnostic;
+global using Location = Microsoft.CodeAnalysis.Location;
+
+global using Process = System.Diagnostics.Process;
+
+global using Directory = System.IO.Directory;
+global using File = System.IO.File;

--- a/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
@@ -1,11 +1,10 @@
 ﻿using System.Threading.Tasks;
 using MsGraphSDKSnippetsCompiler.Models;
 
-namespace MsGraphSDKSnippetsCompiler
+namespace MsGraphSDKSnippetsCompiler;
+
+public interface IMicrosoftGraphSnippetsCompiler
 {
-    public interface IMicrosoftGraphSnippetsCompiler
-    {
-        CompilationResultsModel CompileSnippet(string codeSnippet, Versions version);
-        Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version);
-    }
+    CompilationResultsModel CompileSnippet(string codeSnippet, Versions version);
+    Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version);
 }

--- a/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/IMicrosoftGraphSnippetsCompiler.cs
@@ -1,7 +1,4 @@
-﻿using System.Threading.Tasks;
-using MsGraphSDKSnippetsCompiler.Models;
-
-namespace MsGraphSDKSnippetsCompiler;
+﻿namespace MsGraphSDKSnippetsCompiler;
 
 public interface IMicrosoftGraphSnippetsCompiler
 {

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -21,61 +21,61 @@ using System.Text;
 using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 
-namespace MsGraphSDKSnippetsCompiler
+namespace MsGraphSDKSnippetsCompiler;
+
+/// <summary>
+///     Microsoft Graph SDK CSharp snippets compiler class
+/// </summary>
+public class MicrosoftGraphCSharpCompiler : IMicrosoftGraphSnippetsCompiler
 {
-    /// <summary>
-    ///     Microsoft Graph SDK CSharp snippets compiler class
-    /// </summary>
-    public class MicrosoftGraphCSharpCompiler : IMicrosoftGraphSnippetsCompiler
+    const string SourceCodePath = "generated.cs";
+    private readonly LanguageTestData TestData;
+    private bool _isEducation;
+
+    private async Task<PermissionManager> GetPermissionManager()
     {
-        const string SourceCodePath = "generated.cs";
-        private readonly LanguageTestData TestData;
-        private bool _isEducation;
+        return _isEducation
+            ? await TestsSetup.EducationTenantPermissionManager.Value.ConfigureAwait(false)
+            : await TestsSetup.RegularTenantPermissionManager.Value.ConfigureAwait(false);
+    }
 
-        private async Task<PermissionManager> GetPermissionManager()
+    /// for hiding bearer token
+    private const string AuthHeaderPattern = "Authorization: Bearer .*";
+    private const string AuthHeaderReplacement = "Authorization: Bearer <token>";
+    private static readonly Regex AuthHeaderRegex = new Regex(AuthHeaderPattern, RegexOptions.Compiled);
+
+    public MicrosoftGraphCSharpCompiler(LanguageTestData testData)
+    {
+        if (testData is null)
         {
-            return _isEducation
-                ? await TestsSetup.EducationTenantPermissionManager.Value.ConfigureAwait(false)
-                : await TestsSetup.RegularTenantPermissionManager.Value.ConfigureAwait(false);
+            throw new ArgumentNullException(nameof(testData));
         }
 
-        /// for hiding bearer token
-        private const string AuthHeaderPattern = "Authorization: Bearer .*";
-        private const string AuthHeaderReplacement = "Authorization: Bearer <token>";
-        private static readonly Regex AuthHeaderRegex = new Regex(AuthHeaderPattern, RegexOptions.Compiled);
+        TestData = testData;
+    }
 
-        public MicrosoftGraphCSharpCompiler(LanguageTestData testData)
-        {
-            if (testData is null)
-            {
-                throw new ArgumentNullException(nameof(testData));
-            }
+    /// <summary>
+    ///     Returns CompilationResultsModel which has the results status and the compilation diagnostics.
+    /// </summary>
+    /// <param name="codeSnippet">The code snippet to be compiled.</param>
+    /// <param name="version"></param>
+    /// <returns>CompilationResultsModel</returns>
+    private (CompilationResultsModel, Assembly) CompileSnippetAndGetAssembly(string codeSnippet, Versions version)
+    {
+        var buffer = Encoding.UTF8.GetBytes(codeSnippet);
+        // Mark Original Source as Embeddable
+        var sourceText = SourceText.From(buffer, buffer.Length, Encoding.UTF8, canBeEmbedded: true);
+        // Embed Original Source Code in Syntax Tree
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(codeSnippet, new CSharpParseOptions(), SourceCodePath);
+        var syntaxRootNode = syntaxTree.GetRoot() as CSharpSyntaxNode;
+        var encoded = CSharpSyntaxTree.Create(syntaxRootNode, null, SourceCodePath, Encoding.UTF8);
 
-            TestData = testData;
-        }
+        string assemblyName = Path.GetRandomFileName();
+        string commonAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        string graphAssemblyPathV1 = Path.GetDirectoryName(typeof(GraphServiceClient).Assembly.Location);
+        string graphAssemblyPathBeta = Path.GetDirectoryName(typeof(beta.Microsoft.Graph.GraphServiceClient).Assembly.Location);
 
-        /// <summary>
-        ///     Returns CompilationResultsModel which has the results status and the compilation diagnostics.
-        /// </summary>
-        /// <param name="codeSnippet">The code snippet to be compiled.</param>
-        /// <param name="version"></param>
-        /// <returns>CompilationResultsModel</returns>
-        private (CompilationResultsModel, Assembly) CompileSnippetAndGetAssembly(string codeSnippet, Versions version)
-        {
-            var buffer = Encoding.UTF8.GetBytes(codeSnippet);
-            // Mark Original Source as Embeddable
-            var sourceText = SourceText.From(buffer, buffer.Length, Encoding.UTF8, canBeEmbedded: true);
-            // Embed Original Source Code in Syntax Tree
-            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(codeSnippet, new CSharpParseOptions(), SourceCodePath);
-            var syntaxRootNode = syntaxTree.GetRoot() as CSharpSyntaxNode;
-            var encoded = CSharpSyntaxTree.Create(syntaxRootNode, null, SourceCodePath, Encoding.UTF8);
-
-            string assemblyName = Path.GetRandomFileName();
-            string commonAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
-            string graphAssemblyPathV1 = Path.GetDirectoryName(typeof(GraphServiceClient).Assembly.Location);
-            string graphAssemblyPathBeta = Path.GetDirectoryName(typeof(beta.Microsoft.Graph.GraphServiceClient).Assembly.Location);
-
-            List<MetadataReference> metadataReferences = new List<MetadataReference>
+        List<MetadataReference> metadataReferences = new List<MetadataReference>
             {
                 MetadataReference.CreateFromFile(Path.Combine(commonAssemblyPath, "System.Private.CoreLib.dll")),
                 MetadataReference.CreateFromFile(Path.Combine(commonAssemblyPath, "System.Console.dll")),
@@ -92,236 +92,235 @@ namespace MsGraphSDKSnippetsCompiler
                 MetadataReference.CreateFromFile(Path.Combine(Path.GetDirectoryName(typeof(Uri).Assembly.Location), "System.Private.Uri.dll"))
             };
 
-            //Use the right Microsoft Graph Version
-            if (!string.IsNullOrEmpty(TestData.DllPath))
+        //Use the right Microsoft Graph Version
+        if (!string.IsNullOrEmpty(TestData.DllPath))
+        {
+            if (!System.IO.File.Exists(TestData.DllPath))
             {
-                if (!System.IO.File.Exists(TestData.DllPath))
-                {
-                    throw new ArgumentException($"Provided dll path {TestData.DllPath} doesn't exist!");
-                }
-
-                metadataReferences.Add(MetadataReference.CreateFromFile(TestData.DllPath));
-            }
-            else if (version == Versions.V1)
-            {
-                metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(graphAssemblyPathV1, "Microsoft.Graph.dll")));
-            }
-            else
-            {
-                metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(graphAssemblyPathBeta, "Microsoft.Graph.Beta.dll")));
+                throw new ArgumentException($"Provided dll path {TestData.DllPath} doesn't exist!");
             }
 
-            var compilation = CSharpCompilation.Create(
-                assemblyName,
-                syntaxTrees: new[] { encoded },
-                references: metadataReferences,
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, deterministic: true, platform: Platform.AnyCpu)
-                    .WithConcurrentBuild(true)
-                    .WithOptimizationLevel(OptimizationLevel.Release));
-
-            var (emitResult, assembly) = GetEmitResult(compilation, sourceText);
-            CompilationResultsModel results = GetCompilationResults(emitResult);
-
-            return (results, assembly);
+            metadataReferences.Add(MetadataReference.CreateFromFile(TestData.DllPath));
+        }
+        else if (version == Versions.V1)
+        {
+            metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(graphAssemblyPathV1, "Microsoft.Graph.dll")));
+        }
+        else
+        {
+            metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(graphAssemblyPathBeta, "Microsoft.Graph.Beta.dll")));
         }
 
-        public CompilationResultsModel CompileSnippet(string codeSnippet, Versions version)
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            syntaxTrees: new[] { encoded },
+            references: metadataReferences,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, deterministic: true, platform: Platform.AnyCpu)
+                .WithConcurrentBuild(true)
+                .WithOptimizationLevel(OptimizationLevel.Release));
+
+        var (emitResult, assembly) = GetEmitResult(compilation, sourceText);
+        CompilationResultsModel results = GetCompilationResults(emitResult);
+
+        return (results, assembly);
+    }
+
+    public CompilationResultsModel CompileSnippet(string codeSnippet, Versions version)
+    {
+        var (results, _) = CompileSnippetAndGetAssembly(codeSnippet, version);
+        return results;
+    }
+
+    /// <summary>
+    ///     Returns ExecutionResultsModel which has the results status and the compilation diagnostics.
+    /// </summary>
+    /// <param name="codeSnippet">The code snippet to be compiled and executed.</param>
+    /// <param name="version">Graph API version</param>
+    /// <returns>ExecutionResultsModel</returns>
+    public async Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version)
+    {
+        var (compilationResult, assembly) = CompileSnippetAndGetAssembly(codeSnippet, version);
+
+        string exceptionMessage = null;
+        bool success = false;
+        if (compilationResult.IsSuccess)
         {
-            var (results, _) = CompileSnippetAndGetAssembly(codeSnippet, version);
-            return results;
-        }
-
-        /// <summary>
-        ///     Returns ExecutionResultsModel which has the results status and the compilation diagnostics.
-        /// </summary>
-        /// <param name="codeSnippet">The code snippet to be compiled and executed.</param>
-        /// <param name="version">Graph API version</param>
-        /// <returns>ExecutionResultsModel</returns>
-        public async Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version)
-        {
-            var (compilationResult, assembly) = CompileSnippetAndGetAssembly(codeSnippet, version);
-
-            string exceptionMessage = null;
-            bool success = false;
-            if (compilationResult.IsSuccess)
-            {
-                try
-                {
-                    dynamic instance = assembly.CreateInstance("GraphSDKTest");
-
-                    using HttpRequestMessage httpRequestMessage = instance.GetRequestMessage(null);
-                    if (httpRequestMessage.RequestUri.PathAndQuery[5..].Contains("/education", StringComparison.OrdinalIgnoreCase))
-                    {
-                        _isEducation = true;
-                    }
-
-                    var delegatedScopes = await GetScopes(httpRequestMessage).ConfigureAwait(false);
-
-                    if (delegatedScopes != null)
-                    {
-                        // succeeding for one scope is OK for now.
-                        success = await ExecuteWithDelegatedPermissions(instance, delegatedScopes);
-                    }
-
-                    if (!success)
-                    {
-                        success = await ExecuteWithApplicationPermissions(instance);
-                    }
-                }
-                catch (Exception e)
-                {
-                    var innerExceptionMessage = e.InnerException?.Message ?? string.Empty;
-                    exceptionMessage = e.Message + Environment.NewLine + innerExceptionMessage;
-                    if (!TestsSetup.Config.Value.IsLocalRun)
-                    {
-                        exceptionMessage = AuthHeaderRegex.Replace(exceptionMessage, AuthHeaderReplacement);
-                    }
-                }
-            }
-
-            return new ExecutionResultsModel(compilationResult, success, exceptionMessage);
-        }
-
-        /// <summary>
-        /// Executes the compiled snippet with tokens from given scope.
-        /// </summary>
-        /// <param name="instance">snippet instance</param>
-        /// <param name="scopes">delegated permission scopes</param>
-        /// <returns>
-        /// true if a token from one of the scopes executes successfully
-        /// false if none of them.
-        /// </returns>
-        private async Task<bool> ExecuteWithDelegatedPermissions(dynamic instance, Scope[] scopes)
-        {
-            var permissionManager = await GetPermissionManager().ConfigureAwait(false);
-            foreach (var scope in scopes)
-            {
-                try
-                {
-                    var authProvider = permissionManager.GetDelegatedAuthProvider(scope);
-
-                    // Pass custom http provider to provide interception and logging
-                    using var customHttpProvider = new CustomHttpProvider();
-                    await ((instance.Main(authProvider, customHttpProvider) as Task).ConfigureAwait(false));
-                    return true;
-                }
-                catch (Exception e)
-                {
-                    await TestContext.Out.WriteLineAsync($"Failed for delegated scope: {scope}").ConfigureAwait(false);
-                    await TestContext.Out.WriteLineAsync(e.Message).ConfigureAwait(false);
-                }
-            }
-
-            await TestContext.Out.WriteLineAsync($"None of the delegated permissions work!").ConfigureAwait(false);
-            return false;
-        }
-
-        /// <summary>
-        /// Executes the compiled snippet with an auth provider that that has all the application permissions
-        /// </summary>
-        /// <param name="instance">snippet instance</param>
-        /// <returns>true if the call succeeds</returns>
-        private async Task<bool> ExecuteWithApplicationPermissions(dynamic instance)
-        {
-            var permissionManager = await GetPermissionManager().ConfigureAwait(false);
-            // Pass custom http provider to provide interception and logging
-            using var customHttpProvider = new CustomHttpProvider();
-            await ((instance.Main(permissionManager.AuthProvider, customHttpProvider) as Task).ConfigureAwait(false));
-            return true;
-        }
-
-        /// <summary>
-        /// Calls DevX Api to get required permissions
-        /// </summary>
-        /// <param name="httpRequestMessage">HttpRequestMessage that the C# SDK built for the snippet</param>
-        /// <returns>
-        /// 1. delegated scopes if found
-        /// 2. null only if application scopes are found (we don't care about the specific application permission as our app has all of them)
-        /// </returns>
-        /// <exception cref="AggregateException">
-        /// If DevX API fails to return scopes for both application and delegation permissions,
-        /// throws an AggregateException containing the last exception from the service
-        /// </exception>
-        private async Task<Scope[]> GetScopes(HttpRequestMessage httpRequestMessage)
-        {
-            var path = httpRequestMessage.RequestUri.LocalPath;
-            var versionSegmentLength = "/v1.0".Length;
-            if (path.StartsWith("/v1.0", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/beta", StringComparison.OrdinalIgnoreCase))
-            {
-                path = path[versionSegmentLength..];
-            }
-
-            using var httpClient = new HttpClient();
-
-            async Task<Scope[]> getScopesForScopeType(string scopeType)
-            {
-                using var scopesRequest = new HttpRequestMessage(HttpMethod.Get, $"https://graphexplorerapi.azurewebsites.net/permissions?requesturl={path}&method={httpRequestMessage.Method}&scopeType={scopeType}");
-                scopesRequest.Headers.Add("Accept-Language", "en-US");
-
-                using var response = await httpClient.SendAsync(scopesRequest).ConfigureAwait(false);
-                var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                return JsonSerializer.Deserialize<Scope[]>(responseString);
-            }
-
             try
             {
-                return await getScopesForScopeType("DelegatedWork").ConfigureAwait(false);
-            }
-            catch
-            {
-                await TestContext.Out.WriteLineAsync($"Can't get scopes for scopeType=DelegatedWork, url={httpRequestMessage.RequestUri}").ConfigureAwait(false);
-            }
+                dynamic instance = assembly.CreateInstance("GraphSDKTest");
 
-            try
-            {
-                // we don't care about a specific Application permission, we only want to make sure that DevX API returns
-                // either delegated or application permissions.
-                _ = await getScopesForScopeType("Application").ConfigureAwait(false);
-                return null;
+                using HttpRequestMessage httpRequestMessage = instance.GetRequestMessage(null);
+                if (httpRequestMessage.RequestUri.PathAndQuery[5..].Contains("/education", StringComparison.OrdinalIgnoreCase))
+                {
+                    _isEducation = true;
+                }
+
+                var delegatedScopes = await GetScopes(httpRequestMessage).ConfigureAwait(false);
+
+                if (delegatedScopes != null)
+                {
+                    // succeeding for one scope is OK for now.
+                    success = await ExecuteWithDelegatedPermissions(instance, delegatedScopes);
+                }
+
+                if (!success)
+                {
+                    success = await ExecuteWithApplicationPermissions(instance);
+                }
             }
             catch (Exception e)
             {
-                await TestContext.Out.WriteLineAsync($"Can't get scopes for both delegated and application scopes").ConfigureAwait(false);
-                await TestContext.Out.WriteLineAsync($"url={httpRequestMessage.RequestUri}").ConfigureAwait(false);
-                await TestContext.Out.WriteLineAsync($"docslink={TestData.DocsLink}").ConfigureAwait(false);
-                throw new AggregateException("Can't get scopes for both delegated and application scopes", e);
+                var innerExceptionMessage = e.InnerException?.Message ?? string.Empty;
+                exceptionMessage = e.Message + Environment.NewLine + innerExceptionMessage;
+                if (!TestsSetup.Config.Value.IsLocalRun)
+                {
+                    exceptionMessage = AuthHeaderRegex.Replace(exceptionMessage, AuthHeaderReplacement);
+                }
             }
         }
 
-        /// <summary>
-        ///     Gets the result of the Compilation.Emit method.
-        /// </summary>
-        /// <param name="compilation">Immutable representation of a single invocation of the compiler</param>
-        /// <param name="sourceText">Original Source Representation of the Snippet</param>
-        private static (EmitResult, Assembly) GetEmitResult(CSharpCompilation compilation, SourceText sourceText)
+        return new ExecutionResultsModel(compilationResult, success, exceptionMessage);
+    }
+
+    /// <summary>
+    /// Executes the compiled snippet with tokens from given scope.
+    /// </summary>
+    /// <param name="instance">snippet instance</param>
+    /// <param name="scopes">delegated permission scopes</param>
+    /// <returns>
+    /// true if a token from one of the scopes executes successfully
+    /// false if none of them.
+    /// </returns>
+    private async Task<bool> ExecuteWithDelegatedPermissions(dynamic instance, Scope[] scopes)
+    {
+        var permissionManager = await GetPermissionManager().ConfigureAwait(false);
+        foreach (var scope in scopes)
         {
-            Assembly assembly = null;
-
-            using MemoryStream assemblyStream = new MemoryStream();
-            var emitOptions = new EmitOptions(false, DebugInformationFormat.Embedded);
-            var embeddedTexts = new List<EmbeddedText> { EmbeddedText.FromSource(SourceCodePath, sourceText) };
-            EmitResult emitResult = compilation.Emit(assemblyStream, embeddedTexts: embeddedTexts, options: emitOptions);
-
-            if (emitResult.Success)
+            try
             {
-                assemblyStream.Seek(0, SeekOrigin.Begin);
-                assembly = AssemblyLoadContext.Default.LoadFromStream(assemblyStream);
+                var authProvider = permissionManager.GetDelegatedAuthProvider(scope);
+
+                // Pass custom http provider to provide interception and logging
+                using var customHttpProvider = new CustomHttpProvider();
+                await ((instance.Main(authProvider, customHttpProvider) as Task).ConfigureAwait(false));
+                return true;
             }
-            return (emitResult, assembly);
+            catch (Exception e)
+            {
+                await TestContext.Out.WriteLineAsync($"Failed for delegated scope: {scope}").ConfigureAwait(false);
+                await TestContext.Out.WriteLineAsync(e.Message).ConfigureAwait(false);
+            }
         }
 
-        /// <summary>
-        ///     Checks whether the EmitResult is successful and returns an instance of CompilationResultsModel.
-        /// </summary>
-        /// <param name="emitResult">The result of the Compilation.Emit method.</param>
-        private CompilationResultsModel GetCompilationResults(EmitResult emitResult)
+        await TestContext.Out.WriteLineAsync($"None of the delegated permissions work!").ConfigureAwait(false);
+        return false;
+    }
+
+    /// <summary>
+    /// Executes the compiled snippet with an auth provider that that has all the application permissions
+    /// </summary>
+    /// <param name="instance">snippet instance</param>
+    /// <returns>true if the call succeeds</returns>
+    private async Task<bool> ExecuteWithApplicationPermissions(dynamic instance)
+    {
+        var permissionManager = await GetPermissionManager().ConfigureAwait(false);
+        // Pass custom http provider to provide interception and logging
+        using var customHttpProvider = new CustomHttpProvider();
+        await ((instance.Main(permissionManager.AuthProvider, customHttpProvider) as Task).ConfigureAwait(false));
+        return true;
+    }
+
+    /// <summary>
+    /// Calls DevX Api to get required permissions
+    /// </summary>
+    /// <param name="httpRequestMessage">HttpRequestMessage that the C# SDK built for the snippet</param>
+    /// <returns>
+    /// 1. delegated scopes if found
+    /// 2. null only if application scopes are found (we don't care about the specific application permission as our app has all of them)
+    /// </returns>
+    /// <exception cref="AggregateException">
+    /// If DevX API fails to return scopes for both application and delegation permissions,
+    /// throws an AggregateException containing the last exception from the service
+    /// </exception>
+    private async Task<Scope[]> GetScopes(HttpRequestMessage httpRequestMessage)
+    {
+        var path = httpRequestMessage.RequestUri.LocalPath;
+        var versionSegmentLength = "/v1.0".Length;
+        if (path.StartsWith("/v1.0", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/beta", StringComparison.OrdinalIgnoreCase))
         {
-            // We are only interested with warnings and errors hence the diagnostics filter
-            var failures = emitResult.Success
-                ? null
-                : emitResult.Diagnostics.Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error);
-
-            return new CompilationResultsModel(emitResult.Success, failures, TestData.FileName);
+            path = path[versionSegmentLength..];
         }
+
+        using var httpClient = new HttpClient();
+
+        async Task<Scope[]> getScopesForScopeType(string scopeType)
+        {
+            using var scopesRequest = new HttpRequestMessage(HttpMethod.Get, $"https://graphexplorerapi.azurewebsites.net/permissions?requesturl={path}&method={httpRequestMessage.Method}&scopeType={scopeType}");
+            scopesRequest.Headers.Add("Accept-Language", "en-US");
+
+            using var response = await httpClient.SendAsync(scopesRequest).ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<Scope[]>(responseString);
+        }
+
+        try
+        {
+            return await getScopesForScopeType("DelegatedWork").ConfigureAwait(false);
+        }
+        catch
+        {
+            await TestContext.Out.WriteLineAsync($"Can't get scopes for scopeType=DelegatedWork, url={httpRequestMessage.RequestUri}").ConfigureAwait(false);
+        }
+
+        try
+        {
+            // we don't care about a specific Application permission, we only want to make sure that DevX API returns
+            // either delegated or application permissions.
+            _ = await getScopesForScopeType("Application").ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception e)
+        {
+            await TestContext.Out.WriteLineAsync($"Can't get scopes for both delegated and application scopes").ConfigureAwait(false);
+            await TestContext.Out.WriteLineAsync($"url={httpRequestMessage.RequestUri}").ConfigureAwait(false);
+            await TestContext.Out.WriteLineAsync($"docslink={TestData.DocsLink}").ConfigureAwait(false);
+            throw new AggregateException("Can't get scopes for both delegated and application scopes", e);
+        }
+    }
+
+    /// <summary>
+    ///     Gets the result of the Compilation.Emit method.
+    /// </summary>
+    /// <param name="compilation">Immutable representation of a single invocation of the compiler</param>
+    /// <param name="sourceText">Original Source Representation of the Snippet</param>
+    private static (EmitResult, Assembly) GetEmitResult(CSharpCompilation compilation, SourceText sourceText)
+    {
+        Assembly assembly = null;
+
+        using MemoryStream assemblyStream = new MemoryStream();
+        var emitOptions = new EmitOptions(false, DebugInformationFormat.Embedded);
+        var embeddedTexts = new List<EmbeddedText> { EmbeddedText.FromSource(SourceCodePath, sourceText) };
+        EmitResult emitResult = compilation.Emit(assemblyStream, embeddedTexts: embeddedTexts, options: emitOptions);
+
+        if (emitResult.Success)
+        {
+            assemblyStream.Seek(0, SeekOrigin.Begin);
+            assembly = AssemblyLoadContext.Default.LoadFromStream(assemblyStream);
+        }
+        return (emitResult, assembly);
+    }
+
+    /// <summary>
+    ///     Checks whether the EmitResult is successful and returns an instance of CompilationResultsModel.
+    /// </summary>
+    /// <param name="emitResult">The result of the Compilation.Emit method.</param>
+    private CompilationResultsModel GetCompilationResults(EmitResult emitResult)
+    {
+        // We are only interested with warnings and errors hence the diagnostics filter
+        var failures = emitResult.Success
+            ? null
+            : emitResult.Diagnostics.Where(diagnostic => diagnostic.IsWarningAsError || diagnostic.Severity == DiagnosticSeverity.Error);
+
+        return new CompilationResultsModel(emitResult.Success, failures, TestData.FileName);
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphCSharpCompiler.cs
@@ -1,25 +1,11 @@
 ﻿extern alias beta;
 
 using Azure.Core;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
-using Microsoft.Graph;
-using MsGraphSDKSnippetsCompiler.Models;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Net.Http;
 using System.Runtime.Loader;
-using System.Threading.Tasks;
 using System.Reflection;
-using System.Text.RegularExpressions;
-using System.Text.Json;
-using System.Text;
-using Microsoft.CodeAnalysis.Text;
-using NUnit.Framework;
 
 namespace MsGraphSDKSnippetsCompiler;
 

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
@@ -1,18 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using MsGraphSDKSnippetsCompiler.Models;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace MsGraphSDKSnippetsCompiler;
+﻿namespace MsGraphSDKSnippetsCompiler;
 
 public class MicrosoftGraphJavaCompiler : IMicrosoftGraphSnippetsCompiler
 {

--- a/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
+++ b/msgraph-sdk-raptor-compiler-lib/MicrosoftGraphJavaCompiler.cs
@@ -12,18 +12,18 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace MsGraphSDKSnippetsCompiler
-{
-    public class MicrosoftGraphJavaCompiler : IMicrosoftGraphSnippetsCompiler
-    {
-        private readonly string _markdownFileName;
-        private readonly string _previewLibraryPath;
-        private readonly string _javaLibVersion;
-        private readonly string _javaCoreVersion;
-        private static readonly string[] testFileSubDirectories = new string[] { "src", "main", "java", "com", "microsoft", "graph", "raptor" };
+namespace MsGraphSDKSnippetsCompiler;
 
-        private const string gradleBuildFileName = "build.gradle";
-        private const string previewGradleBuildFileTemplate = @"plugins {
+public class MicrosoftGraphJavaCompiler : IMicrosoftGraphSnippetsCompiler
+{
+    private readonly string _markdownFileName;
+    private readonly string _previewLibraryPath;
+    private readonly string _javaLibVersion;
+    private readonly string _javaCoreVersion;
+    private static readonly string[] testFileSubDirectories = new string[] { "src", "main", "java", "com", "microsoft", "graph", "raptor" };
+
+    private const string gradleBuildFileName = "build.gradle";
+    private const string previewGradleBuildFileTemplate = @"plugins {
     id 'java'
     id 'application'
 }
@@ -42,7 +42,7 @@ dependencies {
 application {
     mainClassName = 'com.microsoft.graph.raptor.App'
 }";
-        private const string v1GradleBuildFileTemplate = @"plugins {
+    private const string v1GradleBuildFileTemplate = @"plugins {
     id 'java'
     id 'application'
 }
@@ -57,7 +57,7 @@ dependencies {
 application {
     mainClassName = 'com.microsoft.graph.raptor.App'
 }";
-        private const string betaGradleBuildFileTemplate = @"plugins {
+    private const string betaGradleBuildFileTemplate = @"plugins {
     id 'java'
     id 'application'
 }
@@ -75,186 +75,187 @@ dependencies {
 application {
     mainClassName = 'com.microsoft.graph.raptor.App'
 }";
-        private const string deps = @"implementation 'com.google.guava:guava:30.1.1-jre'
+    private const string deps = @"implementation 'com.google.guava:guava:30.1.1-jre'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'com.azure:azure-identity:1.2.5'";
-        private const string gradleSettingsFileName = "settings.gradle";
-        private const string gradleSettingsFileTemplate = @"rootProject.name = 'msgraph-sdk-java-raptor'";
+    private const string gradleSettingsFileName = "settings.gradle";
+    private const string gradleSettingsFileTemplate = @"rootProject.name = 'msgraph-sdk-java-raptor'";
 
-        private static Versions? currentlyConfiguredVersion;
+    private static Versions? currentlyConfiguredVersion;
 #pragma warning disable CA5394 // Do not use insecure randomness: security is not a concern here
-        private static readonly Lazy<int> currentExcutionFolder = new Lazy<int>(() => new Random().Next(0, int.MaxValue));
+    private static readonly Lazy<int> currentExcutionFolder = new Lazy<int>(() => new Random().Next(0, int.MaxValue));
 #pragma warning restore CA5394 // Do not use insecure randomness
-        private static readonly object versionLock = new { };
+    private static readonly object versionLock = new { };
 
-        private static void SetCurrentlyConfiguredVersion (Versions version)
-        {// we don't want to overwrite the build.gradle for each test, this prevents gradle from caching things and slows down build time
-            lock(versionLock) {
-                currentlyConfiguredVersion = version;
-            }
+    private static void SetCurrentlyConfiguredVersion(Versions version)
+    {// we don't want to overwrite the build.gradle for each test, this prevents gradle from caching things and slows down build time
+        lock (versionLock)
+        {
+            currentlyConfiguredVersion = version;
         }
+    }
 
-        public MicrosoftGraphJavaCompiler(string markdownFileName, string previewLibPath, string javaLibVersion, string javaCoreVersion)
+    public MicrosoftGraphJavaCompiler(string markdownFileName, string previewLibPath, string javaLibVersion, string javaCoreVersion)
+    {
+        _markdownFileName = markdownFileName;
+        _previewLibraryPath = previewLibPath;
+        _javaLibVersion = javaLibVersion;
+        _javaCoreVersion = javaCoreVersion;
+    }
+    public CompilationResultsModel CompileSnippet(string codeSnippet, Versions version)
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), "msgraph-sdk-raptor");
+        Directory.CreateDirectory(tempPath);
+        var rootPath = Path.Combine(tempPath, "java" + currentExcutionFolder.Value);
+        var sourceFileDirectory = Path.Combine(new string[] { rootPath }.Union(testFileSubDirectories).ToArray());
+        if (!currentlyConfiguredVersion.HasValue || currentlyConfiguredVersion.Value != version)
         {
-            _markdownFileName = markdownFileName;
-            _previewLibraryPath = previewLibPath;
-            _javaLibVersion = javaLibVersion;
-            _javaCoreVersion = javaCoreVersion;
+            InitializeProjectStructure(version, rootPath).GetAwaiter().GetResult();
+            SetCurrentlyConfiguredVersion(version);
         }
-        public CompilationResultsModel CompileSnippet(string codeSnippet, Versions version)
+        File.WriteAllText(Path.Combine(sourceFileDirectory, "App.java"), codeSnippet); //could be async
+        using var javacProcess = new Process
         {
-            var tempPath = Path.Combine(Path.GetTempPath(), "msgraph-sdk-raptor");
-            Directory.CreateDirectory(tempPath);
-            var rootPath = Path.Combine(tempPath, "java" + currentExcutionFolder.Value);
-            var sourceFileDirectory = Path.Combine(new string[] { rootPath }.Union(testFileSubDirectories).ToArray());
-            if (!currentlyConfiguredVersion.HasValue || currentlyConfiguredVersion.Value != version)
+            StartInfo = new ProcessStartInfo
             {
-                InitializeProjectStructure(version, rootPath).GetAwaiter().GetResult();
-                SetCurrentlyConfiguredVersion(version);
+                FileName = "gradle",
+                Arguments = "build",
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                WorkingDirectory = rootPath,
+            },
+        };
+        var stdOuputSB = new StringBuilder();
+        var stdErrSB = new StringBuilder();
+        using var outputWaitHandle = new AutoResetEvent(false);
+        using var errorWaitHandle = new AutoResetEvent(false);
+        javacProcess.OutputDataReceived += (sender, e) =>
+        {
+            if (string.IsNullOrEmpty(e.Data))
+            {
+                outputWaitHandle.Set();
             }
-            File.WriteAllText(Path.Combine(sourceFileDirectory, "App.java"), codeSnippet); //could be async
-            using var javacProcess = new Process
+            else
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "gradle",
-                    Arguments = "build",
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
-                    WorkingDirectory = rootPath,
-                },
-            };
-            var stdOuputSB = new StringBuilder();
-            var stdErrSB = new StringBuilder();
-            using var outputWaitHandle = new AutoResetEvent(false);
-            using var errorWaitHandle = new AutoResetEvent(false);
-            javacProcess.OutputDataReceived += (sender, e) => {
-                if (string.IsNullOrEmpty(e.Data))
-                {
-                    outputWaitHandle.Set();
-                }
-                else
-                {
-                    stdOuputSB.Append(e.Data);
-                }
-            };
-            javacProcess.ErrorDataReceived += (sender, e) =>
+                stdOuputSB.Append(e.Data);
+            }
+        };
+        javacProcess.ErrorDataReceived += (sender, e) =>
+        {
+            if (string.IsNullOrEmpty(e.Data))
             {
-                if (string.IsNullOrEmpty(e.Data))
-                {
-                    errorWaitHandle.Set();
-                }
-                else
-                {
-                    stdErrSB.Append(e.Data);
-                }
-            };
-            javacProcess.Start();
-            javacProcess.BeginOutputReadLine();
-            javacProcess.BeginErrorReadLine();
-            var hasExited = javacProcess.WaitForExit(20000);
-            if (!hasExited)
-                javacProcess.Kill(true);
-            var stdOutput = stdOuputSB.ToString();
-            var stdErr = stdErrSB.ToString();
-            return new CompilationResultsModel(
-                hasExited && stdOutput.Contains("BUILD SUCCESSFUL", StringComparison.OrdinalIgnoreCase),
-                GetDiagnosticsFromStdErr(stdOutput, stdErr, hasExited),
-                _markdownFileName
-            );
-        }
+                errorWaitHandle.Set();
+            }
+            else
+            {
+                stdErrSB.Append(e.Data);
+            }
+        };
+        javacProcess.Start();
+        javacProcess.BeginOutputReadLine();
+        javacProcess.BeginErrorReadLine();
+        var hasExited = javacProcess.WaitForExit(20000);
+        if (!hasExited)
+            javacProcess.Kill(true);
+        var stdOutput = stdOuputSB.ToString();
+        var stdErr = stdErrSB.ToString();
+        return new CompilationResultsModel(
+            hasExited && stdOutput.Contains("BUILD SUCCESSFUL", StringComparison.OrdinalIgnoreCase),
+            GetDiagnosticsFromStdErr(stdOutput, stdErr, hasExited),
+            _markdownFileName
+        );
+    }
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version)
-        {
-            throw new NotImplementedException("not yet implemented for Java");
-        }
+    public async Task<ExecutionResultsModel> ExecuteSnippet(string codeSnippet, Versions version)
+    {
+        throw new NotImplementedException("not yet implemented for Java");
+    }
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
-        private const string errorsSuffix = "FAILURE";
-        private static readonly Regex notesFilterRegex = new Regex(@"^Note:\s[^\n]*$", RegexOptions.Compiled | RegexOptions.Multiline);
-        private static readonly Regex doubleLineReturnCleanupRegex = new Regex(@"\n{2,}", RegexOptions.Compiled | RegexOptions.Multiline);
-        private static readonly Regex errorCountCleanupRegex = new Regex(@"\d+ error", RegexOptions.Compiled);
-        private static readonly Regex errorMessageCaptureRegex = new Regex(@":(?<linenumber>\d+):(?<message>[^\/\\]+)", RegexOptions.Compiled | RegexOptions.Multiline);
-        private static List<Diagnostic> GetDiagnosticsFromStdErr(string stdOutput, string stdErr, bool hasExited)
+    private const string errorsSuffix = "FAILURE";
+    private static readonly Regex notesFilterRegex = new Regex(@"^Note:\s[^\n]*$", RegexOptions.Compiled | RegexOptions.Multiline);
+    private static readonly Regex doubleLineReturnCleanupRegex = new Regex(@"\n{2,}", RegexOptions.Compiled | RegexOptions.Multiline);
+    private static readonly Regex errorCountCleanupRegex = new Regex(@"\d+ error", RegexOptions.Compiled);
+    private static readonly Regex errorMessageCaptureRegex = new Regex(@":(?<linenumber>\d+):(?<message>[^\/\\]+)", RegexOptions.Compiled | RegexOptions.Multiline);
+    private static List<Diagnostic> GetDiagnosticsFromStdErr(string stdOutput, string stdErr, bool hasExited)
+    {
+        var result = new List<Diagnostic>();
+        if (stdErr.Contains(errorsSuffix, StringComparison.OrdinalIgnoreCase))
         {
-            var result = new List<Diagnostic>();
-            if(stdErr.Contains(errorsSuffix, StringComparison.OrdinalIgnoreCase))
-            {
-                var diagnosticsToParse = doubleLineReturnCleanupRegex.Replace(
-                                                errorCountCleanupRegex.Replace(
-                                                    notesFilterRegex.Replace(// we don't need informational notes
-                                                        stdErr[0..stdErr.IndexOf(errorsSuffix, StringComparison.OrdinalIgnoreCase)], // we want the traces before FAILURE
-                                                        string.Empty),
+            var diagnosticsToParse = doubleLineReturnCleanupRegex.Replace(
+                                            errorCountCleanupRegex.Replace(
+                                                notesFilterRegex.Replace(// we don't need informational notes
+                                                    stdErr[0..stdErr.IndexOf(errorsSuffix, StringComparison.OrdinalIgnoreCase)], // we want the traces before FAILURE
                                                     string.Empty),
-                                                string.Empty);
-                result.AddRange(errorMessageCaptureRegex
-                                            .Matches(diagnosticsToParse)
-                                            .Select(x => new { message = x.Groups["message"].Value, linenumber = int.Parse(x.Groups["linenumber"].Value, CultureInfo.CurrentCulture) })
-                                            .Select(x => Diagnostic.Create(new DiagnosticDescriptor("JAVA1001",
-                                                                                "Error during Java compilation",
-                                                                                x.message,
-                                                                                "JAVA1001: 'Java.Language'",
-                                                                                DiagnosticSeverity.Error,
-                                                                                true),
-                                                                            Location.Create("App.java",
-                                                                                new TextSpan(0, 5),
-                                                                                new LinePositionSpan(
-                                                                                    new LinePosition(x.linenumber, 0),
-                                                                                    new LinePosition(x.linenumber, 2))))));
-            }
-            if (!hasExited)
-            {
-                result.Add(Diagnostic.Create(new DiagnosticDescriptor("JAVA1000",
-                                                                        "Sample didn't finish compiling",
-                                                                        "The compilation for that sample timed out",
-                                                                        "JAVA1000: 'Gradle.Build'",
-                                                                        DiagnosticSeverity.Error,
-                                                                        true),
-                                            null));
-                result.Add(Diagnostic.Create(new DiagnosticDescriptor("JAVA1000",
-                                                                        "Sample didn't finish compiling",
-                                                                        stdErr,
-                                                                        "JAVA1000: 'Gradle.StdErr'",
-                                                                        DiagnosticSeverity.Error,
-                                                                        true),
-                                            null));
-                result.Add(Diagnostic.Create(new DiagnosticDescriptor("JAVA1000",
-                                                                        "Sample didn't finish compiling",
-                                                                        stdOutput,
-                                                                        "JAVA1000: 'Gradle.StdOut'",
-                                                                        DiagnosticSeverity.Error,
-                                                                        true),
-                                            null));
-            }
-            return result;
+                                                string.Empty),
+                                            string.Empty);
+            result.AddRange(errorMessageCaptureRegex
+                                        .Matches(diagnosticsToParse)
+                                        .Select(x => new { message = x.Groups["message"].Value, linenumber = int.Parse(x.Groups["linenumber"].Value, CultureInfo.CurrentCulture) })
+                                        .Select(x => Diagnostic.Create(new DiagnosticDescriptor("JAVA1001",
+                                                                            "Error during Java compilation",
+                                                                            x.message,
+                                                                            "JAVA1001: 'Java.Language'",
+                                                                            DiagnosticSeverity.Error,
+                                                                            true),
+                                                                        Location.Create("App.java",
+                                                                            new TextSpan(0, 5),
+                                                                            new LinePositionSpan(
+                                                                                new LinePosition(x.linenumber, 0),
+                                                                                new LinePosition(x.linenumber, 2))))));
         }
-
-        private async Task InitializeProjectStructure(Versions version, string rootPath)
+        if (!hasExited)
         {
-            Directory.CreateDirectory(rootPath);
-            var buildGradleFileContent = version == Versions.V1 ? v1GradleBuildFileTemplate : betaGradleBuildFileTemplate;
-            if (!string.IsNullOrEmpty(_previewLibraryPath))
-                buildGradleFileContent = previewGradleBuildFileTemplate.Replace("--path--", _previewLibraryPath, StringComparison.OrdinalIgnoreCase);
-            await File.WriteAllTextAsync(Path.Combine(rootPath, gradleBuildFileName), buildGradleFileContent
-                                                                            .Replace("--deps--", deps, StringComparison.OrdinalIgnoreCase)
-                                                                            .Replace("--coreversion--", _javaCoreVersion, StringComparison.OrdinalIgnoreCase)
-                                                                            .Replace("--libversion--", _javaLibVersion, StringComparison.OrdinalIgnoreCase)).ConfigureAwait(false);
-            var gradleSettingsFilePath = Path.Combine(rootPath, gradleSettingsFileName);
-            if (!File.Exists(gradleSettingsFilePath))
-                await File.WriteAllTextAsync(gradleSettingsFilePath, gradleSettingsFileTemplate).ConfigureAwait(false);
-
-            CreateDirectoryStructure(rootPath, testFileSubDirectories);
+            result.Add(Diagnostic.Create(new DiagnosticDescriptor("JAVA1000",
+                                                                    "Sample didn't finish compiling",
+                                                                    "The compilation for that sample timed out",
+                                                                    "JAVA1000: 'Gradle.Build'",
+                                                                    DiagnosticSeverity.Error,
+                                                                    true),
+                                        null));
+            result.Add(Diagnostic.Create(new DiagnosticDescriptor("JAVA1000",
+                                                                    "Sample didn't finish compiling",
+                                                                    stdErr,
+                                                                    "JAVA1000: 'Gradle.StdErr'",
+                                                                    DiagnosticSeverity.Error,
+                                                                    true),
+                                        null));
+            result.Add(Diagnostic.Create(new DiagnosticDescriptor("JAVA1000",
+                                                                    "Sample didn't finish compiling",
+                                                                    stdOutput,
+                                                                    "JAVA1000: 'Gradle.StdOut'",
+                                                                    DiagnosticSeverity.Error,
+                                                                    true),
+                                        null));
         }
+        return result;
+    }
 
-        private static void CreateDirectoryStructure(string rootPath, string[] subdirectoriesNames)
+    private async Task InitializeProjectStructure(Versions version, string rootPath)
+    {
+        Directory.CreateDirectory(rootPath);
+        var buildGradleFileContent = version == Versions.V1 ? v1GradleBuildFileTemplate : betaGradleBuildFileTemplate;
+        if (!string.IsNullOrEmpty(_previewLibraryPath))
+            buildGradleFileContent = previewGradleBuildFileTemplate.Replace("--path--", _previewLibraryPath, StringComparison.OrdinalIgnoreCase);
+        await File.WriteAllTextAsync(Path.Combine(rootPath, gradleBuildFileName), buildGradleFileContent
+                                                                        .Replace("--deps--", deps, StringComparison.OrdinalIgnoreCase)
+                                                                        .Replace("--coreversion--", _javaCoreVersion, StringComparison.OrdinalIgnoreCase)
+                                                                        .Replace("--libversion--", _javaLibVersion, StringComparison.OrdinalIgnoreCase)).ConfigureAwait(false);
+        var gradleSettingsFilePath = Path.Combine(rootPath, gradleSettingsFileName);
+        if (!File.Exists(gradleSettingsFilePath))
+            await File.WriteAllTextAsync(gradleSettingsFilePath, gradleSettingsFileTemplate).ConfigureAwait(false);
+
+        CreateDirectoryStructure(rootPath, testFileSubDirectories);
+    }
+
+    private static void CreateDirectoryStructure(string rootPath, string[] subdirectoriesNames)
+    {
+        var dirsAsList = subdirectoriesNames.ToList();
+        dirsAsList.ForEach(name =>
         {
-            var dirsAsList = subdirectoriesNames.ToList();
-            dirsAsList.ForEach(name =>
-            {
-                Directory.CreateDirectory(Path.Combine(new string[] { rootPath }.Union(dirsAsList.Take(dirsAsList.IndexOf(name) + 1)).ToArray()));
-            });
-        }
+            Directory.CreateDirectory(Path.Combine(new string[] { rootPath }.Union(dirsAsList.Take(dirsAsList.IndexOf(name) + 1)).ToArray()));
+        });
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 
-namespace MsGraphSDKSnippetsCompiler.Models
-{
-    public record CompilationResultsModel(bool IsSuccess, IEnumerable<Diagnostic> Diagnostics, string MarkdownFileName);
+namespace MsGraphSDKSnippetsCompiler.Models;
+
+public record CompilationResultsModel(bool IsSuccess, IEnumerable<Diagnostic> Diagnostics, string MarkdownFileName);
 #pragma warning disable CA1801 // Review unused parameters (false positive, seems to be fixed in vNext of dotnet: https://github.com/dotnet/roslyn-analyzers/pull/4499/files)
-    public record ExecutionResultsModel(CompilationResultsModel CompilationResult, bool Success, string ExceptionMessage = null);
-#pragma warning restore CA1801 // Review unused parameters
-}
+public record ExecutionResultsModel(CompilationResultsModel CompilationResult, bool Success, string ExceptionMessage = null);

--- a/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/CompilationResultsModel.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using System.Collections.Generic;
-
-namespace MsGraphSDKSnippetsCompiler.Models;
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
 
 public record CompilationResultsModel(bool IsSuccess, IEnumerable<Diagnostic> Diagnostics, string MarkdownFileName);
 #pragma warning disable CA1801 // Review unused parameters (false positive, seems to be fixed in vNext of dotnet: https://github.com/dotnet/roslyn-analyzers/pull/4499/files)

--- a/msgraph-sdk-raptor-compiler-lib/Models/IDTree.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IDTree.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Linq;
-
-namespace MsGraphSDKSnippetsCompiler.Models;
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
 
 /// <summary>
 /// Tree data structure to represent ID placeholders in graph URLs.

--- a/msgraph-sdk-raptor-compiler-lib/Models/IDTree.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IDTree.cs
@@ -4,129 +4,133 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Linq;
 
-namespace MsGraphSDKSnippetsCompiler.Models
+namespace MsGraphSDKSnippetsCompiler.Models;
+
+/// <summary>
+/// Tree data structure to represent ID placeholders in graph URLs.
+///
+/// Example URLs:
+///   https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}
+///   https://graph.microsoft.com/v1.0/communications/callRecords/{callRecords.callRecord-id}?$expand=sessions($expand=segments)
+///   https://graph.microsoft.com/v1.0/chats/{chat-id}/members/{conversationMember-id}
+///
+/// Corresponding tree representation:
+///
+///                                 root
+///                               /  |  \
+///                              /   |   \
+///                             /    |    \
+///                         chat   team   callRecords.callRecord
+///                          /       |
+///         conversationMember    channel
+///                                  |
+///                             conversationMember
+/// </summary>
+[JsonConverter(typeof(IDTreeConverter))]
+public class IDTree : Dictionary<string, IDTree>, IEquatable<IDTree>
 {
-    /// <summary>
-    /// Tree data structure to represent ID placeholders in graph URLs.
-    ///
-    /// Example URLs:
-    ///   https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}
-    ///   https://graph.microsoft.com/v1.0/communications/callRecords/{callRecords.callRecord-id}?$expand=sessions($expand=segments)
-    ///   https://graph.microsoft.com/v1.0/chats/{chat-id}/members/{conversationMember-id}
-    ///
-    /// Corresponding tree representation:
-    ///
-    ///                                 root
-    ///                               /  |  \
-    ///                              /   |   \
-    ///                             /    |    \
-    ///                         chat   team   callRecords.callRecord
-    ///                          /       |
-    ///         conversationMember    channel
-    ///                                  |
-    ///                             conversationMember
-    /// </summary>
-    [JsonConverter(typeof(IDTreeConverter))]
-    public class IDTree : Dictionary<string, IDTree>, IEquatable<IDTree>
+    public string Value
     {
-        public string Value { get; set; }
-        public IDTree(string value)
+        get; set;
+    }
+    public IDTree(string value)
+    {
+        if (string.IsNullOrEmpty(value))
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException($"{nameof(value)} can't be null or empty!");
-            }
-
-            Value = value;
+            throw new ArgumentException($"{nameof(value)} can't be null or empty!");
         }
 
-        public IDTree() { }
-
-        public bool Equals(IDTree other)
-        {
-            return other != null &&
-                Value == other.Value &&
-                Keys.Count == other.Keys.Count &&
-                Keys.All(key => other.ContainsKey(key) && (this[key]?.Equals(other[key]) ?? false));
-        }
-
-        public override bool Equals(object obj) => Equals(obj as IDTree);
-
-        public override int GetHashCode() => base.GetHashCode();
+        Value = value;
     }
 
-    public class IDTreeConverter : JsonConverter<IDTree>
+    public IDTree()
     {
-        public override IDTree Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    }
+
+    public bool Equals(IDTree other)
+    {
+        return other != null &&
+            Value == other.Value &&
+            Keys.Count == other.Keys.Count &&
+            Keys.All(key => other.ContainsKey(key) && (this[key]?.Equals(other[key]) ?? false));
+    }
+
+    public override bool Equals(object obj) => Equals(obj as IDTree);
+
+    public override int GetHashCode() => base.GetHashCode();
+}
+
+public class IDTreeConverter : JsonConverter<IDTree>
+{
+    public override IDTree Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
         {
-            if (reader.TokenType != JsonTokenType.StartObject)
-            {
-                throw new JsonException();
-            }
-
-            IDTree tree = new IDTree();
-
-            while (reader.Read())
-            {
-                if (reader.TokenType == JsonTokenType.EndObject)
-                {
-                    return tree;
-                }
-
-                if (reader.TokenType != JsonTokenType.PropertyName)
-                {
-                    break;
-                }
-
-                var propertyName = reader.GetString();
-                if (propertyName == "_value")
-                {
-                    // Json may contain Numbers( Integers or Floating Point), handle them as objects.
-                    var currentValue = JsonSerializer.Deserialize<object>(ref reader, options);
-                    if (currentValue != null)
-                    {
-                        tree.Value = currentValue.ToString();
-                    }
-                }
-                else
-                {
-                    IDTree subTree = JsonSerializer.Deserialize<IDTree>(ref reader, options);
-                    tree[propertyName] = subTree;
-                }
-            }
-
-            throw new JsonException("Unexpected JSON object. See identifiers.json file for a sample JSON in the TestCommon.Tests project.");
+            throw new JsonException();
         }
+
+        IDTree tree = new IDTree();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return tree;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                break;
+            }
+
+            var propertyName = reader.GetString();
+            if (propertyName == "_value")
+            {
+                // Json may contain Numbers( Integers or Floating Point), handle them as objects.
+                var currentValue = JsonSerializer.Deserialize<object>(ref reader, options);
+                if (currentValue != null)
+                {
+                    tree.Value = currentValue.ToString();
+                }
+            }
+            else
+            {
+                IDTree subTree = JsonSerializer.Deserialize<IDTree>(ref reader, options);
+                tree[propertyName] = subTree;
+            }
+        }
+
+        throw new JsonException("Unexpected JSON object. See identifiers.json file for a sample JSON in the TestCommon.Tests project.");
+    }
 
 #pragma warning disable CA1725 // Parameter names should match base declaration, tree is more descriptive in this case
-        public override void Write(Utf8JsonWriter writer, IDTree tree, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, IDTree tree, JsonSerializerOptions options)
 #pragma warning restore CA1725 // Parameter names should match base declaration
+    {
+        if (writer == null)
         {
-            if (writer == null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
-
-            if (tree == null)
-            {
-                throw new ArgumentNullException(nameof(tree));
-            }
-
-            writer.WriteStartObject();
-            if (tree.Value is not null)
-            {
-                writer.WritePropertyName("_value");
-                writer.WriteStringValue(tree.Value);
-            }
-
-            foreach (var key in tree.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
-            {
-                writer.WritePropertyName(key);
-                Write(writer, tree[key], options);
-            }
-            writer.WriteEndObject();
-            writer.Flush();
+            throw new ArgumentNullException(nameof(writer));
         }
+
+        if (tree == null)
+        {
+            throw new ArgumentNullException(nameof(tree));
+        }
+
+        writer.WriteStartObject();
+        if (tree.Value is not null)
+        {
+            writer.WritePropertyName("_value");
+            writer.WriteStringValue(tree.Value);
+        }
+
+        foreach (var key in tree.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+        {
+            writer.WritePropertyName(key);
+            Write(writer, tree[key], options);
+        }
+        writer.WriteEndObject();
+        writer.Flush();
     }
 }
 

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -1,12 +1,4 @@
-﻿using System.Collections.Generic;
-using System;
-using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Text.Json;
-using System.Text.RegularExpressions;
-
-using Azure.Storage.Blobs;
+﻿using Azure.Storage.Blobs;
 
 namespace MsGraphSDKSnippetsCompiler.Models;
 

--- a/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/IdentifierReplacer.cs
@@ -8,77 +8,77 @@ using System.Text.RegularExpressions;
 
 using Azure.Storage.Blobs;
 
-namespace MsGraphSDKSnippetsCompiler.Models
+namespace MsGraphSDKSnippetsCompiler.Models;
+
+public class IdentifierReplacer
 {
-    public class IdentifierReplacer
+    /// <summary>
+    /// singleton lazy instance
+    /// </summary>
+    public static IdentifierReplacer Instance => lazy.Value;
+
+    private static readonly Lazy<IdentifierReplacer> lazy = new(() => new IdentifierReplacer());
+
+    /// <summary>
+    /// tree of IDs that appear in sample Graph URLs
+    /// </summary>
+    private readonly IDTree tree;
+
+    /// <summary>
+    /// regular expression to match strings like {namespace.type-id}
+    /// also extracts namespace.type part separately so that we can use it as a lookup key.
+    /// </summary>
+    private readonly Regex idRegex = new Regex(@"{([A-Za-z\.]+)\-id}", RegexOptions.Compiled);
+
+    public IdentifierReplacer(IDTree tree)
     {
-        /// <summary>
-        /// singleton lazy instance
-        /// </summary>
-        public static IdentifierReplacer Instance => lazy.Value;
+        this.tree = tree;
+    }
 
-        private static readonly Lazy<IdentifierReplacer> lazy = new(() => new IdentifierReplacer());
+    /// <summary>
+    /// Default constructor which builds the tree from Azure blob storage
+    /// </summary>
+    private IdentifierReplacer()
+    {
+        var config = TestsSetup.Config.Value;
 
-        /// <summary>
-        /// tree of IDs that appear in sample Graph URLs
-        /// </summary>
-        private readonly IDTree tree;
-
-        /// <summary>
-        /// regular expression to match strings like {namespace.type-id}
-        /// also extracts namespace.type part separately so that we can use it as a lookup key.
-        /// </summary>
-        private readonly Regex idRegex = new Regex(@"{([A-Za-z\.]+)\-id}", RegexOptions.Compiled);
-
-        public IdentifierReplacer(IDTree tree)
+        string json;
+        if (config.IsLocalRun)
         {
-            this.tree = tree;
+            json = File.ReadAllText(@"identifiers.json");
+        }
+        else
+        {
+            const string blobContainerName = "raptoridentifiers";
+            const string blobName = "identifiers.json";
+
+            var raptorStorageConnectionString = config.RaptorStorageConnectionString;
+            var blobClient = new BlobClient(raptorStorageConnectionString, blobContainerName, blobName);
+
+            using var stream = new MemoryStream();
+            blobClient.DownloadTo(stream);
+            json = new UTF8Encoding().GetString(stream.ToArray());
         }
 
-        /// <summary>
-        /// Default constructor which builds the tree from Azure blob storage
-        /// </summary>
-        private IdentifierReplacer()
+        tree = JsonSerializer.Deserialize<IDTree>(json);
+    }
+
+    public string ReplaceIds(string input)
+    {
+        if (input == null)
         {
-            var config = TestsSetup.Config.Value;
-
-            string json;
-            if (config.IsLocalRun)
-            {
-                json = File.ReadAllText(@"identifiers.json");
-            }
-            else
-            {
-                const string blobContainerName = "raptoridentifiers";
-                const string blobName = "identifiers.json";
-
-                var raptorStorageConnectionString = config.RaptorStorageConnectionString;
-                var blobClient = new BlobClient(raptorStorageConnectionString, blobContainerName, blobName);
-
-                using var stream = new MemoryStream();
-                blobClient.DownloadTo(stream);
-                json = new UTF8Encoding().GetString(stream.ToArray());
-            }
-
-            tree = JsonSerializer.Deserialize<IDTree>(json);
+            throw new ArgumentNullException(nameof(input));
         }
 
-        public string ReplaceIds(string input)
-        {
-            if (input == null)
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
+        return ReplaceIdsFromIdentifiersFile(ReplaceEdgeCases(input));
+    }
 
-            return ReplaceIdsFromIdentifiersFile(ReplaceEdgeCases(input));
-        }
+    private static string ReplaceEdgeCases(string input)
+    {
+        var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var yesterday = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
 
-        private static string ReplaceEdgeCases(string input)
-        {
-            var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
-            var yesterday = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
-
-            var edgeCases = new Dictionary<string, string>
+        var edgeCases = new Dictionary<string, string>
             {
                 // https://docs.microsoft.com/en-us/graph/api/drive-get-specialfolder?view=graph-rest-1.0&amp%3Btabs=csharp&tabs=csharp#http-request-1
                 { "Special[\"{driveItem-id}\"]", "Special[\"music\"]" },
@@ -96,51 +96,50 @@ namespace MsGraphSDKSnippetsCompiler.Models
 
             };
 
-            foreach (var (key, value) in edgeCases)
-            {
-                input = input.Replace(key, value, StringComparison.Ordinal);
-            }
-
-            return input;
-        }
-
-        /// <summary>
-        /// Replaces ID placeholders of the form {name-id} by looking up name in the IDTree.
-        /// If there is more than one placeholder, it traverses through the tree, e.g.
-        /// For input string "sites/{site-id}/lists/{list-id}",
-        ///   {site-id} is replaced by root->site entry from the IDTree.
-        ///   {list-id} is replaced by root->site->list entry from the IDTree.
-        /// </summary>
-        /// <param name="input">String containing ID placeholders</param>
-        /// <returns>input string, but its placeholders replaced from IDTree</returns>
-        private string ReplaceIdsFromIdentifiersFile(string input)
+        foreach (var (key, value) in edgeCases)
         {
-            if (input == null)
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
-
-            var matches = idRegex.Matches(input);
-            IDTree currentIdNode = tree;
-            foreach (Match match in matches)
-            {
-                var id = match.Groups[0].Value;     // e.g. {site-id}
-                var idType = match.Groups[1].Value; // e.g. extract site from {site-id}
-
-                currentIdNode.TryGetValue(idType, out IDTree localTree);
-                if (localTree == null
-                    || localTree.Value.EndsWith($"{idType}>", StringComparison.Ordinal)) // placeholder value, e.g. <teamsApp_teamsAppDefinition> for teamsApp->teamsAppDefinition
-                {
-                    throw new InvalidDataException($"no data found for id: {id} in identifiers.json file");
-                }
-                else
-                {
-                    currentIdNode = localTree;
-                    input = input.Replace(id, currentIdNode.Value, StringComparison.OrdinalIgnoreCase);
-                }
-            }
-
-            return input;
+            input = input.Replace(key, value, StringComparison.Ordinal);
         }
+
+        return input;
+    }
+
+    /// <summary>
+    /// Replaces ID placeholders of the form {name-id} by looking up name in the IDTree.
+    /// If there is more than one placeholder, it traverses through the tree, e.g.
+    /// For input string "sites/{site-id}/lists/{list-id}",
+    ///   {site-id} is replaced by root->site entry from the IDTree.
+    ///   {list-id} is replaced by root->site->list entry from the IDTree.
+    /// </summary>
+    /// <param name="input">String containing ID placeholders</param>
+    /// <returns>input string, but its placeholders replaced from IDTree</returns>
+    private string ReplaceIdsFromIdentifiersFile(string input)
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        var matches = idRegex.Matches(input);
+        IDTree currentIdNode = tree;
+        foreach (Match match in matches)
+        {
+            var id = match.Groups[0].Value;     // e.g. {site-id}
+            var idType = match.Groups[1].Value; // e.g. extract site from {site-id}
+
+            currentIdNode.TryGetValue(idType, out IDTree localTree);
+            if (localTree == null
+                || localTree.Value.EndsWith($"{idType}>", StringComparison.Ordinal)) // placeholder value, e.g. <teamsApp_teamsAppDefinition> for teamsApp->teamsAppDefinition
+            {
+                throw new InvalidDataException($"no data found for id: {id} in identifiers.json file");
+            }
+            else
+            {
+                currentIdNode = localTree;
+                input = input.Replace(id, currentIdNode.Value, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        return input;
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/LanguageTestData.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/LanguageTestData.cs
@@ -1,35 +1,34 @@
-﻿namespace MsGraphSDKSnippetsCompiler.Models
-{
-    /// <summary>
-    /// Test Data
-    /// </summary>
-    /// <param name="Version">Docs version e.g. V1 or Beta</param>
-    /// <param name="IsCompilationKnownIssue">Whether the test case is failing due to a known issue in compilation</param>
-    /// <param name="IsExecutionKnownIssue">Whether the test case is failing due to a known issue in execution</param>
-    /// <param name="KnownIssueMessage">Message to represent known issue</param>
-    /// <param name="KnownIssueTestNamePrefix">Test name prefix for the known issue</param>
-    /// <param name="DocsLink">Documentation link where snippet is shown</param>
-    /// <param name="FileName">Snippet file name</param>
-    /// <param name="DllPath">Optional dll path to load Microsoft.Graph from a local resource instead of published nuget</param>
-    /// <param name="JavaCoreVersion">Optional. Version to use for the java core library. Ignored when using JavaPreviewLibPath</param>
-    /// <param name="JavaLibVersion">Optional. Version to use for the java service library. Ignored when using JavaPreviewLibPath</param>
-    /// <param name="JavaPreviewLibPath">Optional. Folder container the java core and java service library repositories so the unit testing uses that local version instead.</param>
-    /// <param name="TestName">name of the test case</param>
-    /// <param name="Owner">test case owner</param>
-    /// <param name="FileContent">contents of the snippet file</param>
-    public record LanguageTestData(
-        Versions Version,
-        bool IsCompilationKnownIssue,
-        bool IsExecutionKnownIssue,
-        string KnownIssueMessage,
-        string KnownIssueTestNamePrefix,
-        string DocsLink,
-        string FileName,
-        string DllPath,
-        string JavaCoreVersion,
-        string JavaLibVersion,
-        string JavaPreviewLibPath,
-        string TestName,
-        string Owner,
-        string FileContent);
-}
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
+
+/// <summary>
+/// Test Data
+/// </summary>
+/// <param name="Version">Docs version e.g. V1 or Beta</param>
+/// <param name="IsCompilationKnownIssue">Whether the test case is failing due to a known issue in compilation</param>
+/// <param name="IsExecutionKnownIssue">Whether the test case is failing due to a known issue in execution</param>
+/// <param name="KnownIssueMessage">Message to represent known issue</param>
+/// <param name="KnownIssueTestNamePrefix">Test name prefix for the known issue</param>
+/// <param name="DocsLink">Documentation link where snippet is shown</param>
+/// <param name="FileName">Snippet file name</param>
+/// <param name="DllPath">Optional dll path to load Microsoft.Graph from a local resource instead of published nuget</param>
+/// <param name="JavaCoreVersion">Optional. Version to use for the java core library. Ignored when using JavaPreviewLibPath</param>
+/// <param name="JavaLibVersion">Optional. Version to use for the java service library. Ignored when using JavaPreviewLibPath</param>
+/// <param name="JavaPreviewLibPath">Optional. Folder container the java core and java service library repositories so the unit testing uses that local version instead.</param>
+/// <param name="TestName">name of the test case</param>
+/// <param name="Owner">test case owner</param>
+/// <param name="FileContent">contents of the snippet file</param>
+public record LanguageTestData(
+    Versions Version,
+    bool IsCompilationKnownIssue,
+    bool IsExecutionKnownIssue,
+    string KnownIssueMessage,
+    string KnownIssueTestNamePrefix,
+    string DocsLink,
+    string FileName,
+    string DllPath,
+    string JavaCoreVersion,
+    string JavaLibVersion,
+    string JavaPreviewLibPath,
+    string TestName,
+    string Owner,
+    string FileContent);

--- a/msgraph-sdk-raptor-compiler-lib/Models/LanguagesAndVersions.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/LanguagesAndVersions.cs
@@ -1,77 +1,76 @@
 ﻿using System;
 
-namespace MsGraphSDKSnippetsCompiler.Models
+namespace MsGraphSDKSnippetsCompiler.Models;
+
+/// <summary>
+/// Programming languages that we generate snippets for
+/// </summary>
+public enum Languages
 {
-    /// <summary>
-    /// Programming languages that we generate snippets for
-    /// </summary>
-    public enum Languages
-    {
-        CSharp,
-        JavaScript,
-        Java,
-        ObjC
-    }
+    CSharp,
+    JavaScript,
+    Java,
+    ObjC
+}
 
-    public static class LanguagesExtension
-    {
+public static class LanguagesExtension
+{
 #pragma warning disable CA1308 // Normalize strings to uppercase
-        public static string AsString(this Languages language) => language.ToString().ToLowerInvariant();
+    public static string AsString(this Languages language) => language.ToString().ToLowerInvariant();
 #pragma warning restore CA1308 // Normalize strings to uppercase
+}
+
+/// <summary>
+/// Microsoft Graph Documetation Versions
+/// </summary>
+public enum Versions
+{
+    V1,
+    Beta
+}
+
+/// <summary>
+/// String representation for docs versions as file path or url segments
+/// </summary>
+public class VersionString
+{
+    private const string UnexpectedVersionMessage = "Unexpected version, we can't resolve this to a path or url segment.";
+    private readonly Versions Version;
+
+    public VersionString(Versions version)
+    {
+        Version = version;
     }
 
-    /// <summary>
-    /// Microsoft Graph Documetation Versions
-    /// </summary>
-    public enum Versions
+    public static Versions GetVersion(string versionString)
     {
-        V1,
-        Beta
+        return versionString switch
+        {
+            "v1.0" => Versions.V1,
+            "beta" => Versions.Beta,
+            _ => throw new ArgumentException(UnexpectedVersionMessage)
+        };
     }
 
-    /// <summary>
-    /// String representation for docs versions as file path or url segments
-    /// </summary>
-    public class VersionString
+    public override string ToString()
     {
-        private const string UnexpectedVersionMessage = "Unexpected version, we can't resolve this to a path or url segment.";
-        private readonly Versions Version;
-
-        public VersionString(Versions version)
+        return Version switch
         {
-            Version = version;
-        }
-
-        public static Versions GetVersion(string versionString)
-        {
-            return versionString switch
-            {
-                "v1.0" => Versions.V1,
-                "beta" => Versions.Beta,
-                _ => throw new ArgumentException(UnexpectedVersionMessage)
-            };
-        }
-
-        public override string ToString()
-        {
-            return Version switch
-            {
-                Versions.V1 => "v1.0",
-                Versions.Beta => "beta",
-                _ => "UNEXPECTED VERSION"
-            };
-        }
+            Versions.V1 => "v1.0",
+            Versions.Beta => "beta",
+            _ => "UNEXPECTED VERSION"
+        };
+    }
 
 #pragma warning disable CA1055 // URI-like return values should not be strings
-        public string DocsUrlSegment()
+    public string DocsUrlSegment()
 #pragma warning restore CA1055 // URI-like return values should not be strings
+    {
+        return Version switch
         {
-            return Version switch
-            {
-                Versions.V1 => "1.0",
-                Versions.Beta => "beta",
-                _ => throw new ArgumentException("Unexpected version, we can't resolve this to a path or url segment."),
-            };
-        }
+            Versions.V1 => "1.0",
+            Versions.Beta => "beta",
+            _ => throw new ArgumentException("Unexpected version, we can't resolve this to a path or url segment."),
+        };
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/LanguagesAndVersions.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/LanguagesAndVersions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace MsGraphSDKSnippetsCompiler.Models;
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
 
 /// <summary>
 /// Programming languages that we generate snippets for

--- a/msgraph-sdk-raptor-compiler-lib/Models/PermissionDescriptions.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/PermissionDescriptions.cs
@@ -1,7 +1,5 @@
-﻿namespace MsGraphSDKSnippetsCompiler.Models
-{
-    // modeling JSON object here: https://github.com/microsoftgraph/microsoft-graph-devx-content/blob/dev/permissions/permissions-descriptions.json
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
+
+// modeling JSON object here: https://github.com/microsoftgraph/microsoft-graph-devx-content/blob/dev/permissions/permissions-descriptions.json
 #pragma warning disable CA1819 // Properties should not return arrays: used only to deserialized a JSON model
-    public record PermissionDescriptions(Scope[] delegatedScopesList, Scope[] applicationScopesList);
-#pragma warning restore CA1819 // Properties should not return arrays
-}
+public record PermissionDescriptions(Scope[] delegatedScopesList, Scope[] applicationScopesList);

--- a/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using Microsoft.Extensions.Configuration;
-
-namespace MsGraphSDKSnippetsCompiler.Models;
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
 
 public class RaptorConfig
 {

--- a/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/RaptorConfig.cs
@@ -1,127 +1,126 @@
 ﻿using System.IO;
 using Microsoft.Extensions.Configuration;
 
-namespace MsGraphSDKSnippetsCompiler.Models
+namespace MsGraphSDKSnippetsCompiler.Models;
+
+public class RaptorConfig
 {
-    public class RaptorConfig
+    public static RaptorConfig Create(IConfigurationRoot config)
     {
-        public static RaptorConfig Create(IConfigurationRoot config)
+        var raptorConfig = new RaptorConfig
         {
-            var raptorConfig = new RaptorConfig
-            {
-                Authority = config.GetNonEmptyValue(nameof(Authority)), //Delegated Permissions
-                Username = config.GetNonEmptyValue(nameof(Username)),
-                Password = config.GetNonEmptyValue(nameof(Password)), // Application permissions
-                EducationUsername = config.GetNonEmptyValue(nameof(EducationUsername)),
-                EducationPassword = config.GetNonEmptyValue(nameof(EducationPassword)), // Application permissions
-                TenantID = config.GetNonEmptyValue(nameof(TenantID)),
-                ClientID = config.GetNonEmptyValue(nameof(ClientID)),
-                ClientSecret = config.GetNonEmptyValue(nameof(ClientSecret)),
-                EducationTenantID = config.GetNonEmptyValue(nameof(EducationTenantID)),
-                EducationClientID = config.GetNonEmptyValue(nameof(EducationClientID)),
-                EducationClientSecret = config.GetNonEmptyValue(nameof(EducationClientSecret)),
-                DocsRepoCheckoutDirectory = config.GetNonEmptyValue("BUILD_SOURCESDIRECTORY"),
-                RaptorStorageConnectionString = config.GetNonEmptyValue(nameof(RaptorStorageConnectionString)),
-                IsLocalRun = bool.Parse(config.GetNonEmptyValue(nameof(IsLocalRun)))
-            };
+            Authority = config.GetNonEmptyValue(nameof(Authority)), //Delegated Permissions
+            Username = config.GetNonEmptyValue(nameof(Username)),
+            Password = config.GetNonEmptyValue(nameof(Password)), // Application permissions
+            EducationUsername = config.GetNonEmptyValue(nameof(EducationUsername)),
+            EducationPassword = config.GetNonEmptyValue(nameof(EducationPassword)), // Application permissions
+            TenantID = config.GetNonEmptyValue(nameof(TenantID)),
+            ClientID = config.GetNonEmptyValue(nameof(ClientID)),
+            ClientSecret = config.GetNonEmptyValue(nameof(ClientSecret)),
+            EducationTenantID = config.GetNonEmptyValue(nameof(EducationTenantID)),
+            EducationClientID = config.GetNonEmptyValue(nameof(EducationClientID)),
+            EducationClientSecret = config.GetNonEmptyValue(nameof(EducationClientSecret)),
+            DocsRepoCheckoutDirectory = config.GetNonEmptyValue("BUILD_SOURCESDIRECTORY"),
+            RaptorStorageConnectionString = config.GetNonEmptyValue(nameof(RaptorStorageConnectionString)),
+            IsLocalRun = bool.Parse(config.GetNonEmptyValue(nameof(IsLocalRun)))
+        };
 
-            if (!Directory.Exists(Path.Join(raptorConfig.DocsRepoCheckoutDirectory, "microsoft-graph-docs")))
-            {
-                throw new FileNotFoundException("If you are running this locally, please set environment" +
-                    " variable BUILD_SOURCESDIRECTORY to the docs repo checkout location.");
-            }
-
-            return raptorConfig;
+        if (!Directory.Exists(Path.Join(raptorConfig.DocsRepoCheckoutDirectory, "microsoft-graph-docs")))
+        {
+            throw new FileNotFoundException("If you are running this locally, please set environment" +
+                " variable BUILD_SOURCESDIRECTORY to the docs repo checkout location.");
         }
 
-        public string ClientID
-        {
-            get;
-            init;
-        }
+        return raptorConfig;
+    }
 
-        public string EducationClientID
-        {
-            get;
-            init;
-        }
+    public string ClientID
+    {
+        get;
+        init;
+    }
 
-        public string Authority
-        {
-            get;
-            init;
-        }
+    public string EducationClientID
+    {
+        get;
+        init;
+    }
 
-        public string Username
-        {
-            get;
-            init;
-        }
+    public string Authority
+    {
+        get;
+        init;
+    }
 
-        public string Password
-        {
-            get;
-            init;
-        }
+    public string Username
+    {
+        get;
+        init;
+    }
+
+    public string Password
+    {
+        get;
+        init;
+    }
 
 
-        public string EducationUsername
-        {
-            get;
-            init;
-        }
+    public string EducationUsername
+    {
+        get;
+        init;
+    }
 
-        public string EducationPassword
-        {
-            get;
-            init;
-        }
+    public string EducationPassword
+    {
+        get;
+        init;
+    }
 
-        public string TenantID
-        {
-            get;
-            init;
-        }
+    public string TenantID
+    {
+        get;
+        init;
+    }
 
-        public string ClientSecret
-        {
-            get;
-            init;
-        }
-        public string EducationTenantID
-        {
-            get;
-            init;
-        }
+    public string ClientSecret
+    {
+        get;
+        init;
+    }
+    public string EducationTenantID
+    {
+        get;
+        init;
+    }
 
-        public string EducationClientSecret
-        {
-            get;
-            init;
-        }
+    public string EducationClientSecret
+    {
+        get;
+        init;
+    }
 
-        public string CertificateThumbprint
-        {
-            get;
-            init;
-        }
+    public string CertificateThumbprint
+    {
+        get;
+        init;
+    }
 
-        public string DocsRepoCheckoutDirectory
-        {
-            get;
-            init;
-        }
+    public string DocsRepoCheckoutDirectory
+    {
+        get;
+        init;
+    }
 
-        public string RaptorStorageConnectionString
-        {
-            get;
-            init;
-        }
+    public string RaptorStorageConnectionString
+    {
+        get;
+        init;
+    }
 
-        public bool IsLocalRun
-        {
-            get;
-            init;
-        }
+    public bool IsLocalRun
+    {
+        get;
+        init;
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/Scope.cs
@@ -1,19 +1,17 @@
-﻿namespace MsGraphSDKSnippetsCompiler.Models
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
+
+/// <summary>
+/// Model from https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/dev/GraphExplorerPermissionsService/Models/ScopeInformation.cs
+/// </summary>
+public record Scope(string value, bool isAdmin, string id)
 {
     /// <summary>
-    /// Model from https://github.com/microsoftgraph/microsoft-graph-devx-api/blob/dev/GraphExplorerPermissionsService/Models/ScopeInformation.cs
+    /// Creates a delegated app name from scope
     /// </summary>
-    public record Scope(string value, bool isAdmin, string id)
+    /// <param name="prefix">app display name prefix</param>
+    /// <returns>e.g. 'DelegatedApp User.Read' for prefix: 'DelegatedApp ' and Scope: 'User.Read'</returns>
+    public string DelegatedAppName(string prefix)
     {
-        /// <summary>
-        /// Creates a delegated app name from scope
-        /// </summary>
-        /// <param name="prefix">app display name prefix</param>
-        /// <returns>e.g. 'DelegatedApp User.Read' for prefix: 'DelegatedApp ' and Scope: 'User.Read'</returns>
-        public string DelegatedAppName(string prefix)
-        {
-            return prefix + value;
-        }
-    };
-
-}
+        return prefix + value;
+    }
+};

--- a/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace MsGraphSDKSnippetsCompiler.Models
-{
-    public static class TestsSetup
-    {
-        public static readonly Lazy<RaptorConfig> Config = new Lazy<RaptorConfig>(() => RaptorConfig.Create(AppSettings.Config()));
-        public static readonly Lazy<Task<PermissionManager>> RegularTenantPermissionManager
-            = new Lazy<Task<PermissionManager>>(GetPermissionManagerApplication());
-        public static readonly Lazy<Task<PermissionManager>> EducationTenantPermissionManager
-            = new Lazy<Task<PermissionManager>>(GetPermissionManagerApplication(true));
+namespace MsGraphSDKSnippetsCompiler.Models;
 
-        /// <summary>
-        /// Initilizes permission manager application with the tenant and application specified in the config
-        /// Fetches delegated tokens and caches them
-        /// </summary>
-        /// <returns>Permission manager application to access auth providers and tokens</returns>
-        public static async Task<PermissionManager> GetPermissionManagerApplication(bool isEducation = false)
-        {
-            var permissionManagerApplication = new PermissionManager(isEducation);
-            await permissionManagerApplication.CreateDelegatedAuthProviders().ConfigureAwait(false);
-            return permissionManagerApplication;
-        }
+public static class TestsSetup
+{
+    public static readonly Lazy<RaptorConfig> Config = new Lazy<RaptorConfig>(() => RaptorConfig.Create(AppSettings.Config()));
+    public static readonly Lazy<Task<PermissionManager>> RegularTenantPermissionManager
+        = new Lazy<Task<PermissionManager>>(GetPermissionManagerApplication());
+    public static readonly Lazy<Task<PermissionManager>> EducationTenantPermissionManager
+        = new Lazy<Task<PermissionManager>>(GetPermissionManagerApplication(true));
+
+    /// <summary>
+    /// Initilizes permission manager application with the tenant and application specified in the config
+    /// Fetches delegated tokens and caches them
+    /// </summary>
+    /// <returns>Permission manager application to access auth providers and tokens</returns>
+    public static async Task<PermissionManager> GetPermissionManagerApplication(bool isEducation = false)
+    {
+        var permissionManagerApplication = new PermissionManager(isEducation);
+        await permissionManagerApplication.CreateDelegatedAuthProviders().ConfigureAwait(false);
+        return permissionManagerApplication;
     }
 }

--- a/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
+++ b/msgraph-sdk-raptor-compiler-lib/Models/TestsSetup.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace MsGraphSDKSnippetsCompiler.Models;
+﻿namespace MsGraphSDKSnippetsCompiler.Models;
 
 public static class TestsSetup
 {

--- a/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
+++ b/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
@@ -9,294 +9,293 @@ using Microsoft.Graph;
 using MsGraphSDKSnippetsCompiler.Models;
 using static NUnit.Framework.TestContext;
 
-namespace MsGraphSDKSnippetsCompiler
+namespace MsGraphSDKSnippetsCompiler;
+
+/// <summary>
+/// A Graph client to get information about all of the Azure Applications that have the permissions used in the test cases.
+/// </summary>
+public class PermissionManager
 {
     /// <summary>
-    /// A Graph client to get information about all of the Azure Applications that have the permissions used in the test cases.
+    /// Graph service client with application permissions
     /// </summary>
-    public class PermissionManager
+    private readonly GraphServiceClient _client;
+
+    private readonly RaptorConfig _config;
+
+    private readonly bool IsEducation;
+
+    /// <summary>
+    /// Delegated auth providers
+    /// key: scopeName
+    /// value: token credential auth provider instance
+    /// </summary>
+    private readonly IDictionary<string, TokenCredentialAuthProvider> _authProviders;
+
+    /// <summary>
+    /// Auth provider to initialize GraphServiceClients within the snippets
+    /// when application permissions are needed
+    /// </summary>
+    public IAuthenticationProvider AuthProvider
     {
-        /// <summary>
-        /// Graph service client with application permissions
-        /// </summary>
-        private readonly GraphServiceClient _client;
+        get; init;
+    }
 
-        private readonly RaptorConfig _config;
+    public PermissionManager(bool isEducation = false)
+    {
+        IsEducation = isEducation;
+        _config = TestsSetup.Config.Value;
+        var clientSecretCredential = IsEducation
+            ? new ClientSecretCredential(_config.EducationTenantID, _config.EducationClientID, _config.EducationClientSecret)
+            : new ClientSecretCredential(_config.TenantID, _config.ClientID, _config.ClientSecret);
 
-        private readonly bool IsEducation;
+        const string DefaultAuthScope = "https://graph.microsoft.com/.default";
+        AuthProvider = new TokenCredentialAuthProvider(
+            clientSecretCredential,
+            new List<string> { DefaultAuthScope });
+        _client = new GraphServiceClient(AuthProvider);
+        _authProviders = new Dictionary<string, TokenCredentialAuthProvider>();
+    }
 
-        /// <summary>
-        /// Delegated auth providers
-        /// key: scopeName
-        /// value: token credential auth provider instance
-        /// </summary>
-        private readonly IDictionary<string, TokenCredentialAuthProvider> _authProviders;
+    /// <summary>
+    /// Gets permission descriptions from DevX API
+    /// </summary>
+    /// <returns>permission descriptions</returns>
+    public static async Task<PermissionDescriptions> GetPermissionDescriptions()
+    {
+        using var httpClient = new HttpClient();
 
-        /// <summary>
-        /// Auth provider to initialize GraphServiceClients within the snippets
-        /// when application permissions are needed
-        /// </summary>
-        public IAuthenticationProvider AuthProvider
+        using var scopesRequest = new HttpRequestMessage(HttpMethod.Get, "https://raw.githubusercontent.com/microsoftgraph/microsoft-graph-devx-content/dev/permissions/permissions-descriptions.json");
+
+        var result = new Dictionary<string, string>();
+
+        using var response = await httpClient.SendAsync(scopesRequest).ConfigureAwait(false);
+        var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return JsonSerializer.Deserialize<PermissionDescriptions>(responseString);
+    }
+
+    /// <summary>
+    /// Gets existing applications from the tenant with the given prefix in app display name
+    /// </summary>
+    /// <param name="prefix">prefix for the application name. e.g. DelegatedApp for querying DelegatedApp User.Read, DelegatedApp Group.Read etc.</param>
+    /// <returns>application names matching the query</returns>
+    public async Task<HashSet<string>> GetExistingApplicationsWithPrefix(string prefix = "DelegatedApp ")
+    {
+        var query = $"startswith(displayName, '{prefix}')";
+        var result = new HashSet<string>();
+        var applications = await _client.Applications
+            .Request()
+            .Filter(query)
+            .Select("displayName")
+            .GetAsync().ConfigureAwait(false);
+
+        var pageIterator = PageIterator<Application>
+            .CreatePageIterator(
+            _client,
+            applications,
+            (application) =>
+            {
+                result.Add(application.DisplayName);
+                return true;
+            });
+        await pageIterator.IterateAsync().ConfigureAwait(false);
+        return result;
+    }
+
+    /// <summary>
+    /// Gets id of the service principal representing Microsoft Graph Service in the tenant.
+    /// </summary>
+    /// <returns>Microsoft Graph Service Principal id</returns>
+    public async Task<string> GetMicrosoftGraphServicePrincipalId()
+    {
+        var servicePrincipals = await _client.ServicePrincipals
+            .Request()
+            .Filter("servicePrincipalNames/any(n:n eq 'https://graph.microsoft.com')")
+            .GetAsync().ConfigureAwait(false);
+
+        return servicePrincipals?.FirstOrDefault()?.Id;
+    }
+
+    /// <summary>
+    /// Creates an application with desired Microsoft Graph delegated scopes
+    /// </summary>
+    /// <param name="applicationName">application name</param>
+    /// <param name="scopeGuid">Guid representing the delegated scope</param>
+    /// <returns>created application</returns>
+    public async Task<Application> CreateApplication(string applicationName, string scopeGuid)
+    {
+        if (applicationName is null)
         {
-            get; init;
+            throw new ArgumentNullException(nameof(applicationName));
         }
 
-        public PermissionManager(bool isEducation = false)
+        if (scopeGuid is null)
         {
-            IsEducation = isEducation;
-            _config = TestsSetup.Config.Value;
-            var clientSecretCredential = IsEducation
-                ? new ClientSecretCredential(_config.EducationTenantID, _config.EducationClientID, _config.EducationClientSecret)
-                : new ClientSecretCredential(_config.TenantID, _config.ClientID, _config.ClientSecret);
-
-            const string DefaultAuthScope = "https://graph.microsoft.com/.default";
-            AuthProvider = new TokenCredentialAuthProvider(
-                clientSecretCredential,
-                new List<string> { DefaultAuthScope });
-            _client = new GraphServiceClient(AuthProvider);
-            _authProviders = new Dictionary<string, TokenCredentialAuthProvider>();
+            throw new ArgumentNullException(nameof(scopeGuid));
         }
 
-        /// <summary>
-        /// Gets permission descriptions from DevX API
-        /// </summary>
-        /// <returns>permission descriptions</returns>
-        public static async Task<PermissionDescriptions> GetPermissionDescriptions()
+        var resourceAccess = new ResourceAccess
         {
-            using var httpClient = new HttpClient();
+            Type = "Scope",
+            Id = new Guid(scopeGuid)
+        };
 
-            using var scopesRequest = new HttpRequestMessage(HttpMethod.Get, "https://raw.githubusercontent.com/microsoftgraph/microsoft-graph-devx-content/dev/permissions/permissions-descriptions.json");
+        var requiredResourceAccess = new RequiredResourceAccess()
+        {
+            ResourceAccess = new List<ResourceAccess> { resourceAccess },
+            ResourceAppId = "00000003-0000-0000-c000-000000000000"
+        };
 
-            var result = new Dictionary<string, string>();
+        var application = new Application
+        {
+            DisplayName = applicationName,
+            PublicClient = new PublicClientApplication
+            {
+                RedirectUris = new string[] { "http://localhost" }
+            },
+            RequiredResourceAccess = new List<RequiredResourceAccess> { requiredResourceAccess },
+            SignInAudience = "AzureADMyOrg",
+            IsFallbackPublicClient = true // allowPublicClient: true in application manifest
+        };
 
-            using var response = await httpClient.SendAsync(scopesRequest).ConfigureAwait(false);
-            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            return JsonSerializer.Deserialize<PermissionDescriptions>(responseString);
+        var createdApplication = await _client.Applications
+            .Request()
+            .AddAsync(application).ConfigureAwait(false);
+
+        return createdApplication;
+    }
+
+    /// <summary>
+    /// Creates an oauth2 permission grant
+    /// </summary>
+    /// <param name="clientId">object id of the service principal representing the application</param>
+    /// <param name="resourceId">Microsoft Graph Resource id</param>
+    /// <param name="scope">desired scope</param>
+    /// <returns>created permission grant object</returns>
+    public async Task<OAuth2PermissionGrant> CreateOAuthPermission(string clientId, string resourceId, string scope)
+    {
+        if (clientId is null)
+        {
+            throw new ArgumentNullException(nameof(clientId));
         }
 
-        /// <summary>
-        /// Gets existing applications from the tenant with the given prefix in app display name
-        /// </summary>
-        /// <param name="prefix">prefix for the application name. e.g. DelegatedApp for querying DelegatedApp User.Read, DelegatedApp Group.Read etc.</param>
-        /// <returns>application names matching the query</returns>
-        public async Task<HashSet<string>> GetExistingApplicationsWithPrefix(string prefix = "DelegatedApp ")
+        if (resourceId is null)
         {
-            var query = $"startswith(displayName, '{prefix}')";
-            var result = new HashSet<string>();
-            var applications = await _client.Applications
-                .Request()
-                .Filter(query)
-                .Select("displayName")
-                .GetAsync().ConfigureAwait(false);
-
-            var pageIterator = PageIterator<Application>
-                .CreatePageIterator(
-                _client,
-                applications,
-                (application) =>
-                {
-                    result.Add(application.DisplayName);
-                    return true;
-                });
-            await pageIterator.IterateAsync().ConfigureAwait(false);
-            return result;
+            throw new ArgumentNullException(nameof(resourceId));
         }
 
-        /// <summary>
-        /// Gets id of the service principal representing Microsoft Graph Service in the tenant.
-        /// </summary>
-        /// <returns>Microsoft Graph Service Principal id</returns>
-        public async Task<string> GetMicrosoftGraphServicePrincipalId()
+        if (scope is null)
         {
-            var servicePrincipals = await _client.ServicePrincipals
-                .Request()
-                .Filter("servicePrincipalNames/any(n:n eq 'https://graph.microsoft.com')")
-                .GetAsync().ConfigureAwait(false);
-
-            return servicePrincipals?.FirstOrDefault()?.Id;
+            throw new ArgumentNullException(nameof(scope));
         }
 
-        /// <summary>
-        /// Creates an application with desired Microsoft Graph delegated scopes
-        /// </summary>
-        /// <param name="applicationName">application name</param>
-        /// <param name="scopeGuid">Guid representing the delegated scope</param>
-        /// <returns>created application</returns>
-        public async Task<Application> CreateApplication(string applicationName, string scopeGuid)
+        var oauthPermission = new OAuth2PermissionGrant
         {
-            if (applicationName is null)
-            {
-                throw new ArgumentNullException(nameof(applicationName));
-            }
+            ClientId = clientId,
+            ConsentType = "AllPrincipals",
+            PrincipalId = null,
+            ResourceId = resourceId,
+            Scope = scope
+        };
 
-            if (scopeGuid is null)
-            {
-                throw new ArgumentNullException(nameof(scopeGuid));
-            }
+        var createdOauthPermission = await _client.Oauth2PermissionGrants
+            .Request()
+            .AddAsync(oauthPermission).ConfigureAwait(false);
 
-            var resourceAccess = new ResourceAccess
-            {
-                Type = "Scope",
-                Id = new Guid(scopeGuid)
-            };
+        return createdOauthPermission;
+    }
 
-            var requiredResourceAccess = new RequiredResourceAccess()
-            {
-                ResourceAccess = new List<ResourceAccess> { resourceAccess },
-                ResourceAppId = "00000003-0000-0000-c000-000000000000"
-            };
-
-            var application = new Application
-            {
-                DisplayName = applicationName,
-                PublicClient = new PublicClientApplication
-                {
-                    RedirectUris = new string[] { "http://localhost" }
-                },
-                RequiredResourceAccess = new List<RequiredResourceAccess> { requiredResourceAccess },
-                SignInAudience = "AzureADMyOrg",
-                IsFallbackPublicClient = true // allowPublicClient: true in application manifest
-            };
-
-            var createdApplication = await _client.Applications
-                .Request()
-                .AddAsync(application).ConfigureAwait(false);
-
-            return createdApplication;
+    /// <summary>
+    /// Creates a service principal to represent an application
+    /// </summary>
+    /// <param name="appId">appId of the application</param>
+    /// <returns>created service principal</returns>
+    public async Task<ServicePrincipal> CreateServicePrincipal(string appId)
+    {
+        if (appId is null)
+        {
+            throw new ArgumentNullException(nameof(appId));
         }
 
-        /// <summary>
-        /// Creates an oauth2 permission grant
-        /// </summary>
-        /// <param name="clientId">object id of the service principal representing the application</param>
-        /// <param name="resourceId">Microsoft Graph Resource id</param>
-        /// <param name="scope">desired scope</param>
-        /// <returns>created permission grant object</returns>
-        public async Task<OAuth2PermissionGrant> CreateOAuthPermission(string clientId, string resourceId, string scope)
+        var servicePrincipal = new ServicePrincipal
         {
-            if (clientId is null)
-            {
-                throw new ArgumentNullException(nameof(clientId));
-            }
+            AppId = appId
+        };
 
-            if (resourceId is null)
-            {
-                throw new ArgumentNullException(nameof(resourceId));
-            }
+        return await _client.ServicePrincipals
+            .Request()
+            .AddAsync(servicePrincipal).ConfigureAwait(false);
+    }
 
-            if (scope is null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+    /// <summary>
+    /// Gets the preconfigured app corresponding to the scope using app's display name
+    /// e.g. for User.Read -> DelegatedApp User.Read
+    /// </summary>
+    /// <param name="scope">delegated permission scope, e.g. User.Read</param>
+    /// <returns>Application to acquire a token in given scope</returns>
+    internal async Task<Application> GetApplication(Scope scope)
+    {
+        var AppDisplayNamePrefix = "DelegatedApp ";
 
-            var oauthPermission = new OAuth2PermissionGrant
-            {
-                ClientId = clientId,
-                ConsentType = "AllPrincipals",
-                PrincipalId = null,
-                ResourceId = resourceId,
-                Scope = scope
-            };
+        var appDisplayName = AppDisplayNamePrefix + scope.value;
 
-            var createdOauthPermission = await _client.Oauth2PermissionGrants
-                .Request()
-                .AddAsync(oauthPermission).ConfigureAwait(false);
+        var collectionPage = await _client.Applications
+                          .Request()
+                          .Filter($"displayName eq '{ appDisplayName }'")
+                          .GetAsync().ConfigureAwait(false);
+        return collectionPage?.FirstOrDefault();
+    }
 
-            return createdOauthPermission;
-        }
+    /// <summary>
+    /// Gets delegated auth provider
+    /// </summary>
+    /// <param name="delegatedScope">delegated scope</param>
+    /// <exception cref="KeyNotFoundException">throws key not found if there is no app in the tenant representing the given scope</exception>
+    /// <returns>token credential provider for the delegated scope</returns>
+    internal TokenCredentialAuthProvider GetDelegatedAuthProvider(Scope delegatedScope)
+    {
+        return _authProviders[delegatedScope?.value];
+    }
 
-        /// <summary>
-        /// Creates a service principal to represent an application
-        /// </summary>
-        /// <param name="appId">appId of the application</param>
-        /// <returns>created service principal</returns>
-        public async Task<ServicePrincipal> CreateServicePrincipal(string appId)
+    /// <summary>
+    /// Creates delegated auth providers
+    /// 1. Gets the list of all delegated permission scopes
+    /// 2. For all scopes
+    ///   2. a. Gets the corresponding preconfigured app in the tenant for a particular scope
+    ///   2. b. Creates a token credential provider for the app
+    /// </summary>
+    /// <returns></returns>
+    internal async Task CreateDelegatedAuthProviders()
+    {
+        var permissionDescriptions = await GetPermissionDescriptions().ConfigureAwait(false);
+        (string username, string password, string tenantID) = IsEducation
+            ? (_config.EducationUsername, _config.EducationPassword, _config.EducationTenantID)
+            : (_config.Username, _config.Password, _config.TenantID);
+
+        foreach (var delegatedPermissionScope in permissionDescriptions.delegatedScopesList)
         {
-            if (appId is null)
+            var scopeName = delegatedPermissionScope.value;
+            try
             {
-                throw new ArgumentNullException(nameof(appId));
-            }
-
-            var servicePrincipal = new ServicePrincipal
-            {
-                AppId = appId
-            };
-
-            return await _client.ServicePrincipals
-                .Request()
-                .AddAsync(servicePrincipal).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Gets the preconfigured app corresponding to the scope using app's display name
-        /// e.g. for User.Read -> DelegatedApp User.Read
-        /// </summary>
-        /// <param name="scope">delegated permission scope, e.g. User.Read</param>
-        /// <returns>Application to acquire a token in given scope</returns>
-        internal async Task<Application> GetApplication(Scope scope)
-        {
-            var AppDisplayNamePrefix = "DelegatedApp ";
-
-            var appDisplayName = AppDisplayNamePrefix + scope.value;
-
-            var collectionPage = await _client.Applications
-                              .Request()
-                              .Filter($"displayName eq '{ appDisplayName }'")
-                              .GetAsync().ConfigureAwait(false);
-            return collectionPage?.FirstOrDefault();
-        }
-
-        /// <summary>
-        /// Gets delegated auth provider
-        /// </summary>
-        /// <param name="delegatedScope">delegated scope</param>
-        /// <exception cref="KeyNotFoundException">throws key not found if there is no app in the tenant representing the given scope</exception>
-        /// <returns>token credential provider for the delegated scope</returns>
-        internal TokenCredentialAuthProvider GetDelegatedAuthProvider(Scope delegatedScope)
-        {
-            return _authProviders[delegatedScope?.value];
-        }
-
-        /// <summary>
-        /// Creates delegated auth providers
-        /// 1. Gets the list of all delegated permission scopes
-        /// 2. For all scopes
-        ///   2. a. Gets the corresponding preconfigured app in the tenant for a particular scope
-        ///   2. b. Creates a token credential provider for the app
-        /// </summary>
-        /// <returns></returns>
-        internal async Task CreateDelegatedAuthProviders()
-        {
-            var permissionDescriptions = await GetPermissionDescriptions().ConfigureAwait(false);
-            (string username, string password, string tenantID) = IsEducation
-                ? (_config.EducationUsername, _config.EducationPassword, _config.EducationTenantID)
-                : (_config.Username, _config.Password, _config.TenantID);
-
-            foreach (var delegatedPermissionScope in permissionDescriptions.delegatedScopesList)
-            {
-                var scopeName = delegatedPermissionScope.value;
-                try
-                {
-                    var application = await GetApplication(delegatedPermissionScope).ConfigureAwait(false);
-                    _authProviders[delegatedPermissionScope.value] = new TokenCredentialAuthProvider(
-                        new UsernamePasswordCredential(username, password, tenantID, application.AppId, new UsernamePasswordCredentialOptions
+                var application = await GetApplication(delegatedPermissionScope).ConfigureAwait(false);
+                _authProviders[delegatedPermissionScope.value] = new TokenCredentialAuthProvider(
+                    new UsernamePasswordCredential(username, password, tenantID, application.AppId, new UsernamePasswordCredentialOptions
+                    {
+                        TokenCachePersistenceOptions = new TokenCachePersistenceOptions
                         {
-                            TokenCachePersistenceOptions = new TokenCachePersistenceOptions
-                            {
-                                Name = username + delegatedPermissionScope.value,
+                            Name = username + delegatedPermissionScope.value,
                                 // there is no default linux implementation for safe storage. This project is run in 2 environments:
                                 // 1. local development
                                 // 2. disposable Azure DevOps machines
                                 // So we are OK to use unencrypted storage for Raptor tokens at the moment.
                                 UnsafeAllowUnencryptedStorage = true
-                            }
-                        }),
-                        new List<string> { scopeName });
-                }
-                catch
-                {
-                    await Out.WriteLineAsync($"Couldn't create an auth provider for scope: {scopeName}").ConfigureAwait(false);
-                }
+                        }
+                    }),
+                    new List<string> { scopeName });
+            }
+            catch
+            {
+                await Out.WriteLineAsync($"Couldn't create an auth provider for scope: {scopeName}").ConfigureAwait(false);
             }
         }
     }

--- a/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
+++ b/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
@@ -1,13 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text.Json;
-using System.Threading.Tasks;
-using Azure.Identity;
-using Microsoft.Graph;
-using MsGraphSDKSnippetsCompiler.Models;
-using static NUnit.Framework.TestContext;
+﻿using static NUnit.Framework.TestContext;
 
 namespace MsGraphSDKSnippetsCompiler;
 


### PR DESCRIPTION
fixes #598 

Reviewers, please use `ignore whitespace` option on GitHub for this PR as most of the changes are just gained 4 spaces in each line :)

- file-scoped namespaces
- global usings for the compiler lib
- global usings for ReportGenerator
- global usings for TestsCommon
- global usings for UnitTests
