### PR TITLE
add a hard reference to the SDK so that dependabot can update go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,10 @@ updates:
     time: "11:00"  #11am utc
     timezone: "GMT"
   open-pull-requests-limit: 10
-#- package-ecosystem: gomod
-#  directory: "/GoV1Tests/goDependencies"
-#  schedule:
-#    interval: daily
-#    time: "11:00"  #11am utc
-#    timezone: "GMT"
-#  open-pull-requests-limit: 10
+- package-ecosystem: gomod
+ directory: "/GoV1Tests/goDependencies"
+ schedule:
+   interval: daily
+   time: "11:00"  #11am utc
+   timezone: "GMT"
+ open-pull-requests-limit: 10

--- a/GoV1Tests/goDependencies/src/hard-reference.go
+++ b/GoV1Tests/goDependencies/src/hard-reference.go
@@ -1,0 +1,16 @@
+// needed for dependabot updates to update go.mod properly
+package snippets
+
+import (
+    "log"
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+)
+
+func GetEducationUser() {
+	graphClient := msgraphsdk.NewGraphServiceClient(nil)
+	_, err := graphClient.Education().Me().User().Get()
+
+    if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
- fixes #1062 

### Changes proposed in this pull request
- Adds a `go` source code file that references the SDK directly. Tested in a private repo that this fixes the issue.