### PR TITLE
Pipeline separation

### DIFF
--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-daily.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-daily.yml
@@ -11,17 +11,6 @@ schedules:
       - dev
     always: true
 
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
-
 resources:
  repositories:
    - repository: microsoft-graph-docs
@@ -33,17 +22,10 @@ resources:
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellBetaExecutionTests:
-            projectFileName: PowerShellBetaExecutionTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+pool: MsGraphBuildAgentsWindowsRaptor
+
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellBetaExecutionTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-daily.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-daily.yml
@@ -38,12 +38,10 @@ jobs:
   pool: ${{ parameters.BuildAgentPool }}
   timeoutInMinutes: ${{ parameters.PipelineTimeout }}
   strategy:
-    maxParallel: 2
+    maxParallel: 1
     matrix:
         PowerShellBetaExecutionTests:
             projectFileName: PowerShellBetaExecutionTests
-        PowerShellBetaExecutionKnownFailureTests:
-            projectFileName: PowerShellBetaExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:

--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly-knownissues.yml
@@ -4,23 +4,12 @@ trigger: none # disable triggers based on commits.
 pr: none # disable as a PR gate.
 name: 'Weekly Beta PowerShell Snippet Execution Tests - Known issues'
 schedules:
-  - cron: "0 4 * * WED"  # every Wednesday at 4AM UTC (off hours for Redmond, Nairobi and Montréal)
+  - cron: "0 3 * * WED"  # every Wednesday at 4AM UTC (off hours for Redmond, Nairobi and Montréal)
     displayName: 'Weekly Beta PowerShell Snippet Execution Tests'
     branches:
       include:
       - dev
     always: true
-
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
 
 resources:
  repositories:
@@ -33,17 +22,10 @@ resources:
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellBetaExecutionKnownFailureTests:
-            projectFileName: PowerShellBetaExecutionKnownFailureTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+pool: MsGraphBuildAgentsWindowsRaptor
+
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellBetaExecutionKnownFailureTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly-knownissues.yml
@@ -2,10 +2,10 @@
 
 trigger: none # disable triggers based on commits.
 pr: none # disable as a PR gate.
-name: 'Daily V1 PowerShell Snippet Execution Tests'
+name: 'Weekly Beta PowerShell Snippet Execution Tests - Known issues'
 schedules:
-  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
-    displayName: 'Daily V1 PowerShell Snippet Execution Tests'
+  - cron: "0 4 * * WED"  # every Wednesday at 4AM UTC (off hours for Redmond, Nairobi and Montréal)
+    displayName: 'Weekly Beta PowerShell Snippet Execution Tests'
     branches:
       include:
       - dev
@@ -40,8 +40,8 @@ jobs:
   strategy:
     maxParallel: 1
     matrix:
-        PowerShellV1ExecutionTests:
-            projectFileName: PowerShellV1ExecutionTests
+        PowerShellBetaExecutionKnownFailureTests:
+            projectFileName: PowerShellBetaExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:

--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly.yml
@@ -4,7 +4,7 @@ trigger: none # disable triggers based on commits.
 pr: none # disable as a PR gate.
 name: 'Weekly Beta PowerShell Snippet Execution Tests'
 schedules:
-  - cron: "0 3 * * WED"  # every Wednesday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
+  - cron: "0 4 * * WED"  # every Wednesday at 4AM UTC (off hours for Redmond, Nairobi and Montréal)
     displayName: 'Weekly Beta PowerShell Snippet Execution Tests'
     branches:
       include:
@@ -38,12 +38,10 @@ jobs:
   pool: ${{ parameters.BuildAgentPool }}
   timeoutInMinutes: ${{ parameters.PipelineTimeout }}
   strategy:
-    maxParallel: 2
+    maxParallel: 1
     matrix:
         PowerShellBetaExecutionTests:
             projectFileName: PowerShellBetaExecutionTests
-        PowerShellBetaExecutionKnownFailureTests:
-            projectFileName: PowerShellBetaExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:

