### PR TITLE
application permissions auto updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder
 .mfractor/
+
+# F#
+.ionide/

--- a/ApplicationPermissionsUpdater/ApplicationPermissionsUpdater.cs
+++ b/ApplicationPermissionsUpdater/ApplicationPermissionsUpdater.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MsGraphSDKSnippetsCompiler;
+
+namespace ApplicationPermissionsUpdater;
+
+/// <summary>
+/// For both the regular and the education tenants:
+/// 1. Fetches all application scopes listed in permission descriptions in the devx-content repo.
+/// 2. Fetches all application permissions assigned to PermissionManager application in the tenant.
+/// 3. Creates missing application permissions and assigns app roles associated with them (admin consent in the Azure Portal)
+/// </summary>
+class ApplicationPermissionsUpdater
+{
+    static async Task Main(string[] args)
+    {
+        Console.WriteLine("*************************");
+        Console.WriteLine("Updating application permissions for regular tenant...");
+        Console.WriteLine("*************************");
+        await UpdatePermissions(new PermissionManager()).ConfigureAwait(false);
+
+        Console.WriteLine();
+        Console.WriteLine("*************************");
+        Console.WriteLine("Updating application permissions for education tenant...");
+        Console.WriteLine("*************************");
+        await UpdatePermissions(new PermissionManager(isEducation: true)).ConfigureAwait(false);
+    }
+
+    private static async Task UpdatePermissions(PermissionManager permissionManagerApplication)
+    {
+        // get assigned permissions
+        var permissionDescriptions = await PermissionManager.GetPermissionDescriptions().ConfigureAwait(false);
+
+        // get application scopes
+        var applicationScopes = permissionDescriptions.applicationScopesList;
+
+        // get existing application permissions
+        var existingApplicationPermissions = await permissionManagerApplication.GetExistingApplicationPermissions().ConfigureAwait(false);
+
+        // find missing application permissions
+        var missingPermissions = applicationScopes
+            .Where(x => !existingApplicationPermissions.Contains(x.id));
+
+        if (!missingPermissions.Any())
+        {
+            Console.WriteLine("All the permissions exist in the app! Exiting...");
+            return;
+        }
+
+        // print missing permissions
+        Console.WriteLine();
+        Console.WriteLine("*************************");
+        Console.WriteLine("Missing permissions:");
+        Console.WriteLine("*************************");
+        foreach (var permission in missingPermissions)
+        {
+            Console.WriteLine($"{permission.id} - {permission.value}");
+        }
+        Console.WriteLine("*************************");
+
+        // create missing permissions by pushing the full list of application scopes as the new resource access object in the manifest
+        await permissionManagerApplication.UpdateApplication(applicationScopes.Select(x => x.id)).ConfigureAwait(false);
+
+        var resourceId = await permissionManagerApplication.GetMicrosoftGraphServicePrincipalId().ConfigureAwait(false);
+        var principalId = await permissionManagerApplication.GetPermissionManagerServicePrincipalId().ConfigureAwait(false);
+        var listSucceeded = new List<string>();
+        var listFailed = new List<string>();
+        foreach(var permission in missingPermissions)
+        {
+            try
+            {
+                await permissionManagerApplication.AssignAppRole(principalId, resourceId, permission.id).ConfigureAwait(false);
+                listSucceeded.Add(permission.value);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to assign permission {permission.value}");
+                Console.WriteLine(ex.Message);
+                listFailed.Add(permission.value);
+            }
+        }
+
+        // print succeded permissions
+        Console.WriteLine();
+        Console.WriteLine("*************************");
+        Console.WriteLine("Succeeded permissions:");
+        Console.WriteLine("*************************");
+        foreach (var permission in listSucceeded)
+        {
+            Console.WriteLine($"{permission}");
+        }
+        Console.WriteLine("*************************");
+
+        // print failed permissions
+        Console.WriteLine();
+        Console.WriteLine("*************************");
+        Console.WriteLine("Failed permissions:");
+        Console.WriteLine("*************************");
+        foreach (var permission in listFailed)
+        {
+            Console.WriteLine($"{permission}");
+        }
+        Console.WriteLine("*************************");
+    }
+}

