### PR TITLE
use netstandard dll, netcoreapp is no longer applicable

### DIFF
--- a/azure-pipelines/e2e-templates/known-issue-tests.yml
+++ b/azure-pipelines/e2e-templates/known-issue-tests.yml
@@ -10,7 +10,7 @@ steps:
   workingDirectory: $(Build.ArtifactStagingDirectory)
 
 - pwsh: |
-    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netcoreapp") }).FullName
+    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netstandard") }).FullName
     Write-Host "Path to Microsoft.Graph.dll: $dllPath"
 
     ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -TestType "CompilationKnownIssues" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"

--- a/azure-pipelines/e2e-templates/known-issue-tests.yml
+++ b/azure-pipelines/e2e-templates/known-issue-tests.yml
@@ -10,7 +10,7 @@ steps:
   workingDirectory: $(Build.ArtifactStagingDirectory)
 
 - pwsh: |
-    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netstandard") }).FullName
+    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netstandard") } | Select-Object -First 1).FullName
     Write-Host "Path to Microsoft.Graph.dll: $dllPath"
 
     ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -TestType "CompilationKnownIssues" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"

--- a/azure-pipelines/e2e-templates/regular-tests.yml
+++ b/azure-pipelines/e2e-templates/regular-tests.yml
@@ -9,7 +9,7 @@ steps:
   workingDirectory: $(Build.ArtifactStagingDirectory)
 
 - pwsh: |
-    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netcoreapp") }).FullName
+    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netstandard") }).FullName
     Write-Host "Path to Microsoft.Graph.dll: $dllPath"
 
     ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -TestType "CompilationStable" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"

--- a/azure-pipelines/e2e-templates/regular-tests.yml
+++ b/azure-pipelines/e2e-templates/regular-tests.yml
@@ -9,7 +9,7 @@ steps:
   workingDirectory: $(Build.ArtifactStagingDirectory)
 
 - pwsh: |
-    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netstandard") }).FullName
+    $dllPath = (Get-ChildItem ./msgraph-sdk-dotnet/ -Include Microsoft.Graph.dll -Recurse | Where-Object { $_.FullName.Contains("netstandard") }| Select-Object -First 1).FullName
     Write-Host "Path to Microsoft.Graph.dll: $dllPath"
 
     ./msgraph-sdk-raptor/azure-pipelines/e2e-templates/transformSettings.ps1 -Version "$(metadataVersion)" -TestType "CompilationStable" -DllPath "$dllPath" -Language "CSharp" -RunSettingsPath "$(runSettingsFile)"


### PR DESCRIPTION
- fixes #1126 

### Changes proposed in this pull request
- The dll is no longer created under netcoreapp3.1 folder, instead it is under netstandard2.0

### Other links
- Successful run: https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=78122&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9