### PR TITLE
adds hard reference to Go Beta SDK for dependabot

### DIFF
--- a/GoBetaTests/goDependencies/src/hard-reference.go
+++ b/GoBetaTests/goDependencies/src/hard-reference.go
@@ -1,0 +1,16 @@
+// needed for dependabot updates to update go.mod properly
+package snippets
+
+import (
+    "log"
+	msgraphsdk "github.com/microsoftgraph/msgraph-beta-sdk-go"
+)
+
+func GetEducationUser() {
+	graphClient := msgraphsdk.NewGraphServiceClient(nil)
+	_, err := graphClient.Education().Me().User().Get()
+
+    if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
- fixes #1166

### Changes proposed in this pull request
- Hard reference to Go Beta SDK so that dependabot doesn't trim the dependencies file.