--- a/ApplicationPermissionsUpdater/ApplicationPermissionsUpdater.csproj
+++ b/ApplicationPermissionsUpdater/ApplicationPermissionsUpdater.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="$(MSBuildProjectDirectory)\..\RaptorShared.targets" />
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\msgraph-sdk-raptor-compiler-lib\msgraph-sdk-raptor-compiler-lib.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/ApplicationPermissionsUpdater/AssemblyInfo.cs
+++ b/ApplicationPermissionsUpdater/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using System;
+[assembly: CLSCompliant(false)]

--- a/ApplicationPermissionsUpdater/GlobalSuppressions.cs
+++ b/ApplicationPermissionsUpdater/GlobalSuppressions.cs
@@ -1,0 +1,10 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "English only. No need for a resource table.", Scope = "member", Target = "~M:ApplicationPermissionsUpdater.ApplicationPermissionsUpdater.UpdatePermissions(MsGraphSDKSnippetsCompiler.PermissionManager)~System.Threading.Tasks.Task")]
+[assembly: SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "English only. No need for a resource table.", Scope = "member", Target = "~M:ApplicationPermissionsUpdater.ApplicationPermissionsUpdater.Main(System.String[])~System.Threading.Tasks.Task")]
+[assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We are interested in the success or failure of the operation.", Scope = "member", Target = "~M:ApplicationPermissionsUpdater.ApplicationPermissionsUpdater.UpdatePermissions(MsGraphSDKSnippetsCompiler.PermissionManager)~System.Threading.Tasks.Task")]

--- a/azure-pipelines/application-permissions-updater.yml
+++ b/azure-pipelines/application-permissions-updater.yml
@@ -40,17 +40,17 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: 'build'
-    projects: '**/DelegatedAppCreator.csproj'
+    projects: '**/ApplicationPermissionsUpdater.csproj'
     arguments: '--configuration $(buildConfiguration)'
-  displayName: 'Build DelegatedAppCreator'
+  displayName: 'Build ApplicationPermissionsUpdater'
 
 
 # not using dotnet run due to the following issue preventing us from picking up appsettings.json file
 # consistently between VS and dotnet command line: https://github.com/dotnet/project-system/issues/3619
 - pwsh: |
-    chmod +x ./DelegatedAppCreator
-    ./DelegatedAppCreator
-  workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/DelegatedAppCreator/bin/Release/net6.0'
+    chmod +x ./ApplicationPermissionsUpdater
+    ./ApplicationPermissionsUpdater
+  workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/ApplicationPermissionsUpdater/bin/Release/net6.0'
   displayName: 'Create delegated apps'
   env:
     RAPTOR_CONFIGCONNECTIONSTRING: $(RAPTOR_CONFIGCONNECTIONSTRING)

--- a/azure-pipelines/application-permissions-updater.yml
+++ b/azure-pipelines/application-permissions-updater.yml
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+trigger: none # disable triggers based on commits.
+pr: none # disable this as a PR check
+name: 'Weekly Application Permissions Updater'
+
+schedules:
+  - cron: "0 3 * * SAT" # every Saturday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
+    displayName: 'Weekly Application Permissions Updater'
+    branches:
+      include:
+      - dev
+    always: true
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  buildConfiguration: 'Release'
+
+resources:
+  repositories:
+    - repository: microsoft-graph-docs
+      type: github
+      endpoint: microsoftgraph
+      name: microsoftgraph/microsoft-graph-docs
+      ref: main
+
+steps:
+- checkout: self
+  clean: true
+  fetchDepth: 1
+
+- checkout: microsoft-graph-docs
+  displayName: checkout docs
+  fetchDepth: 1
+  persistCredentials: true
+
+- template: common-templates/use-dotnet-sdk.yml
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'build'
+    projects: '**/DelegatedAppCreator.csproj'
+    arguments: '--configuration $(buildConfiguration)'
+  displayName: 'Build DelegatedAppCreator'
+
+
+# not using dotnet run due to the following issue preventing us from picking up appsettings.json file
+# consistently between VS and dotnet command line: https://github.com/dotnet/project-system/issues/3619
+- pwsh: |
+    chmod +x ./DelegatedAppCreator
+    ./DelegatedAppCreator
+  workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/DelegatedAppCreator/bin/Release/net6.0'
+  displayName: 'Create delegated apps'
+  env:
+    RAPTOR_CONFIGCONNECTIONSTRING: $(RAPTOR_CONFIGCONNECTIONSTRING)

--- a/azure-pipelines/application-permissions-updater.yml
+++ b/azure-pipelines/application-permissions-updater.yml
@@ -44,13 +44,12 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
   displayName: 'Build ApplicationPermissionsUpdater'
 
-
 # not using dotnet run due to the following issue preventing us from picking up appsettings.json file
 # consistently between VS and dotnet command line: https://github.com/dotnet/project-system/issues/3619
 - pwsh: |
     chmod +x ./ApplicationPermissionsUpdater
     ./ApplicationPermissionsUpdater
   workingDirectory: '$(Build.SourcesDirectory)/msgraph-sdk-raptor/ApplicationPermissionsUpdater/bin/Release/net6.0'
-  displayName: 'Create delegated apps'
+  displayName: 'Update Application Permissions'
   env:
     RAPTOR_CONFIGCONNECTIONSTRING: $(RAPTOR_CONFIGCONNECTIONSTRING)

--- a/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
+++ b/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
@@ -248,7 +248,7 @@ public class PermissionManager
     }
 
     /// <summary>
