### PR TITLE
Push reports with PAT instead of  GITHUB_TOKEN

### DIFF
--- a/.github/workflows/create-reports.yml
+++ b/.github/workflows/create-reports.yml
@@ -35,7 +35,7 @@ jobs:
       shell: pwsh
     - name: Create reports
       run: |
-        dotnet run -p ./ReportGenerator/ReportGenerator.csproj
+        dotnet run --project ./ReportGenerator/ReportGenerator.csproj
       shell: pwsh
       working-directory: ${{ env.BUILD_SOURCESDIRECTORY }}/msgraph-sdk-raptor
       env:
@@ -44,12 +44,17 @@ jobs:
     - name: push reports
       run: |
         Write-Host "Pushing reports to $env:CURRENT_BRANCH branch"
-        git config --global user.email "GraphTooling@service.microsoft.com"
-        git config --global user.name "Microsoft Graph DevX Tooling"
+        git config --global user.email "muzengin@microsoft.com"
+        git config --global user.name "Mustafa Zengin"
         git add report/
         git commit -m "Update reports"
+
+        git remote remove origin
+        git remote add origin https://$env:PAT@github.com/microsoftgraph/msgraph-sdk-raptor.git
+
         git push origin $env:CURRENT_BRANCH
       shell: pwsh
       working-directory: ${{ env.BUILD_SOURCESDIRECTORY }}/msgraph-sdk-raptor
       env:
         CURRENT_BRANCH: ${{ env.CURRENT_BRANCH }}
+        PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
Fixes #698 

GitHub doesn't allow other workflow runs being triggered from a workflow commit to prevent recursive triggering. The suggested workaround by GitHub is to use PAT unfortunately :(

https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token