--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-execution-tests-weekly.yml
@@ -4,23 +4,12 @@ trigger: none # disable triggers based on commits.
 pr: none # disable as a PR gate.
 name: 'Weekly Beta PowerShell Snippet Execution Tests'
 schedules:
-  - cron: "0 4 * * WED"  # every Wednesday at 4AM UTC (off hours for Redmond, Nairobi and Montréal)
+  - cron: "0 3 * * WED"  # every Wednesday at 4AM UTC (off hours for Redmond, Nairobi and Montréal)
     displayName: 'Weekly Beta PowerShell Snippet Execution Tests'
     branches:
       include:
       - dev
     always: true
-
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
 
 resources:
  repositories:
@@ -33,17 +22,10 @@ resources:
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellBetaExecutionTests:
-            projectFileName: PowerShellBetaExecutionTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+pool: MsGraphBuildAgentsWindowsRaptor
+
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellBetaExecutionTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-tests-daily-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-tests-daily-knownissues.yml
@@ -2,10 +2,10 @@
 
 trigger: none # disable triggers based on commits.
 pr: none # disable as a PR gate.
-name: 'Daily V1 PowerShell Snippet Execution Tests'
+name: 'Daily Beta PowerShell Snippet Execution Tests'
 schedules:
   - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
-    displayName: 'Daily V1 PowerShell Snippet Execution Tests'
+    displayName: 'Daily Beta PowerShell Snippet Execution Tests - Known Issues'
     branches:
       include:
       - dev
@@ -40,8 +40,8 @@ jobs:
   strategy:
     maxParallel: 1
     matrix:
-        PowerShellV1ExecutionTests:
-            projectFileName: PowerShellV1ExecutionTests
+        PowerShellBetaExecutionKnownFailureTests:
+            projectFileName: PowerShellBetaExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:

--- a/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-tests-daily-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-beta-powershell-scheduled-tests-daily-knownissues.yml
@@ -11,17 +11,6 @@ schedules:
       - dev
     always: true
 
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
-
 resources:
  repositories:
    - repository: microsoft-graph-docs
@@ -33,17 +22,10 @@ resources:
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellBetaExecutionKnownFailureTests:
-            projectFileName: PowerShellBetaExecutionKnownFailureTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+pool: MsGraphBuildAgentsWindowsRaptor
+
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellBetaExecutionKnownFailureTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-daily-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-daily-knownissues.yml
@@ -11,17 +11,6 @@ schedules:
       - dev
     always: true
 
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
-
 resources:
  repositories:
    - repository: microsoft-graph-docs
@@ -32,18 +21,11 @@ resources:
 
 variables:
   buildConfiguration: 'Release'
+  
+pool: MsGraphBuildAgentsWindowsRaptor
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellV1ExecutionKnownFailureTests:
-            projectFileName: PowerShellV1ExecutionKnownFailureTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellV1ExecutionKnownFailureTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-daily-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-daily-knownissues.yml
@@ -2,7 +2,7 @@
 
 trigger: none # disable triggers based on commits.
 pr: none # disable as a PR gate.
-name: 'Daily V1 PowerShell Snippet Execution Tests'
+name: 'Daily V1 PowerShell Snippet Execution Tests - Known Issues'
 schedules:
   - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
     displayName: 'Daily V1 PowerShell Snippet Execution Tests'
@@ -40,8 +40,8 @@ jobs:
   strategy:
     maxParallel: 1
     matrix:
-        PowerShellV1ExecutionTests:
-            projectFileName: PowerShellV1ExecutionTests
+        PowerShellV1ExecutionKnownFailureTests:
+            projectFileName: PowerShellV1ExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:

--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-daily.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-daily.yml
@@ -11,17 +11,6 @@ schedules:
       - dev
     always: true
 
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
-
 resources:
  repositories:
    - repository: microsoft-graph-docs
@@ -33,17 +22,10 @@ resources:
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellV1ExecutionTests:
-            projectFileName: PowerShellV1ExecutionTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+pool: MsGraphBuildAgentsWindowsRaptor
+
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellV1ExecutionTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly-knownissues.yml
@@ -2,10 +2,10 @@
 
 trigger: none # disable triggers based on commits.
 pr: none # disable as a PR gate.