-    /// Assigns application permissions to the service principal of the application
+    /// Assigns application permissions to the service principal of the application (equivalent of clicking "Grant admin consent" in Azure Portal)
     /// </summary>
     /// <param name="principalId">service principal id of the application</param>
     /// <param name="resourceId">Microsoft Graph Service service principal id</param>

--- a/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
+++ b/msgraph-sdk-raptor-compiler-lib/PermissionManager.cs
@@ -212,6 +212,11 @@ public class PermissionManager
     /// <returns>updated application</returns>
     public async Task<Application> UpdateApplication(IEnumerable<string> scopeGuids)
     {
+        if (scopeGuids is null)
+        {
+            throw new ArgumentNullException(nameof(scopeGuids));
+        }
+
         var listOfResourceAccesses = new List<ResourceAccess>();
         foreach (var scopeGuid in scopeGuids)
         {

--- a/msgraph-sdk-raptor.sln
+++ b/msgraph-sdk-raptor.sln
@@ -75,6 +75,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReportGenerator", "ReportGe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TypeScriptBetaTests", "TypeScriptBetaTests\TypeScriptBetaTests.csproj", "{757FC453-510F-4DD2-90F9-D652B026803E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationPermissionsUpdater", "ApplicationPermissionsUpdater\ApplicationPermissionsUpdater.csproj", "{7008F2BA-A803-493D-969B-90DC0A56CD98}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -157,6 +159,10 @@ Global
 		{757FC453-510F-4DD2-90F9-D652B026803E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{757FC453-510F-4DD2-90F9-D652B026803E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{757FC453-510F-4DD2-90F9-D652B026803E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7008F2BA-A803-493D-969B-90DC0A56CD98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7008F2BA-A803-493D-969B-90DC0A56CD98}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7008F2BA-A803-493D-969B-90DC0A56CD98}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7008F2BA-A803-493D-969B-90DC0A56CD98}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Fetches all application permission from devx-content repo
- Fetches all assigned application permissions for the PermissionManager application
- Figures out the missing permissions and adds them into the PermissionManager application and assigns app roles (equivalent of clicking "Grant Admin Consent" button in Azure Portal)

PermissionManager application is responsible for fetching/updating data in InitTenant script whenever application permissions are needed. It is also used to make the request in Raptor execution tests where the application permissions are required.

The PR also introduces a weekly Azure DevOps runner to keep permissions up-to-date.

Successful run updating permissions:
https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=62002&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7dae026f-9e99-5d65-075e-3f7579577f94

Successful run where no update is required:
https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=62003&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7dae026f-9e99-5d65-075e-3f7579577f94

fixes #724
