### PR TITLE
Removed incorrect set of variables defined in the matrix strategy

### DIFF
--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly.yml
@@ -40,10 +40,10 @@ jobs:
   strategy:
     maxParallel: 2
     matrix:
-        PowerShellBetaExecutionTests:
-            projectFileName: PowerShellBetaExecutionTests
-        PowerShellBetaExecutionKnownFailureTests:
-            projectFileName: PowerShellBetaExecutionKnownFailureTests
+        PowerShellV1ExecutionTests:
+            projectFileName: PowerShellV1ExecutionTests
+        PowerShellV1ExecutionKnownFailureTests:
+            projectFileName: PowerShellV1ExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:


### PR DESCRIPTION
This PR is supposed to address the issue (https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/937)) of fluctuating number of powershell tests for both beta and v1.

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. Please focus on how this PR resolves the issue above instead of repeating the issue description. Provide as much context as possible for reviewers and your future self who will look back at the PR at a later time. -->
### Changes proposed in this pull request
-  Replace "PowerShellBetaExecutionTests" and "PowerShellBetaExecutionKnownFailureTests" with "PowerShellV1ExecutionTests" and "PowerShellV1ExecutionKnownFailureTests" respectively as defined in the matrix strategy variable set of prod-v1-powershell-scheduled-execution-tests-weekly.yml file. The initial set of variables had wrongly been defined.