### PR TITLE
Fix pipelines after Typewriter update

### DIFF
--- a/scripts/generateCSharpModels.ps1
+++ b/scripts/generateCSharpModels.ps1
@@ -9,7 +9,7 @@ $raptorUtils = Join-Path $PSScriptRoot "./TenantSetup/RaptorUtils.ps1" -Resolve
 $outputPath = Join-Path -Path $env:BUILD_SOURCESDIRECTORY -ChildPath "output"
 Write-Output "Path to typewriter output $outputPath"
 
-$typewriterDirectory = Join-Path -Path $env:BUILD_SOURCESDIRECTORY -ChildPath "MSGraph-SDK-Code-Generator" "src" "Typewriter" "bin" $env:BuildConfiguration "net5.0"
+$typewriterDirectory = Join-Path -Path $env:BUILD_SOURCESDIRECTORY -ChildPath "MSGraph-SDK-Code-Generator" "src" "Typewriter" "bin" $env:BuildConfiguration "net6.0"
 $typewriterPath = Join-Path $typewriterDirectory "Typewriter"
 Write-Output "Path to typewriter tool: $typewriterPath"
 


### PR DESCRIPTION
This PR fixes the metadata transform task as its now broken after the update made via https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/676 and https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/672