-name: 'Daily V1 PowerShell Snippet Execution Tests'
+name: 'Weekly V1 PowerShell Snippet Execution Tests'
 schedules:
-  - cron: "0 3 * * *" # everyday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
-    displayName: 'Daily V1 PowerShell Snippet Execution Tests'
+  - cron: "0 3 * * WED"  # every Wednesday at 3AM UTC (off hours for Redmond, Nairobi and Montréal)
+    displayName: 'Weekly V1 PowerShell Snippet Execution Tests - Known Issues'
     branches:
       include:
       - dev
@@ -40,8 +40,8 @@ jobs:
   strategy:
     maxParallel: 1
     matrix:
-        PowerShellV1ExecutionTests:
-            projectFileName: PowerShellV1ExecutionTests
+        PowerShellV1ExecutionKnownFailureTests:
+            projectFileName: PowerShellV1ExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:

--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly-knownissues.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly-knownissues.yml
@@ -11,17 +11,6 @@ schedules:
       - dev
     always: true
 
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
-
 resources:
  repositories:
    - repository: microsoft-graph-docs
@@ -33,17 +22,10 @@ resources:
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellV1ExecutionKnownFailureTests:
-            projectFileName: PowerShellV1ExecutionKnownFailureTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+pool: MsGraphBuildAgentsWindowsRaptor
+
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellV1ExecutionKnownFailureTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly.yml
@@ -11,17 +11,6 @@ schedules:
       - dev
     always: true
 
-parameters:
-- name: BuildAgentPool
-  displayName: Build Agent Pool
-  type: string
-  default: MsGraphBuildAgentsWindowsRaptor
-
-- name: PipelineTimeout
-  displayName: PipelineTimeout
-  type: number
-  default: 600
-
 resources:
  repositories:
    - repository: microsoft-graph-docs
@@ -33,17 +22,10 @@ resources:
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PowerShell
-  pool: ${{ parameters.BuildAgentPool }}
-  timeoutInMinutes: ${{ parameters.PipelineTimeout }}
-  strategy:
-    maxParallel: 1
-    matrix:
-        PowerShellV1ExecutionTests:
-            projectFileName: PowerShellV1ExecutionTests
-  steps:
-  - template: powershell-execution-tests-template.yml
-    parameters:
-      projectFileName: $(projectFileName)
-      testType: 'Execution'
+pool: MsGraphBuildAgentsWindowsRaptor
+
+steps:
+- template: powershell-execution-tests-template.yml
+  parameters:
+    projectFileName: PowerShellV1ExecutionTests
+    testType: 'Execution'

--- a/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly.yml
+++ b/azure-pipelines/powershell-templates/prod-v1-powershell-scheduled-execution-tests-weekly.yml
@@ -38,12 +38,10 @@ jobs:
   pool: ${{ parameters.BuildAgentPool }}
   timeoutInMinutes: ${{ parameters.PipelineTimeout }}
   strategy:
-    maxParallel: 2
+    maxParallel: 1
     matrix:
         PowerShellV1ExecutionTests:
             projectFileName: PowerShellV1ExecutionTests
-        PowerShellV1ExecutionKnownFailureTests:
-            projectFileName: PowerShellV1ExecutionKnownFailureTests
   steps:
   - template: powershell-execution-tests-template.yml
     parameters:


### PR DESCRIPTION

This PR is supposed to address issues
1. https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/1011
2. https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/937
### Changes proposed in this pull request
-  Have known issues for v1 and beta tests run on their own pipelines i.e. One Job will handle only one test type as per the pipeline configuration on the yaml files.
- Recreate powershell visualization chart to separately show metrics for Execution tests and that for Known failure tests. See sample screnshot below.
 
<img width="978" alt="image" src="https://user-images.githubusercontent.com/10947120/167179784-19d04211-a91d-4278-8ea8-9e27603e6346.png">
